### PR TITLE
Set cache headers for hashed assets and index.html

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -10,29 +10,20 @@
         ],
         "headers": [
             {
+                "source": "**",
+                "headers": [
+                    {
+                        "key": "Cache-Control",
+                        "value": "no-cache"
+                    }
+                ]
+            },
+            {
                 "source": "/assets/**",
                 "headers": [
                     {
                         "key": "Cache-Control",
                         "value": "public, max-age=31536000, immutable"
-                    }
-                ]
-            },
-            {
-                "source": "/",
-                "headers": [
-                    {
-                        "key": "Cache-Control",
-                        "value": "no-cache"
-                    }
-                ]
-            },
-            {
-                "source": "**/*.html",
-                "headers": [
-                    {
-                        "key": "Cache-Control",
-                        "value": "no-cache"
                     }
                 ]
             }

--- a/firebase.json
+++ b/firebase.json
@@ -7,6 +7,35 @@
                 "source": "**",
                 "destination": "/index.html"
             }
+        ],
+        "headers": [
+            {
+                "source": "/assets/**",
+                "headers": [
+                    {
+                        "key": "Cache-Control",
+                        "value": "public, max-age=31536000, immutable"
+                    }
+                ]
+            },
+            {
+                "source": "/",
+                "headers": [
+                    {
+                        "key": "Cache-Control",
+                        "value": "no-cache"
+                    }
+                ]
+            },
+            {
+                "source": "**/*.html",
+                "headers": [
+                    {
+                        "key": "Cache-Control",
+                        "value": "no-cache"
+                    }
+                ]
+            }
         ]
     }
 }


### PR DESCRIPTION
Firebase Hosting's default is `max-age=3600` for everything, which is wrong in both directions for a Vite build.

- **`index.html` → `no-cache`.** It names the content-hashed asset bundles, so caching it for an hour pins clients to a previous deploy's assets for that long. `no-cache` is not `no-store` — the browser still caches it and just revalidates against the ETag first, so the common case is a cheap 304, not a refetch.
- **`/assets/**` → `public, max-age=31536000, immutable`.** Vite content-hashes these filenames, so a given URL's contents can never change. They're safe to cache indefinitely, and the previous 1-hour default meant needlessly re-requesting them.

Header globs match the **request** path, before the SPA rewrite runs, so `/` and `**/*.html` are listed separately — a request for `/` never matches an `*.html` glob even though it serves `index.html`.

This is pre-existing rather than something the Vite migration caused; CRA hashed filenames too and hit the same default. It's just more visible now.

Verification to follow on the preview channel — I'll confirm the actual response headers rather than assume the globs match as intended.