### PR TITLE
Migrate Firebase 8 to 12 modular API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.1.0",
             "dependencies": {
                 "classnames": "^2.3.1",
-                "firebase": "^8.2.7",
+                "firebase": "^12.16.0",
                 "fuse.js": "^6.4.6",
                 "react": "^18.2.0",
                 "react-dom": "^18.2.0"
@@ -1180,107 +1180,208 @@
                 }
             }
         },
+        "node_modules/@firebase/ai": {
+            "version": "2.13.1",
+            "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.13.1.tgz",
+            "integrity": "sha512-RhT/VViTPBSplhQSuEp62HhLvfsV+LowMh8ZUo5MMRDzG7oFtSget4Kmg5oHP50hDVyWQuQj6to9iPFEZk08Tw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@firebase/app-check-interop-types": "0.3.4",
+                "@firebase/component": "0.7.3",
+                "@firebase/logger": "0.5.1",
+                "@firebase/util": "1.15.1",
+                "tslib": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            },
+            "peerDependencies": {
+                "@firebase/app": "0.x",
+                "@firebase/app-types": "0.x"
+            }
+        },
         "node_modules/@firebase/analytics": {
-            "version": "0.6.18",
-            "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.6.18.tgz",
-            "integrity": "sha512-FXNtYDxbs9ynPbzUVuG94BjFPOPpgJ7156660uvCBuKgoBCIVcNqKkJQQ7TH8384fqvGjbjdcgARY9jgAHbtog==",
+            "version": "0.10.22",
+            "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.22.tgz",
+            "integrity": "sha512-8BSaq/QRGU1+xyi8L2PTLTJU7MH9aMA72RQdIxrbhWFauOZY9OXo8f2YDN/972xA8d588tlnNVEQ2Mo69pT9Ow==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/analytics-types": "0.6.0",
-                "@firebase/component": "0.5.6",
-                "@firebase/installations": "0.4.32",
-                "@firebase/logger": "0.2.6",
-                "@firebase/util": "1.3.0",
+                "@firebase/component": "0.7.3",
+                "@firebase/installations": "0.6.22",
+                "@firebase/logger": "0.5.1",
+                "@firebase/util": "1.15.1",
                 "tslib": "^2.1.0"
-            },
-            "peerDependencies": {
-                "@firebase/app": "0.x",
-                "@firebase/app-types": "0.x"
-            }
-        },
-        "node_modules/@firebase/analytics-types": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.6.0.tgz",
-            "integrity": "sha512-kbMawY0WRPyL/lbknBkme4CNLl+Gw+E9G4OpNeXAauqoQiNkBgpIvZYy7BRT4sNGhZbxdxXxXbruqUwDzLmvTw==",
-            "license": "Apache-2.0"
-        },
-        "node_modules/@firebase/app": {
-            "version": "0.6.30",
-            "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.6.30.tgz",
-            "integrity": "sha512-uAYEDXyK0mmpZ8hWQj5TNd7WVvfsU8PgsqKpGljbFBG/HhsH8KbcykWAAA+c1PqL7dt/dbt0Reh1y9zEdYzMhg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/app-types": "0.6.3",
-                "@firebase/component": "0.5.6",
-                "@firebase/logger": "0.2.6",
-                "@firebase/util": "1.3.0",
-                "dom-storage": "2.1.0",
-                "tslib": "^2.1.0",
-                "xmlhttprequest": "1.8.0"
-            }
-        },
-        "node_modules/@firebase/app-check": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.3.2.tgz",
-            "integrity": "sha512-YjpsnV1xVTO1B836IKijRcDeceLgHQNJ/DWa+Vky9UHkm1Mi4qosddX8LZzldaWRTWKX7BN1MbZOLY8r7M/MZQ==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/app-check-interop-types": "0.1.0",
-                "@firebase/app-check-types": "0.3.1",
-                "@firebase/component": "0.5.6",
-                "@firebase/logger": "0.2.6",
-                "@firebase/util": "1.3.0",
-                "tslib": "^2.1.0"
-            },
-            "peerDependencies": {
-                "@firebase/app": "0.x",
-                "@firebase/app-types": "0.x"
-            }
-        },
-        "node_modules/@firebase/app-check-interop-types": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.1.0.tgz",
-            "integrity": "sha512-uZfn9s4uuRsaX5Lwx+gFP3B6YsyOKUE+Rqa6z9ojT4VSRAsZFko9FRn6OxQUA1z5t5d08fY4pf+/+Dkd5wbdbA==",
-            "license": "Apache-2.0"
-        },
-        "node_modules/@firebase/app-check-types": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.3.1.tgz",
-            "integrity": "sha512-KJ+BqJbdNsx4QT/JIT1yDj5p6D+QN97iJs3GuHnORrqL+DU3RWc9nSYQsrY6Tv9jVWcOkMENXAgDT484vzsm2w==",
-            "license": "Apache-2.0"
-        },
-        "node_modules/@firebase/app-types": {
-            "version": "0.6.3",
-            "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.6.3.tgz",
-            "integrity": "sha512-/M13DPPati7FQHEQ9Minjk1HGLm/4K4gs9bR4rzLCWJg64yGtVC0zNg9gDpkw9yc2cvol/mNFxqTtd4geGrwdw==",
-            "license": "Apache-2.0"
-        },
-        "node_modules/@firebase/auth": {
-            "version": "0.16.8",
-            "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.16.8.tgz",
-            "integrity": "sha512-mR0UXG4LirWIfOiCWxVmvz1o23BuKGxeItQ2cCUgXLTjNtWJXdcky/356iTUsd7ZV5A78s2NHeN5tIDDG6H4rg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/auth-types": "0.10.3"
             },
             "peerDependencies": {
                 "@firebase/app": "0.x"
             }
         },
-        "node_modules/@firebase/auth-interop-types": {
-            "version": "0.1.6",
-            "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.1.6.tgz",
-            "integrity": "sha512-etIi92fW3CctsmR9e3sYM3Uqnoq861M0Id9mdOPF6PWIg38BXL5k4upCNBggGUpLIS0H1grMOvy/wn1xymwe2g==",
+        "node_modules/@firebase/analytics-compat": {
+            "version": "0.2.28",
+            "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.28.tgz",
+            "integrity": "sha512-lIAlqUUbBu93FJMlQfslryQtBwwzdzvp23ePC6FNgymXk6Ook5v4Uvc0vdutvoIeqmyA3LfP0ZeRFK8+11kOOQ==",
             "license": "Apache-2.0",
+            "dependencies": {
+                "@firebase/analytics": "0.10.22",
+                "@firebase/analytics-types": "0.8.4",
+                "@firebase/component": "0.7.3",
+                "@firebase/util": "1.15.1",
+                "tslib": "^2.1.0"
+            },
             "peerDependencies": {
-                "@firebase/app-types": "0.x",
-                "@firebase/util": "1.x"
+                "@firebase/app-compat": "0.x"
             }
         },
+        "node_modules/@firebase/analytics-types": {
+            "version": "0.8.4",
+            "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.4.tgz",
+            "integrity": "sha512-zQ+XTgkwH6CY/eUSHJRP7e4LxM30RCxlCmob5sy2axs25GE3Ny0XdgpDscMTHHQIGqWkxPXad4w2Mw9sCgT8zQ==",
+            "license": "Apache-2.0"
+        },
+        "node_modules/@firebase/app": {
+            "version": "0.15.1",
+            "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.15.1.tgz",
+            "integrity": "sha512-iD9+Z5HcPo0Uop5f72/VYMeXwKucBhW7iFrISkJFvQ+lSZikTNgTz0FgAtaaTkAG0pEZSnCymA2Fu49n0rcufQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@firebase/component": "0.7.3",
+                "@firebase/logger": "0.5.1",
+                "@firebase/util": "1.15.1",
+                "idb": "7.1.1",
+                "tslib": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@firebase/app-check": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.12.0.tgz",
+            "integrity": "sha512-wMeT6HLWRAuW7Cp/5UjWBGKgjPNxWNOoNf4PRIv0weljoGMZVeqbUY7wNBWTI2/31cX1NlXx8gQruDLsUShB3Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@firebase/component": "0.7.3",
+                "@firebase/logger": "0.5.1",
+                "@firebase/util": "1.15.1",
+                "tslib": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            },
+            "peerDependencies": {
+                "@firebase/app": "0.x"
+            }
+        },
+        "node_modules/@firebase/app-check-compat": {
+            "version": "0.4.5",
+            "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.5.tgz",
+            "integrity": "sha512-JI17mVcZs34zO6ZeSCrw4U2iohqy+n6GIzkbmsA+TbVjmvFLkUKt3bs5M+qRBteQm/0IWzqSHYFzEQLzDTQebg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@firebase/app-check": "0.12.0",
+                "@firebase/app-check-types": "0.5.4",
+                "@firebase/component": "0.7.3",
+                "@firebase/logger": "0.5.1",
+                "@firebase/util": "1.15.1",
+                "tslib": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            },
+            "peerDependencies": {
+                "@firebase/app-compat": "0.x"
+            }
+        },
+        "node_modules/@firebase/app-check-interop-types": {
+            "version": "0.3.4",
+            "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.4.tgz",
+            "integrity": "sha512-zz3i6e13B8BfWiLy8MABtTh8aGIACgKbf9UVnyHcWs+yQzJXgQcl8A46b0zfaiJHdQ+niF0ouAfcpuf+3LMPQg==",
+            "license": "Apache-2.0"
+        },
+        "node_modules/@firebase/app-check-types": {
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.4.tgz",
+            "integrity": "sha512-xV7JsIyzVr15aA7f3Pi0rB9gdBuVubs89FGA8VkRYA4g0l78poADgdfrScgf7NndSg9mm7cR7PJyY0+t22KaGw==",
+            "license": "Apache-2.0"
+        },
+        "node_modules/@firebase/app-compat": {
+            "version": "0.5.15",
+            "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.15.tgz",
+            "integrity": "sha512-HaiSM9TwbGIR4b7F6+UncHWlqdH89eeY7VUskaOGOlI2PxHS5Z+6hHsYGvNLy0SHDE6zyXO+3QSA6a4aqQxsqA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@firebase/app": "0.15.1",
+                "@firebase/component": "0.7.3",
+                "@firebase/logger": "0.5.1",
+                "@firebase/util": "1.15.1",
+                "tslib": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@firebase/app-types": {
+            "version": "0.9.5",
+            "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.5.tgz",
+            "integrity": "sha512-YevqTjvo7Iujsa9Dwowmd6dSoElhzmD63ZSrq6bzjvQ6POjYgNjOFHLmNIgJs48eNO093NCERibuFnxbfOvU7A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@firebase/logger": "0.5.1"
+            }
+        },
+        "node_modules/@firebase/auth-compat": {
+            "version": "0.6.8",
+            "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.8.tgz",
+            "integrity": "sha512-llcBREUC4iSNKZ6rvwud7Oz9Q7aAWU6KuQLa6pdu7Q+QAQsy4JLw6yFgxwtmzabsgznHmmcsX2UjHLLzqUxi3Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@firebase/auth": "1.13.3",
+                "@firebase/auth-types": "0.13.1",
+                "@firebase/component": "0.7.3",
+                "@firebase/util": "1.15.1",
+                "tslib": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            },
+            "peerDependencies": {
+                "@firebase/app-compat": "0.x"
+            }
+        },
+        "node_modules/@firebase/auth-compat/node_modules/@firebase/auth": {
+            "version": "1.13.3",
+            "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.3.tgz",
+            "integrity": "sha512-bqiq4uubDN2YyQkdvSWPQeJyXAv2O76ImF41En9b6UhV5JuBVYDoHYrrrE3NzIuGkpFMKagfhMRP4Vz6t+yQSQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@firebase/component": "0.7.3",
+                "@firebase/logger": "0.5.1",
+                "@firebase/util": "1.15.1",
+                "tslib": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            },
+            "peerDependencies": {
+                "@firebase/app": "0.x",
+                "@react-native-async-storage/async-storage": "^2.2.0 || ^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@react-native-async-storage/async-storage": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@firebase/auth-interop-types": {
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.5.tgz",
+            "integrity": "sha512-1Li/YuBDBAXcKv7BzY4U28gontUmAaw53sYiqbaVOMCFb2lFKK/c3CGMUWqtwe7+TXrl3poWnTCL5umYBg85Eg==",
+            "license": "Apache-2.0"
+        },
         "node_modules/@firebase/auth-types": {
-            "version": "0.10.3",
-            "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.10.3.tgz",
-            "integrity": "sha512-zExrThRqyqGUbXOFrH/sowuh2rRtfKHp9SBVY2vOqKWdCX1Ztn682n9WLtlUDsiYVIbBcwautYWk2HyCGFv0OA==",
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.1.tgz",
+            "integrity": "sha512-0c1Mnid0uMDfGJHeUS4zfvBa4/CedJXotGy/n/NZJnBjwiJawt0ZYU+wH2VAVLiRCEfG2ncCkAX3yd1/2nrB7g==",
             "license": "Apache-2.0",
             "peerDependencies": {
                 "@firebase/app-types": "0.x",
@@ -1288,68 +1389,124 @@
             }
         },
         "node_modules/@firebase/component": {
-            "version": "0.5.6",
-            "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.5.6.tgz",
-            "integrity": "sha512-GyQJ+2lrhsDqeGgd1VdS7W+Y6gNYyI0B51ovNTxeZVG/W8I7t9MwEiCWsCvfm5wQgfsKp9dkzOcJrL5k8oVO/Q==",
+            "version": "0.7.3",
+            "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.3.tgz",
+            "integrity": "sha512-wFofIaa2879ogD/WvkjYXJxRmfnL0scen6ORgaC3na1FNOR9ASIUANQdhqQcmWu/h77/pVHY7ch5flewa5Bcew==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/util": "1.3.0",
-                "tslib": "^2.1.0"
-            }
-        },
-        "node_modules/@firebase/database": {
-            "version": "0.11.0",
-            "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.11.0.tgz",
-            "integrity": "sha512-b/kwvCubr6G9coPlo48PbieBDln7ViFBHOGeVt/bt82yuv5jYZBEYAac/mtOVSxpf14aMo/tAN+Edl6SWqXApw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/auth-interop-types": "0.1.6",
-                "@firebase/component": "0.5.6",
-                "@firebase/database-types": "0.8.0",
-                "@firebase/logger": "0.2.6",
-                "@firebase/util": "1.3.0",
-                "faye-websocket": "0.11.3",
-                "tslib": "^2.1.0"
-            }
-        },
-        "node_modules/@firebase/database-types": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-0.8.0.tgz",
-            "integrity": "sha512-7IdjAFRfPWyG3b4wcXyghb3Y1CLCSJFZIg1xl5GbTVMttSQFT4B5NYdhsfA34JwAsv5pMzPpjOaS3/K9XJ2KiA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/app-types": "0.6.3",
-                "@firebase/util": "1.3.0"
-            }
-        },
-        "node_modules/@firebase/firestore": {
-            "version": "2.4.1",
-            "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-2.4.1.tgz",
-            "integrity": "sha512-S51XnILdhNt0ZA6bPnbxpqKPI5LatbGY9RQjA2TmATrjSPE3aWndJsLIrutI6aS9K+YFwy5+HLDKVRFYQfmKAw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@firebase/component": "0.5.6",
-                "@firebase/firestore-types": "2.4.0",
-                "@firebase/logger": "0.2.6",
-                "@firebase/util": "1.3.0",
-                "@firebase/webchannel-wrapper": "0.5.1",
-                "@grpc/grpc-js": "^1.3.2",
-                "@grpc/proto-loader": "^0.6.0",
-                "node-fetch": "2.6.7",
+                "@firebase/util": "1.15.1",
                 "tslib": "^2.1.0"
             },
             "engines": {
-                "node": "^8.13.0 || >=10.10.0"
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@firebase/data-connect": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.7.1.tgz",
+            "integrity": "sha512-2LbUU8mmSA63HknxQMmWHjpzuNLBKflvVwQc2tpoVKg0biWleNEJX031ELks0vzFs+dDjOUkCJR72RP6mQHFOg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@firebase/auth-interop-types": "0.2.5",
+                "@firebase/component": "0.7.3",
+                "@firebase/logger": "0.5.1",
+                "@firebase/util": "1.15.1",
+                "tslib": "^2.1.0"
             },
             "peerDependencies": {
-                "@firebase/app": "0.x",
-                "@firebase/app-types": "0.x"
+                "@firebase/app": "0.x"
+            }
+        },
+        "node_modules/@firebase/database": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.3.tgz",
+            "integrity": "sha512-XwWCa+E4TvNGpGwXrycLRNfdogADwFcvuhyow6wDWma9W54roaQIhe+4PM0KiLsIftBdSCGI7OKCXrdSRHbIhw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@firebase/app-check-interop-types": "0.3.4",
+                "@firebase/auth-interop-types": "0.2.5",
+                "@firebase/component": "0.7.3",
+                "@firebase/logger": "0.5.1",
+                "@firebase/util": "1.15.1",
+                "faye-websocket": "0.11.4",
+                "tslib": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@firebase/database-compat": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.4.tgz",
+            "integrity": "sha512-3pK35F1MAgmqFJQlf2nhQl44vtAXQO1uaCaQOEUI9kCRtLFqi7N+QRKR7lFZPg+xIZIyubgxQaxY69YgfZRZWg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@firebase/component": "0.7.3",
+                "@firebase/database": "1.1.3",
+                "@firebase/database-types": "1.0.20",
+                "@firebase/logger": "0.5.1",
+                "@firebase/util": "1.15.1",
+                "tslib": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@firebase/database-types": {
+            "version": "1.0.20",
+            "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.20.tgz",
+            "integrity": "sha512-kegbOk/w8iU64pr0q6k2ItyNGjnQBMHFhwS7ohdWI4W+pc0/zhhdGXTdFj6X1oxItRjPoYOsSQmERgBkn/ihxw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@firebase/app-types": "0.9.5",
+                "@firebase/util": "1.15.1"
+            }
+        },
+        "node_modules/@firebase/firestore": {
+            "version": "4.16.0",
+            "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.16.0.tgz",
+            "integrity": "sha512-qdHMHMvMr0nRMuZyWNR/ArWa0YlPE3C4eAbmxTASJMYXAesKPL0Y54p70moggrNPzaK7MSIIq5RDJJyntQyIYA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@firebase/component": "0.7.3",
+                "@firebase/logger": "0.5.1",
+                "@firebase/util": "1.15.1",
+                "@firebase/webchannel-wrapper": "1.0.6",
+                "@grpc/grpc-js": "~1.9.0",
+                "@grpc/proto-loader": "^0.7.8",
+                "re2js": "^0.4.2",
+                "tslib": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            },
+            "peerDependencies": {
+                "@firebase/app": "0.x"
+            }
+        },
+        "node_modules/@firebase/firestore-compat": {
+            "version": "0.4.11",
+            "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.11.tgz",
+            "integrity": "sha512-W7o1WdwWq5aABK5Up2ncSvTQs/QGLR/fy7cVpFBNqhsXtxoMtflHf2xBIG6+aoptcuGAobddq4g2Sq27wqHaYw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@firebase/component": "0.7.3",
+                "@firebase/firestore": "4.16.0",
+                "@firebase/firestore-types": "3.0.4",
+                "@firebase/util": "1.15.1",
+                "tslib": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            },
+            "peerDependencies": {
+                "@firebase/app-compat": "0.x"
             }
         },
         "node_modules/@firebase/firestore-types": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-2.4.0.tgz",
-            "integrity": "sha512-0dgwfuNP7EN6/OlK2HSNSQiQNGLGaRBH0gvgr1ngtKKJuJFuq0Z48RBMeJX9CGjV4TP9h2KaB+KrUKJ5kh1hMg==",
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.4.tgz",
+            "integrity": "sha512-jGn+JSS4X9zZsrfu7Yw66v5YRdOLD1oyQh4USR0xWl4CUqV/DA6bNIXRPpxH/cUl3iVTNiP6MN7g+EL42A4qfA==",
             "license": "Apache-2.0",
             "peerDependencies": {
                 "@firebase/app-types": "0.x",
@@ -1357,167 +1514,259 @@
             }
         },
         "node_modules/@firebase/functions": {
-            "version": "0.6.16",
-            "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.6.16.tgz",
-            "integrity": "sha512-KDPjLKSjtR/zEH06YXXbdWTi8gzbKHGRzL/+ibZQA/1MLq0IilfM+1V1Fh8bADsMCUkxkqoc1yiA4SUbH5ajJA==",
+            "version": "0.13.5",
+            "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.13.5.tgz",
+            "integrity": "sha512-bWCx713f4kE/uFV7gdFOLBS7lDoiZj48MRkbAqe35gkXcCeWF4QjRNO07Jhmve7EJIoQOBczL29y2r8VRuN1kw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/component": "0.5.6",
-                "@firebase/functions-types": "0.4.0",
-                "@firebase/messaging-types": "0.5.0",
-                "node-fetch": "2.6.7",
+                "@firebase/app-check-interop-types": "0.3.4",
+                "@firebase/auth-interop-types": "0.2.5",
+                "@firebase/component": "0.7.3",
+                "@firebase/messaging-interop-types": "0.2.5",
+                "@firebase/util": "1.15.1",
                 "tslib": "^2.1.0"
             },
+            "engines": {
+                "node": ">=20.0.0"
+            },
             "peerDependencies": {
-                "@firebase/app": "0.x",
-                "@firebase/app-types": "0.x"
+                "@firebase/app": "0.x"
+            }
+        },
+        "node_modules/@firebase/functions-compat": {
+            "version": "0.4.5",
+            "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.4.5.tgz",
+            "integrity": "sha512-10qlUXGY25G5/1g9UihqksPp2po+ZqSE7LEizsrdUP7vrTmkysXxGSZCDyojSEp6mQe/ecRDdDDI+z4XRdb4wQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@firebase/component": "0.7.3",
+                "@firebase/functions": "0.13.5",
+                "@firebase/functions-types": "0.6.4",
+                "@firebase/util": "1.15.1",
+                "tslib": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            },
+            "peerDependencies": {
+                "@firebase/app-compat": "0.x"
             }
         },
         "node_modules/@firebase/functions-types": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.4.0.tgz",
-            "integrity": "sha512-3KElyO3887HNxtxNF1ytGFrNmqD+hheqjwmT3sI09FaDCuaxGbOnsXAXH2eQ049XRXw9YQpHMgYws/aUNgXVyQ==",
+            "version": "0.6.4",
+            "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.4.tgz",
+            "integrity": "sha512-zV6kgqtduR4rUAdC/ilS7kmb93XD7bEZoJDlVBZqlOw2uGGGCNBQBuleww2rr0Ulr3L9o2TDjumEt68/l1f9DQ==",
             "license": "Apache-2.0"
         },
         "node_modules/@firebase/installations": {
-            "version": "0.4.32",
-            "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.4.32.tgz",
-            "integrity": "sha512-K4UlED1Vrhd2rFQQJih+OgEj8OTtrtH4+Izkx7ip2bhXSc+unk8ZhnF69D0kmh7zjXAqEDJrmHs9O5fI3rV6Tw==",
+            "version": "0.6.22",
+            "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.22.tgz",
+            "integrity": "sha512-ef6nn3GGQTdReCfotRMG77PJZu8CqEbiK5pEoBnM0gTu/Z9v0i/az2p3HABsa/1beQmmyh1OsOjf7P5+pgwdZw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/component": "0.5.6",
-                "@firebase/installations-types": "0.3.4",
-                "@firebase/util": "1.3.0",
-                "idb": "3.0.2",
+                "@firebase/component": "0.7.3",
+                "@firebase/util": "1.15.1",
+                "idb": "7.1.1",
                 "tslib": "^2.1.0"
             },
             "peerDependencies": {
-                "@firebase/app": "0.x",
-                "@firebase/app-types": "0.x"
+                "@firebase/app": "0.x"
+            }
+        },
+        "node_modules/@firebase/installations-compat": {
+            "version": "0.2.22",
+            "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.22.tgz",
+            "integrity": "sha512-C/zpAuTP5S9OgKSPvXRupw3hoY/JZSlA1wFjD/Sb7LIQE0FNbcMdO8Y4KXVEkjVzma/DDDDIAzxEXqKMAzc88w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@firebase/component": "0.7.3",
+                "@firebase/installations": "0.6.22",
+                "@firebase/installations-types": "0.5.4",
+                "@firebase/util": "1.15.1",
+                "tslib": "^2.1.0"
+            },
+            "peerDependencies": {
+                "@firebase/app-compat": "0.x"
             }
         },
         "node_modules/@firebase/installations-types": {
-            "version": "0.3.4",
-            "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.3.4.tgz",
-            "integrity": "sha512-RfePJFovmdIXb6rYwtngyxuEcWnOrzdZd9m7xAW0gRxDIjBT20n3BOhjpmgRWXo/DAxRmS7bRjWAyTHY9cqN7Q==",
+            "version": "0.5.4",
+            "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.4.tgz",
+            "integrity": "sha512-U2eFapdHwjb43Vx9o+Pmj4dFfvcHEK1IirEFLqMtWrTHvmdrS3gBpBD1kmJk/9HjsOtoHZxJ2Paoe79e+L1ZPg==",
             "license": "Apache-2.0",
             "peerDependencies": {
                 "@firebase/app-types": "0.x"
             }
         },
         "node_modules/@firebase/logger": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.2.6.tgz",
-            "integrity": "sha512-KIxcUvW/cRGWlzK9Vd2KB864HlUnCfdTH0taHE0sXW5Xl7+W68suaeau1oKNEqmc3l45azkd4NzXTCWZRZdXrw==",
-            "license": "Apache-2.0"
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.1.tgz",
+            "integrity": "sha512-vZKLsqE1ABOy8OjQiE7cUTFn4gvaqlk88yp8N94Pk/sDpq61YqZGqmVFZTvOyflTwuYFcWirBdYGoJgbDaXKYQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
         },
         "node_modules/@firebase/messaging": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.8.0.tgz",
-            "integrity": "sha512-hkFHDyVe1kMcY9KEG+prjCbvS6MtLUgVFUbbQqq7JQfiv58E07YCzRUcMrJolbNi/1QHH6Jv16DxNWjJB9+/qA==",
+            "version": "0.13.0",
+            "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.13.0.tgz",
+            "integrity": "sha512-GZoo0uGRvEbszo83xcgbjJp4FpkmBEr4l8Z4hi8gl+P1Spn/MTK3HapanMzSX4yUHuTEiF5hasWRxOaz+o5sxQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/component": "0.5.6",
-                "@firebase/installations": "0.4.32",
-                "@firebase/messaging-types": "0.5.0",
-                "@firebase/util": "1.3.0",
-                "idb": "3.0.2",
+                "@firebase/component": "0.7.3",
+                "@firebase/installations": "0.6.22",
+                "@firebase/messaging-interop-types": "0.2.5",
+                "@firebase/util": "1.15.1",
+                "idb": "7.1.1",
                 "tslib": "^2.1.0"
             },
             "peerDependencies": {
-                "@firebase/app": "0.x",
-                "@firebase/app-types": "0.x"
+                "@firebase/app": "0.x"
             }
         },
-        "node_modules/@firebase/messaging-types": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/@firebase/messaging-types/-/messaging-types-0.5.0.tgz",
-            "integrity": "sha512-QaaBswrU6umJYb/ZYvjR5JDSslCGOH6D9P136PhabFAHLTR4TWjsaACvbBXuvwrfCXu10DtcjMxqfhdNIB1Xfg==",
+        "node_modules/@firebase/messaging-compat": {
+            "version": "0.2.27",
+            "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.27.tgz",
+            "integrity": "sha512-JNOiu1PPgdHzEPEtoFiNxQuu0x9bm4bfETSQCpGfcTlgWkhlSK7uh7nlsjC10TQLUNgYetLmuutaYTh8aeYLVA==",
             "license": "Apache-2.0",
+            "dependencies": {
+                "@firebase/component": "0.7.3",
+                "@firebase/messaging": "0.13.0",
+                "@firebase/util": "1.15.1",
+                "tslib": "^2.1.0"
+            },
             "peerDependencies": {
-                "@firebase/app-types": "0.x"
+                "@firebase/app-compat": "0.x"
             }
+        },
+        "node_modules/@firebase/messaging-interop-types": {
+            "version": "0.2.5",
+            "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.5.tgz",
+            "integrity": "sha512-tUEKnaAP2Y/MNIqgnriPpV6e5l13Vs/+p2yrd6NGlncPJT9O3a8muYZtdnWe+IJ4fgKLHJVC79n/asxk/N5Msw==",
+            "license": "Apache-2.0"
         },
         "node_modules/@firebase/performance": {
-            "version": "0.4.18",
-            "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.4.18.tgz",
-            "integrity": "sha512-lvZW/TVDne2TyOpWbv++zjRn277HZpbjxbIPfwtnmKjVY1gJ+H77Qi1c2avVIc9hg80uGX/5tNf4pOApNDJLVg==",
+            "version": "0.7.12",
+            "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.12.tgz",
+            "integrity": "sha512-fe7nV8teUU3OBHlMUZ9Lw4gLhCW2k4m5Uc3pfWGV+fl8uwJQBGp9Q3lqsJ+HSrFu3Q2pJyLAgrClPGSKyDeYgQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/component": "0.5.6",
-                "@firebase/installations": "0.4.32",
-                "@firebase/logger": "0.2.6",
-                "@firebase/performance-types": "0.0.13",
-                "@firebase/util": "1.3.0",
+                "@firebase/component": "0.7.3",
+                "@firebase/installations": "0.6.22",
+                "@firebase/logger": "0.5.1",
+                "@firebase/util": "1.15.1",
+                "tslib": "^2.1.0",
+                "web-vitals": "^4.2.4"
+            },
+            "peerDependencies": {
+                "@firebase/app": "0.x"
+            }
+        },
+        "node_modules/@firebase/performance-compat": {
+            "version": "0.2.25",
+            "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.25.tgz",
+            "integrity": "sha512-q6NjTXpIPoFuUmCmMN/maCdTgzT6aExs9xZo+PxfVLj6uLVGvpyAD6XWjmcrb7jChsFBYbq7E5dyNDF7Zhy9kA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@firebase/component": "0.7.3",
+                "@firebase/logger": "0.5.1",
+                "@firebase/performance": "0.7.12",
+                "@firebase/performance-types": "0.2.4",
+                "@firebase/util": "1.15.1",
                 "tslib": "^2.1.0"
             },
             "peerDependencies": {
-                "@firebase/app": "0.x",
-                "@firebase/app-types": "0.x"
+                "@firebase/app-compat": "0.x"
             }
         },
         "node_modules/@firebase/performance-types": {
-            "version": "0.0.13",
-            "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.0.13.tgz",
-            "integrity": "sha512-6fZfIGjQpwo9S5OzMpPyqgYAUZcFzZxHFqOyNtorDIgNXq33nlldTL/vtaUZA8iT9TT5cJlCrF/jthKU7X21EA==",
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.4.tgz",
+            "integrity": "sha512-kJSEk7b0uhpcPRyL4SQ/GPujLqk52XNKcXlnsKDbWGAb9vugcLvOU3u6zfEdwd+d8hWJb5S5ZizV1JFFI0nkKg==",
             "license": "Apache-2.0"
         },
-        "node_modules/@firebase/polyfill": {
-            "version": "0.3.36",
-            "resolved": "https://registry.npmjs.org/@firebase/polyfill/-/polyfill-0.3.36.tgz",
-            "integrity": "sha512-zMM9oSJgY6cT2jx3Ce9LYqb0eIpDE52meIzd/oe/y70F+v9u1LDqk5kUF5mf16zovGBWMNFmgzlsh6Wj0OsFtg==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "core-js": "3.6.5",
-                "promise-polyfill": "8.1.3",
-                "whatwg-fetch": "2.0.4"
-            }
-        },
         "node_modules/@firebase/remote-config": {
-            "version": "0.1.43",
-            "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.1.43.tgz",
-            "integrity": "sha512-laNM4MN0CfeSp7XCVNjYOC4DdV6mj0l2rzUh42x4v2wLTweCoJ/kc1i4oWMX9TI7Jw8Am5Wl71Awn1J2pVe5xA==",
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.9.0.tgz",
+            "integrity": "sha512-aNn6/eJhsSC+gXSToiXiYPv3ypLP9lFtzl+/q9kSOBPB7D6rae0Rt2uENZZLXGYbEgHYKQblOhijJAXGbbJjtQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/component": "0.5.6",
-                "@firebase/installations": "0.4.32",
-                "@firebase/logger": "0.2.6",
-                "@firebase/remote-config-types": "0.1.9",
-                "@firebase/util": "1.3.0",
+                "@firebase/component": "0.7.3",
+                "@firebase/installations": "0.6.22",
+                "@firebase/logger": "0.5.1",
+                "@firebase/util": "1.15.1",
                 "tslib": "^2.1.0"
             },
             "peerDependencies": {
-                "@firebase/app": "0.x",
-                "@firebase/app-types": "0.x"
+                "@firebase/app": "0.x"
+            }
+        },
+        "node_modules/@firebase/remote-config-compat": {
+            "version": "0.2.27",
+            "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.27.tgz",
+            "integrity": "sha512-FYwYWwSbUdza/pRX4NpSBm/Pimntum3jEIBpnDn5Ey1jHNWgjxrE8Z5SB4mCHd5wGCoYd3koJzxARl/VWIEx0Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@firebase/component": "0.7.3",
+                "@firebase/logger": "0.5.1",
+                "@firebase/remote-config": "0.9.0",
+                "@firebase/remote-config-types": "0.5.1",
+                "@firebase/util": "1.15.1",
+                "tslib": "^2.1.0"
+            },
+            "peerDependencies": {
+                "@firebase/app-compat": "0.x"
             }
         },
         "node_modules/@firebase/remote-config-types": {
-            "version": "0.1.9",
-            "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.1.9.tgz",
-            "integrity": "sha512-G96qnF3RYGbZsTRut7NBX0sxyczxt1uyCgXQuH/eAfUCngxjEGcZQnBdy6mvSdqdJh5mC31rWPO4v9/s7HwtzA==",
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.5.1.tgz",
+            "integrity": "sha512-cX/1LT6KQwkXzck2eSzeKnuvXZCyr8qaPpDcikoJs7jmI+oBOXixpDLeDtWj1U6GNMkIoXrEDNoyT2Ypcyp5/A==",
             "license": "Apache-2.0"
         },
         "node_modules/@firebase/storage": {
-            "version": "0.7.1",
-            "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.7.1.tgz",
-            "integrity": "sha512-T7uH6lAgNs/Zq8V3ElvR3ypTQSGWon/R7WRM2I5Td/d0PTsNIIHSAGB6q4Au8mQEOz3HDTfjNQ9LuQ07R6S2ug==",
+            "version": "0.14.3",
+            "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.3.tgz",
+            "integrity": "sha512-YX4/YL6P6/fufSSeGnVhjWddcIXbFq2cWIhMKFTZo1E/Rtcl2mJj/BYUQTwJfcE1Tl8un1FOya4L05jcSLN/Eg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/component": "0.5.6",
-                "@firebase/storage-types": "0.5.0",
-                "@firebase/util": "1.3.0",
-                "node-fetch": "2.6.7",
+                "@firebase/component": "0.7.3",
+                "@firebase/util": "1.15.1",
                 "tslib": "^2.1.0"
             },
+            "engines": {
+                "node": ">=20.0.0"
+            },
             "peerDependencies": {
-                "@firebase/app": "0.x",
-                "@firebase/app-types": "0.x"
+                "@firebase/app": "0.x"
+            }
+        },
+        "node_modules/@firebase/storage-compat": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.3.tgz",
+            "integrity": "sha512-gruVqjtUGX8tEoeNbaWXZm0Zfcfcb7fvmDmBxV8yPAbWvExRnZYLO2+qw9idxNE7BvPXt5csyjSYHy//dAizxw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@firebase/component": "0.7.3",
+                "@firebase/storage": "0.14.3",
+                "@firebase/storage-types": "0.8.4",
+                "@firebase/util": "1.15.1",
+                "tslib": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            },
+            "peerDependencies": {
+                "@firebase/app-compat": "0.x"
             }
         },
         "node_modules/@firebase/storage-types": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.5.0.tgz",
-            "integrity": "sha512-6Wv3Lu7s18hsgW7HG4BFwycTquZ3m/C8bjBoOsmPu0TD6M1GKwCzOC7qBdN7L6tRYPh8ipTj5+rPFrmhGfUVKA==",
+            "version": "0.8.4",
+            "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.4.tgz",
+            "integrity": "sha512-BT7cwxJOx8SWwlQfrlC+bD/Sk3Cw+1odCi8UZNFNWTVZoPsBnA5W+mqtZzVnvsdJpXCFGSGQ7R7vOR6dtM/BRA==",
             "license": "Apache-2.0",
             "peerDependencies": {
                 "@firebase/app-types": "0.x",
@@ -1525,132 +1774,47 @@
             }
         },
         "node_modules/@firebase/util": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.3.0.tgz",
-            "integrity": "sha512-SESvmYwuKOVCZ1ZxLbberbx+9cnbxpCa4CG2FUSQYqN6Ab8KyltegMDIsqMw5KyIBZ4n1phfHoOa22xo5NzAlQ==",
+            "version": "1.15.1",
+            "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.1.tgz",
+            "integrity": "sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g==",
+            "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=20.0.0"
             }
         },
         "node_modules/@firebase/webchannel-wrapper": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-0.5.1.tgz",
-            "integrity": "sha512-dZMzN0uAjwJXWYYAcnxIwXqRTZw3o14hGe7O6uhwjD1ZQWPVYA5lASgnNskEBra0knVBsOXB4KXg+HnlKewN/A==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.6.tgz",
+            "integrity": "sha512-Vr/Mqu79dMwGRAyGbJ4uN4+BtXB3/mRTdzetD1daWNeG8QaWuzhhbG77GltO5c0yYmYls8i250iX73624GJd7Q==",
             "license": "Apache-2.0"
         },
         "node_modules/@grpc/grpc-js": {
-            "version": "1.14.4",
-            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
-            "integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+            "version": "1.9.16",
+            "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.16.tgz",
+            "integrity": "sha512-wE4Ut/olIzfKqp631XrG+wbF0v1vWFN4YL9FyXC2LJiG33DsV7PLzURjrCvY/6je2ntdRkeLpPDluzSRGaVltQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@grpc/proto-loader": "^0.8.0",
-                "@js-sdsl/ordered-map": "^4.4.2"
+                "@grpc/proto-loader": "^0.7.8",
+                "@types/node": ">=12.12.47"
             },
             "engines": {
-                "node": ">=12.10.0"
+                "node": "^8.13.0 || >=10.10.0"
             }
         },
-        "node_modules/@grpc/grpc-js/node_modules/@grpc/proto-loader": {
-            "version": "0.8.1",
-            "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
-            "integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+        "node_modules/@grpc/proto-loader": {
+            "version": "0.7.15",
+            "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+            "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "lodash.camelcase": "^4.3.0",
                 "long": "^5.0.0",
-                "protobufjs": "^7.5.5",
+                "protobufjs": "^7.2.5",
                 "yargs": "^17.7.2"
-            },
-            "bin": {
-                "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/@grpc/grpc-js/node_modules/cliui": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-            "license": "ISC",
-            "dependencies": {
-                "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.1",
-                "wrap-ansi": "^7.0.0"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@grpc/grpc-js/node_modules/long": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
-            "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-            "license": "Apache-2.0"
-        },
-        "node_modules/@grpc/grpc-js/node_modules/protobufjs": {
-            "version": "7.6.5",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
-            "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
-            "hasInstallScript": true,
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "@protobufjs/aspromise": "^1.1.2",
-                "@protobufjs/base64": "^1.1.2",
-                "@protobufjs/codegen": "^2.0.5",
-                "@protobufjs/eventemitter": "^1.1.1",
-                "@protobufjs/fetch": "^1.1.1",
-                "@protobufjs/float": "^1.0.2",
-                "@protobufjs/path": "^1.1.2",
-                "@protobufjs/pool": "^1.1.0",
-                "@protobufjs/utf8": "^1.1.1",
-                "@types/node": ">=13.7.0",
-                "long": "^5.3.2"
-            },
-            "engines": {
-                "node": ">=12.0.0"
-            }
-        },
-        "node_modules/@grpc/grpc-js/node_modules/yargs": {
-            "version": "17.7.3",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
-            "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
-            "license": "MIT",
-            "dependencies": {
-                "cliui": "^8.0.1",
-                "escalade": "^3.1.1",
-                "get-caller-file": "^2.0.5",
-                "require-directory": "^2.1.1",
-                "string-width": "^4.2.3",
-                "y18n": "^5.0.5",
-                "yargs-parser": "^21.1.1"
-            },
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@grpc/grpc-js/node_modules/yargs-parser": {
-            "version": "21.1.1",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=12"
-            }
-        },
-        "node_modules/@grpc/proto-loader": {
-            "version": "0.6.13",
-            "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.6.13.tgz",
-            "integrity": "sha512-FjxPYDRTn6Ec3V0arm1FtSpmP6V50wuph2yILpyvTKzjc76oDdoihXqM1DzOW5ubvCC8GivfCnNtfaRE8myJ7g==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@types/long": "^4.0.1",
-                "lodash.camelcase": "^4.3.0",
-                "long": "^4.0.0",
-                "protobufjs": "^6.11.3",
-                "yargs": "^16.2.0"
             },
             "bin": {
                 "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
@@ -1871,16 +2035,6 @@
                 "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
-        "node_modules/@js-sdsl/ordered-map": {
-            "version": "4.4.2",
-            "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
-            "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
-            "license": "MIT",
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/js-sdsl"
-            }
-        },
         "node_modules/@protobufjs/aspromise": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
@@ -1918,12 +2072,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
             "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-            "license": "BSD-3-Clause"
-        },
-        "node_modules/@protobufjs/inquire": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-            "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/path": {
@@ -2684,12 +2832,6 @@
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
             "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
             "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@types/long": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-            "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
             "license": "MIT"
         },
         "node_modules/@types/node": {
@@ -3700,14 +3842,17 @@
             "license": "MIT"
         },
         "node_modules/cliui": {
-            "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
-            "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
             "license": "ISC",
             "dependencies": {
                 "string-width": "^4.2.0",
-                "strip-ansi": "^6.0.0",
+                "strip-ansi": "^6.0.1",
                 "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/color-convert": {
@@ -3741,18 +3886,6 @@
             "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/core-js": {
-            "version": "3.6.5",
-            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-            "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
-            "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
-            "hasInstallScript": true,
-            "license": "MIT",
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
         },
         "node_modules/core-js-pure": {
             "version": "3.49.0",
@@ -3974,15 +4107,6 @@
             "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/dom-storage": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/dom-storage/-/dom-storage-2.1.0.tgz",
-            "integrity": "sha512-g6RpyWXzl0RR6OTElHKBl7nwnK87GUyZMYC7JWsB/IA73vpqK2K6LT39x4VepLxlSsWBFrPVLnsSR5Jyty0+2Q==",
-            "license": "(MIT or Apache-2.0)",
-            "engines": {
-                "node": "*"
-            }
         },
         "node_modules/dunder-proto": {
             "version": "1.0.1",
@@ -4595,9 +4719,9 @@
             "license": "MIT"
         },
         "node_modules/faye-websocket": {
-            "version": "0.11.3",
-            "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.3.tgz",
-            "integrity": "sha512-D2y4bovYpzziGgbHYtGCMjlJM36vAl/y+xUyn1C+FVx8szd1E+86KwVw6XvYSzOP8iMpm1X0I4xJD+QtUb36OA==",
+            "version": "0.11.4",
+            "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+            "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
             "license": "Apache-2.0",
             "dependencies": {
                 "websocket-driver": ">=0.5.1"
@@ -4655,29 +4779,63 @@
             }
         },
         "node_modules/firebase": {
-            "version": "8.10.1",
-            "resolved": "https://registry.npmjs.org/firebase/-/firebase-8.10.1.tgz",
-            "integrity": "sha512-84z/zqF8Y5IpUYN8nREZ/bxbGtF5WJDOBy4y0hAxRzGpB5+2tw9PQgtTnUzk6MQiVEf/WOniMUL3pCVXKsxALw==",
+            "version": "12.16.0",
+            "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.16.0.tgz",
+            "integrity": "sha512-CNw6hFBdONkzF8UGLDx/RDRY9gVa5VmJNHd7qi4gdmA3ZuLkuOrhmWefB2l+FN+OxFpN77Itq7aO6zlTi780ag==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@firebase/analytics": "0.6.18",
-                "@firebase/app": "0.6.30",
-                "@firebase/app-check": "0.3.2",
-                "@firebase/app-types": "0.6.3",
-                "@firebase/auth": "0.16.8",
-                "@firebase/database": "0.11.0",
-                "@firebase/firestore": "2.4.1",
-                "@firebase/functions": "0.6.16",
-                "@firebase/installations": "0.4.32",
-                "@firebase/messaging": "0.8.0",
-                "@firebase/performance": "0.4.18",
-                "@firebase/polyfill": "0.3.36",
-                "@firebase/remote-config": "0.1.43",
-                "@firebase/storage": "0.7.1",
-                "@firebase/util": "1.3.0"
+                "@firebase/ai": "2.13.1",
+                "@firebase/analytics": "0.10.22",
+                "@firebase/analytics-compat": "0.2.28",
+                "@firebase/app": "0.15.1",
+                "@firebase/app-check": "0.12.0",
+                "@firebase/app-check-compat": "0.4.5",
+                "@firebase/app-compat": "0.5.15",
+                "@firebase/app-types": "0.9.5",
+                "@firebase/auth": "1.13.3",
+                "@firebase/auth-compat": "0.6.8",
+                "@firebase/data-connect": "0.7.1",
+                "@firebase/database": "1.1.3",
+                "@firebase/database-compat": "2.1.4",
+                "@firebase/firestore": "4.16.0",
+                "@firebase/firestore-compat": "0.4.11",
+                "@firebase/functions": "0.13.5",
+                "@firebase/functions-compat": "0.4.5",
+                "@firebase/installations": "0.6.22",
+                "@firebase/installations-compat": "0.2.22",
+                "@firebase/messaging": "0.13.0",
+                "@firebase/messaging-compat": "0.2.27",
+                "@firebase/performance": "0.7.12",
+                "@firebase/performance-compat": "0.2.25",
+                "@firebase/remote-config": "0.9.0",
+                "@firebase/remote-config-compat": "0.2.27",
+                "@firebase/storage": "0.14.3",
+                "@firebase/storage-compat": "0.4.3",
+                "@firebase/util": "1.15.1"
+            }
+        },
+        "node_modules/firebase/node_modules/@firebase/auth": {
+            "version": "1.13.3",
+            "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.3.tgz",
+            "integrity": "sha512-bqiq4uubDN2YyQkdvSWPQeJyXAv2O76ImF41En9b6UhV5JuBVYDoHYrrrE3NzIuGkpFMKagfhMRP4Vz6t+yQSQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@firebase/component": "0.7.3",
+                "@firebase/logger": "0.5.1",
+                "@firebase/util": "1.15.1",
+                "tslib": "^2.1.0"
             },
             "engines": {
-                "node": "^8.13.0 || >=10.10.0"
+                "node": ">=20.0.0"
+            },
+            "peerDependencies": {
+                "@firebase/app": "0.x",
+                "@react-native-async-storage/async-storage": "^2.2.0 || ^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@react-native-async-storage/async-storage": {
+                    "optional": true
+                }
             }
         },
         "node_modules/flat-cache": {
@@ -5072,9 +5230,9 @@
             "license": "MIT"
         },
         "node_modules/idb": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/idb/-/idb-3.0.2.tgz",
-            "integrity": "sha512-+FLa/0sTXqyux0o6C+i2lOR0VoS60LU/jzUo5xjfY6+7sEEgy4Gz1O7yFBXvjd7N0NyIGWIRg8DcQSLEG+VSPw==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+            "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
             "license": "ISC"
         },
         "node_modules/ignore": {
@@ -6080,9 +6238,9 @@
             "license": "MIT"
         },
         "node_modules/long": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-            "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+            "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
             "license": "Apache-2.0"
         },
         "node_modules/loose-envify": {
@@ -6258,48 +6416,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/node-fetch": {
-            "version": "2.6.7",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-            "license": "MIT",
-            "dependencies": {
-                "whatwg-url": "^5.0.0"
-            },
-            "engines": {
-                "node": "4.x || >=6.0.0"
-            },
-            "peerDependencies": {
-                "encoding": "^0.1.0"
-            },
-            "peerDependenciesMeta": {
-                "encoding": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/node-fetch/node_modules/tr46": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-            "license": "MIT"
-        },
-        "node_modules/node-fetch/node_modules/webidl-conversions": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-            "license": "BSD-2-Clause"
-        },
-        "node_modules/node-fetch/node_modules/whatwg-url": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-            "license": "MIT",
-            "dependencies": {
-                "tr46": "~0.0.3",
-                "webidl-conversions": "^3.0.0"
             }
         },
         "node_modules/node-releases": {
@@ -6678,12 +6794,6 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
-        "node_modules/promise-polyfill": {
-            "version": "8.1.3",
-            "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.1.3.tgz",
-            "integrity": "sha512-MG5r82wBzh7pSKDRa9y+vllNHz3e3d4CNj1PQE4BQYxLme0gKYYBm9YENq+UkEikyZ0XbiGWxYlVw3Rl9O/U8g==",
-            "license": "MIT"
-        },
         "node_modules/prop-types": {
             "version": "15.8.1",
             "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -6704,29 +6814,26 @@
             "license": "MIT"
         },
         "node_modules/protobufjs": {
-            "version": "6.11.6",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-6.11.6.tgz",
-            "integrity": "sha512-k8BHqgPBOtrlougZZqF2uUk5Z7bN8f0wj+3e8M3hvtSv0NBAz4VBy5f6R5Nxq/l+i7mRFTgNZb2trxqTpHNY/A==",
+            "version": "7.6.5",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+            "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "dependencies": {
                 "@protobufjs/aspromise": "^1.1.2",
                 "@protobufjs/base64": "^1.1.2",
-                "@protobufjs/codegen": "^2.0.4",
-                "@protobufjs/eventemitter": "^1.1.0",
-                "@protobufjs/fetch": "^1.1.0",
+                "@protobufjs/codegen": "^2.0.5",
+                "@protobufjs/eventemitter": "^1.1.1",
+                "@protobufjs/fetch": "^1.1.1",
                 "@protobufjs/float": "^1.0.2",
-                "@protobufjs/inquire": "^1.1.0",
                 "@protobufjs/path": "^1.1.2",
                 "@protobufjs/pool": "^1.1.0",
-                "@protobufjs/utf8": "^1.1.0",
-                "@types/long": "^4.0.1",
+                "@protobufjs/utf8": "^1.1.1",
                 "@types/node": ">=13.7.0",
-                "long": "^4.0.0"
+                "long": "^5.3.2"
             },
-            "bin": {
-                "pbjs": "bin/pbjs",
-                "pbts": "bin/pbts"
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/punycode": {
@@ -6738,6 +6845,12 @@
             "engines": {
                 "node": ">=6"
             }
+        },
+        "node_modules/re2js": {
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/re2js/-/re2js-0.4.3.tgz",
+            "integrity": "sha512-EuNmh7jurhHEE8Ge/lBo9JuMLb3qf866Xjjfyovw3wPc7+hlqDkZq4LwhrCQMEI+ARWfrKrHozEndzlpNT0WDg==",
+            "license": "MIT"
         },
         "node_modules/react": {
             "version": "18.3.1",
@@ -7962,6 +8075,12 @@
                 "node": ">=18"
             }
         },
+        "node_modules/web-vitals": {
+            "version": "4.2.4",
+            "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+            "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+            "license": "Apache-2.0"
+        },
         "node_modules/webidl-conversions": {
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -7994,12 +8113,6 @@
             "engines": {
                 "node": ">=0.8.0"
             }
-        },
-        "node_modules/whatwg-fetch": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz",
-            "integrity": "sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==",
-            "license": "MIT"
         },
         "node_modules/whatwg-mimetype": {
             "version": "5.0.0",
@@ -8192,15 +8305,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/xmlhttprequest": {
-            "version": "1.8.0",
-            "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-            "integrity": "sha512-58Im/U0mlVBLM38NdZjHyhuMtCqa61469k2YP/AaPbvCoV9aQGUpbJBj1QRm2ytRiVQBD/fsw7L2bJGDVQswBA==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
         "node_modules/y18n": {
             "version": "5.0.8",
             "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -8218,30 +8322,30 @@
             "license": "ISC"
         },
         "node_modules/yargs": {
-            "version": "16.2.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.2.tgz",
-            "integrity": "sha512-Nt9ZJjXTv5R8MHbqby/wXQ6Gi0Bb3TcYZkR1bzuL4yB2OxWPkXknz513gEF0GoA6tn00UpbPvERW8rzCuWCA6w==",
+            "version": "17.7.3",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+            "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
             "license": "MIT",
             "dependencies": {
-                "cliui": "^7.0.2",
+                "cliui": "^8.0.1",
                 "escalade": "^3.1.1",
                 "get-caller-file": "^2.0.5",
                 "require-directory": "^2.1.1",
-                "string-width": "^4.2.0",
+                "string-width": "^4.2.3",
                 "y18n": "^5.0.5",
-                "yargs-parser": "^20.2.2"
+                "yargs-parser": "^21.1.1"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=12"
             }
         },
         "node_modules/yargs-parser": {
-            "version": "20.2.9",
-            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
-            "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
             "license": "ISC",
             "engines": {
-                "node": ">=10"
+                "node": ">=12"
             }
         },
         "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "homepage": "https://sleeper-player-db.web.app/",
     "dependencies": {
         "classnames": "^2.3.1",
-        "firebase": "^8.2.7",
+        "firebase": "^12.16.0",
         "fuse.js": "^6.4.6",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,12 +4,12 @@ import './loader.css';
 import Button from './Components/Button';
 import LeaguePanel from './Panels/LeaguePanel';
 import RanksPanel from './Panels/RanksPanel';
-import firebase, { auth } from './firebase.js';
+import { onAuthStateChanged, signInAnonymously, signInWithPopup, signOut as firebaseSignOut } from 'firebase/auth';
+import { auth, googleProvider } from './firebase.js';
 import createRankings from './helpers.js';
 import APP_DB_URLS, { SLEEPER_API_URLS } from './urls.js';
 const { LATEST_UPDATE_ATTEMPT, ACTIVE_PLAYERS } = APP_DB_URLS;
 const { LEAGUE, ALL_LEAGUES_ACTIVE_YEAR, DRAFT, ROSTERS, SLEEPER_USERS, TRADED_PICKS, DRAFTS } = SLEEPER_API_URLS;
-const provider = new firebase.auth.GoogleAuthProvider();
 
 class App extends React.Component {
     state = {
@@ -30,7 +30,7 @@ class App extends React.Component {
     };
 
     componentDidMount() {
-        auth.onAuthStateChanged((user) => {
+        onAuthStateChanged(auth, (user) => {
             if (user) {
                 const { playerInfo } = this.state;
                 const { currentUser } = auth;
@@ -44,7 +44,7 @@ class App extends React.Component {
                     this.getLeagueData();
                 }
             } else {
-                auth.signInAnonymously().catch((err) => console.error('Error:', err));
+                signInAnonymously(auth).catch((err) => console.error('Error:', err));
             }
         });
     }
@@ -382,18 +382,13 @@ class App extends React.Component {
     };
 
     googleSignIn = () => {
-        firebase
-            .auth()
-            .signInWithPopup(provider)
-            .catch((error) => {
-                console.log(error);
-            });
+        signInWithPopup(auth, googleProvider).catch((error) => {
+            console.log(error);
+        });
     };
 
     signOut = () => {
-        firebase
-            .auth()
-            .signOut()
+        firebaseSignOut(auth)
             .then(() => {
                 this.setState({
                     rankingPlayersIdsList: [],

--- a/src/firebase.js
+++ b/src/firebase.js
@@ -1,5 +1,5 @@
-import firebase from 'firebase/app';
-import 'firebase/auth';
+import { initializeApp, getApps, getApp } from 'firebase/app';
+import { getAuth, GoogleAuthProvider } from 'firebase/auth';
 
 const firebaseConfig = {
     apiKey: 'AIzaSyCg0BOhB2oh686NyBEW_YhDVZjPei6DHIo',
@@ -11,9 +11,7 @@ const firebaseConfig = {
     appId: '1:60081661933:web:2a15f3d9a61dd9eb8ce9e4',
 };
 // Initialize Firebase
-if (firebase.apps.length === 0) {
-    firebase.initializeApp(firebaseConfig);
-}
+const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
 
-export const auth = firebase.auth();
-export default firebase;
+export const auth = getAuth(app);
+export const googleProvider = new GoogleAuthProvider();


### PR DESCRIPTION
Firebase 8's namespaced API is four majors behind and was the last source of critical/high vulnerabilities in the dependency tree. Only Auth is used here — the Realtime Database is reached over its REST API via plain `fetch`, so nothing else needed touching.

**Bundle: 126.98 kB → 90.60 kB gzip (−28.7%)**, because the modular SDK tree-shakes.
**Vulnerabilities: 10 → 6, no criticals remain.** The rest are in the ESLint devDependency chain and never reach the browser.

### Changes
- **`src/firebase.js`** rewritten against the modular API: `initializeApp`/`getApps`/`getApp` for the don't-double-initialize guard, `getAuth`, and a `GoogleAuthProvider` instance now exported as `googleProvider` rather than constructed in `App.jsx` off the namespace object. The `firebase` default export is gone.
- **`src/App.jsx`** call sites moved to the modular function form: `onAuthStateChanged(auth, cb)`, `signInAnonymously(auth)`, `signInWithPopup(auth, googleProvider)`, and `signOut(auth)` — imported as `firebaseSignOut`, since the `App` class has its own `signOut` method.
- **`src/Panels/RanksPanel.jsx`** needed no changes. `currentUser.getIdToken()`/`.uid` are still members of the modular `User` object.
- `firebaseConfig` values untouched — they're public client config, not secrets.

### Verification
- All five CI gates pass; `npm ci` succeeds with no `--legacy-peer-deps`.
- No `firebase/compat` imports introduced — the compat layer would have defeated the whole point.
- **Runtime:** anonymous sign-in and `getIdToken(true)` both work. The "Latest player DB update attempt" timestamp only populates via an authenticated request, and it does — so the token path is exercised end to end, not just the module imports.

### Still needs a manual pass
Google popup sign-in and the saved-rank-list CRUD behind it can't be exercised without real credentials. Worth a signed-in smoke test before merging: sign in, load a saved rank list, save/delete one, sign out.

### Noted, not fixed
`componentDidMount` subscribes via `onAuthStateChanged` and never unsubscribes — there's no `componentWillUnmount`. Pre-existing, and more visible under StrictMode. The modular form returns an unsubscribe function, which makes the fix trivial, but it belongs with the class-to-hooks refactor rather than here.