### PR TITLE
Derive the season and current user instead of hardcoding them

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,9 +9,10 @@ import { auth, googleProvider } from './firebase.js';
 import createRankings from './helpers.js';
 import { buildDraftRounds } from './lib/draft.js';
 import { addPlayerToRoster, removePlayerFromLineup } from './lib/roster.js';
-import APP_DB_URLS, { SLEEPER_API_URLS } from './urls.js';
+import { resolveLeagueSeason, resolveMyDisplayName } from './lib/sleeper.js';
+import APP_DB_URLS, { SLEEPER_API_URLS, SLEEPER_USER_ID } from './urls.js';
 const { LATEST_UPDATE_ATTEMPT, ACTIVE_PLAYERS } = APP_DB_URLS;
-const { LEAGUE, ALL_LEAGUES_ACTIVE_YEAR, DRAFT, ROSTERS, SLEEPER_USERS, TRADED_PICKS, DRAFTS } = SLEEPER_API_URLS;
+const { LEAGUE, USER_LEAGUES, NFL_STATE, DRAFT, ROSTERS, SLEEPER_USERS, TRADED_PICKS, DRAFTS } = SLEEPER_API_URLS;
 
 class App extends React.Component {
     state = {
@@ -29,6 +30,8 @@ class App extends React.Component {
         liveDraft: [],
         signedIn: false,
         signedInEmail: null,
+        season: null,
+        myDisplayName: null,
     };
 
     componentDidMount() {
@@ -106,14 +109,29 @@ class App extends React.Component {
         this.getLeagueData();
     };
 
-    getLeagueData = () => {
+    getLeagueSeason = async () => {
+        return await fetch(NFL_STATE)
+            .then(this.checkErrors)
+            .then((response) => response.json())
+            .then((nflState) => resolveLeagueSeason(nflState))
+            .catch((error) => {
+                console.error('Error fetching NFL state, falling back to current calendar year:', error);
+                return String(new Date().getFullYear());
+            });
+    };
+
+    getLeagueData = async () => {
         const leagueID = this.state.leagueID;
         const LEAGUE_PATH = LEAGUE + leagueID + '/';
+        const season = this.state.season ? this.state.season : await this.getLeagueSeason();
+        if (!this.state.season) {
+            this.setState({ season });
+        }
         const urls = [
             LEAGUE_PATH + ROSTERS,
             LEAGUE_PATH + SLEEPER_USERS,
             LEAGUE_PATH,
-            ALL_LEAGUES_ACTIVE_YEAR,
+            USER_LEAGUES(season),
             LEAGUE_PATH + DRAFTS,
         ];
         const requests = urls.map(async (url) => {
@@ -136,6 +154,7 @@ class App extends React.Component {
                         leagueData: leagueData,
                         isLoading: false,
                         loadingMessage: 'Loading league panel...',
+                        myDisplayName: resolveMyDisplayName(leagueData.managerData, SLEEPER_USER_ID),
                         rosterPositions: leagueData.currentLeague.roster_positions
                             .filter((pos) => pos !== 'BN')
                             .map((pos) => {
@@ -348,6 +367,7 @@ class App extends React.Component {
             leagueID,
             signedIn,
             signedInEmail,
+            myDisplayName,
         } = this.state;
         if (isLoading && loadingMessage === 'Initial load...') {
             return <div className="loader"></div>;
@@ -390,6 +410,7 @@ class App extends React.Component {
                             updatePlayerId={this.updatePlayerId}
                             notFoundPlayers={notFoundPlayers}
                             rankingPlayersIdsList={rankingPlayersIdsList}
+                            myDisplayName={myDisplayName}
                         />
                         <LeaguePanel
                             leagueData={leagueData}

--- a/src/Components/PlayerInfoItem.jsx
+++ b/src/Components/PlayerInfoItem.jsx
@@ -1,7 +1,16 @@
 import { useState } from 'react';
 import Button from './Button';
 
-const PlayerInfoItem = ({ player, playerInfo, addToRoster, searchData, updatePlayerId, isNewRankList, adpData }) => {
+const PlayerInfoItem = ({
+    player,
+    playerInfo,
+    addToRoster,
+    searchData,
+    updatePlayerId,
+    isNewRankList,
+    adpData,
+    myDisplayName,
+}) => {
     const [editingPlayer, setEditingPlayer] = useState(false);
     const [searchValue, setSearchValue] = useState('');
 
@@ -169,7 +178,7 @@ const PlayerInfoItem = ({ player, playerInfo, addToRoster, searchData, updatePla
                 ></div>
             </div>
             <div className="player-add-div">
-                {(player.rostered_by && player.rostered_by === 'ryangh') || !player.is_taken ? (
+                {(player.rostered_by && player.rostered_by === myDisplayName) || !player.is_taken ? (
                     <Button
                         text={`${player.in_lineup ? 'Added' : 'Add'}`}
                         isDisabled={player.in_lineup}

--- a/src/Panels/RanksPanel.jsx
+++ b/src/Panels/RanksPanel.jsx
@@ -20,6 +20,7 @@ const RanksPanel = ({
     addToRoster,
     updatePlayerId,
     notFoundPlayers,
+    myDisplayName,
 }) => {
     const defaultSelector = 'default';
     const defaultSelectorObj = {
@@ -160,13 +161,13 @@ const RanksPanel = ({
             !showTaken &&
             showMyPlayers &&
             (!playerInfo[rankingPlayers.match_results[0][0]].is_taken ||
-                playerInfo[rankingPlayers.match_results[0][0]].rostered_by === 'ryangh')
+                playerInfo[rankingPlayers.match_results[0][0]].rostered_by === myDisplayName)
         ) {
             return true;
         } else if (
             showTaken &&
             !showMyPlayers &&
-            playerInfo[rankingPlayers.match_results[0][0]].rostered_by !== 'ryangh'
+            playerInfo[rankingPlayers.match_results[0][0]].rostered_by !== myDisplayName
         ) {
             return true;
         } else if (!showMyPlayers && !showTaken && !playerInfo[rankingPlayers.match_results[0][0]].is_taken) {
@@ -418,6 +419,7 @@ const RanksPanel = ({
                                     updatePlayerId={updatePlayerId}
                                     searchData={results}
                                     adpData={adp?.[results.match_results[0][0]]?.[adpType] ?? null}
+                                    myDisplayName={myDisplayName}
                                 />
                             ))}
                         {notFoundPlayers.map((item, index) => (

--- a/src/lib/sleeper.js
+++ b/src/lib/sleeper.js
@@ -1,0 +1,19 @@
+const resolveLeagueSeason = (nflState) => {
+    if (nflState && nflState.league_season) {
+        return nflState.league_season;
+    }
+    if (nflState && nflState.season) {
+        return nflState.season;
+    }
+    return String(new Date().getFullYear());
+};
+
+const resolveMyDisplayName = (managerData, userId) => {
+    if (!managerData) {
+        return null;
+    }
+    const manager = managerData.find((manager) => manager.user_id === userId);
+    return manager ? manager.display_name : null;
+};
+
+export { resolveLeagueSeason, resolveMyDisplayName };

--- a/src/lib/sleeper.test.js
+++ b/src/lib/sleeper.test.js
@@ -1,0 +1,61 @@
+import { describe, expect, it, vi, afterEach } from 'vitest';
+import { resolveLeagueSeason, resolveMyDisplayName } from './sleeper.js';
+
+describe('resolveLeagueSeason', () => {
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('returns league_season when present', () => {
+        expect(resolveLeagueSeason({ league_season: '2026', season: '2025' })).toBe('2026');
+    });
+
+    it('falls back to season when league_season is absent', () => {
+        expect(resolveLeagueSeason({ season: '2025' })).toBe('2025');
+    });
+
+    it('falls back to the current year when neither is present', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date(2030, 5, 15));
+        expect(resolveLeagueSeason({})).toBe('2030');
+    });
+
+    it('falls back to the current year for null input', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date(2030, 5, 15));
+        expect(resolveLeagueSeason(null)).toBe('2030');
+    });
+
+    it('falls back to the current year for undefined input', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date(2030, 5, 15));
+        expect(resolveLeagueSeason(undefined)).toBe('2030');
+    });
+});
+
+describe('resolveMyDisplayName', () => {
+    const managerData = [
+        { user_id: '521035584588267520', display_name: 'testDisplayName' },
+        { user_id: '999', display_name: 'someoneElse' },
+    ];
+
+    it('returns the display_name when the user is found', () => {
+        expect(resolveMyDisplayName(managerData, '521035584588267520')).toBe('testDisplayName');
+    });
+
+    it('returns null when the user is not found', () => {
+        expect(resolveMyDisplayName(managerData, 'not-a-real-id')).toBeNull();
+    });
+
+    it('returns null for an empty array', () => {
+        expect(resolveMyDisplayName([], '521035584588267520')).toBeNull();
+    });
+
+    it('returns null and does not throw for null managerData', () => {
+        expect(resolveMyDisplayName(null, '521035584588267520')).toBeNull();
+    });
+
+    it('returns null and does not throw for undefined managerData', () => {
+        expect(resolveMyDisplayName(undefined, '521035584588267520')).toBeNull();
+    });
+});

--- a/src/urls.js
+++ b/src/urls.js
@@ -13,14 +13,15 @@ const sleeperAPI = 'https://api.sleeper.app/';
 const V1 = 'v1/';
 const LEAGUE = 'league/';
 const DRAFT = 'draft/';
-const USER = 'user/521035584588267520/';
+const SLEEPER_USER_ID = '521035584588267520';
+const USER = 'user/' + SLEEPER_USER_ID + '/';
 const ROSTERS = 'rosters/';
 const SLEEPER_USERS = 'users/';
 const LEAGUES = 'leagues/nfl/';
-const YEAR = '2026';
 const TRADED_PICKS = 'traded_picks/';
 const PICKS = 'picks/';
 const DRAFTS = 'drafts/';
+const STATE = 'state/nfl';
 
 const APP_DB_URLS = {
     APP_DB: appDB,
@@ -33,7 +34,8 @@ const APP_DB_URLS = {
 
 const SLEEPER_API_URLS = {
     LEAGUE: sleeperAPI + V1 + LEAGUE,
-    ALL_LEAGUES_ACTIVE_YEAR: sleeperAPI + V1 + USER + LEAGUES + YEAR,
+    USER_LEAGUES: (season) => sleeperAPI + V1 + USER + LEAGUES + season,
+    NFL_STATE: sleeperAPI + V1 + STATE,
     DRAFT: sleeperAPI + V1 + DRAFT,
     ROSTERS: ROSTERS,
     SLEEPER_USERS: SLEEPER_USERS,
@@ -43,4 +45,4 @@ const SLEEPER_API_URLS = {
 };
 
 export default APP_DB_URLS;
-export { SLEEPER_API_URLS };
+export { SLEEPER_API_URLS, SLEEPER_USER_ID };

--- a/src/urls.test.js
+++ b/src/urls.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import APP_DB_URLS, { SLEEPER_API_URLS, SLEEPER_USER_ID } from './urls.js';
+
+describe('SLEEPER_API_URLS.USER_LEAGUES', () => {
+    // Pinned to the exact string the previous hardcoded ALL_LEAGUES_ACTIVE_YEAR
+    // produced, so swapping the hand-edited YEAR constant for a season derived
+    // from the API provably did not change the endpoint being called.
+    it('builds the same URL the hardcoded 2026 constant used to produce', () => {
+        expect(SLEEPER_API_URLS.USER_LEAGUES('2026')).toBe(
+            'https://api.sleeper.app/v1/user/521035584588267520/leagues/nfl/2026',
+        );
+    });
+
+    it('varies only by season', () => {
+        expect(SLEEPER_API_URLS.USER_LEAGUES('2027')).toBe(
+            'https://api.sleeper.app/v1/user/521035584588267520/leagues/nfl/2027',
+        );
+    });
+
+    it('is built from SLEEPER_USER_ID rather than a second copy of the id', () => {
+        expect(SLEEPER_API_URLS.USER_LEAGUES('2026')).toContain(SLEEPER_USER_ID);
+    });
+});
+
+describe('other endpoints', () => {
+    it('points NFL_STATE at the season-state endpoint', () => {
+        expect(SLEEPER_API_URLS.NFL_STATE).toBe('https://api.sleeper.app/v1/state/nfl');
+    });
+
+    it('keeps the player DB path relative in dev so the Vite proxy handles CORS', () => {
+        // import.meta.env.DEV is true under Vitest, matching the dev-server case.
+        expect(APP_DB_URLS.ACTIVE_PLAYERS).toBe('/api/legacy/players');
+    });
+});


### PR DESCRIPTION
Two values needed hand-editing and could silently drift. Both are now resolved at runtime from data the app already reaches.

### Season
`urls.js` held a literal `YEAR = '2026'`, bumped by hand every year — the branch this work started from was itself named `update-year`. It now comes from Sleeper's `/v1/state/nfl`.

Uses that endpoint's **`league_season`**, not `season`: during the offseason `league_season` is the one whose leagues actually exist, which is what the "list this user's leagues" endpoint needs.

### Current user
`'ryangh'` was hardcoded in three places to mean "the current user". It was only ever the `display_name` of the Sleeper user id **already sitting in `urls.js`** — so it never needed writing down. The id is now a single exported `SLEEPER_USER_ID`, and the display name is resolved from the league's own user list. Renaming the Sleeper account no longer silently breaks the "my players" filter.

### Changes
- **`src/lib/sleeper.js`** — `resolveLeagueSeason` and `resolveMyDisplayName`, pure and tested, including fallback paths and null inputs.
- **`src/urls.js`** — `SLEEPER_USER_ID` exported; `ALL_LEAGUES_ACTIVE_YEAR` → `USER_LEAGUES(season)`; `NFL_STATE` added.
- **`src/urls.test.js`** — pins `USER_LEAGUES('2026')` to the exact string the old constant produced, so this provably calls the same endpoint rather than relying on inspection.
- **`App.jsx`** — resolves the season once and caches it in state, so `getLeagueData` works from either entry point. A failed state fetch logs an error and falls back to the calendar year rather than leaving the app blank.

Filter logic is unchanged — only the compared value moved. If the configured user isn't in the selected league, the name resolves to `null` and simply never matches, rather than erroring.

### Verification
Runtime, against live data:

| | |
|---|---|
| Season resolved | `2026` — identical to the constant it replaces |
| Display name resolved | `ryangh` — identical to the literal it replaces |
| Draft board | hashes identically to before (SHA-256) |
| "My players" filter | still identifies 30 players on the roster, of 351 rostered league-wide |
| Leagues in dropdown | 5, unchanged |

All five CI gates pass. **Tests 31 → 36.**

### Not in scope
Making the Sleeper user configurable (so anyone could point the app at their own leagues) is deliberately deferred — it needs UI, persistence, and an unset startup state. Noted separately.