### PR TITLE
Remove in-place state mutation from the live draft sync

### DIFF
--- a/src/Panels/DraftPanel.jsx
+++ b/src/Panels/DraftPanel.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import Button from '../Components/Button';
 import DraftRound from './DraftRound';
 import { SLEEPER_API_URLS } from '../urls';
+import { syncLiveDraft } from '../lib/liveDraft.js';
 const { DRAFT, PICKS, TRADED_PICKS } = SLEEPER_API_URLS;
 
 const DraftPanel = ({ leagueData, playerInfo, updateParentState: updatePlayerInfo, rankingPlayersIdsList }) => {
@@ -17,68 +18,40 @@ const DraftPanel = ({ leagueData, playerInfo, updateParentState: updatePlayerInf
         setDraftPath(DRAFT + val + '/');
     };
 
+    const handlePickChange = (updatedRound) => {
+        setLiveDraft((previousLiveDraft) => ({
+            ...previousLiveDraft,
+            built_draft: previousLiveDraft.built_draft.map((round) =>
+                round.round === updatedRound.round ? updatedRound : round,
+            ),
+        }));
+    };
+
     const getLiveDraft = async () => {
-        const newPlayerInfo = playerInfo;
-        const liveDraftData = await fetch(DRAFT_PATH + PICKS)
+        const livePicks = await fetch(DRAFT_PATH + PICKS)
             .then((response) => response.json())
             .then((data) => data)
             .catch((error) => {
                 console.error('Error:', error);
             });
-        let newLiveDraft = liveDraft;
-        await liveDraftData.forEach((livePick) => {
-            const { draft_slot: draftSlot } = livePick;
-            const round = livePick.round - 1;
-            const pickIndex = newLiveDraft.built_draft[round].picks.findIndex((pick) => pick.board_spot === draftSlot);
-            const pick = newLiveDraft.built_draft[round].picks[pickIndex];
-            pick.player_id = livePick.player_id;
-            pick.picked = true;
-            newPlayerInfo[livePick.player_id].is_taken = true;
-            newPlayerInfo[livePick.player_id].rostered_by = rosterData.find(
-                (roster) => pick.owner_id === roster.roster_id,
-            ).manager_display_name;
-            newLiveDraft.built_draft[round].picks[pickIndex] = pick;
-        });
-        updatePlayerInfo('playerInfo', { ...newPlayerInfo }, 'filterPlayers', '');
-        newLiveDraft = await getTradedDraftPicks(newLiveDraft);
-
-        if (leagueData.currentDraft.type === 'snake') {
-            await newLiveDraft.built_draft.forEach((round) => {
-                if (round.round % 2 === 0) {
-                    if (round.picks[0].board_spot === 1) {
-                        round.picks.reverse();
-                    }
-                    round.picks.sort((a, b) => a.pick_number - b.pick_number);
-                }
-            });
-        }
-
-        setLiveDraft({ ...newLiveDraft });
-    };
-
-    const getTradedDraftPicks = async (newLiveDraft) => {
-        const { built_draft: builtDraft } = newLiveDraft;
         const tradedPicks = await fetch(DRAFT_PATH + TRADED_PICKS)
             .then((response) => response.json())
             .then((data) => data)
             .catch((error) => {
                 console.error('Error:', error);
             });
-        console.log(tradedPicks);
 
-        tradedPicks.forEach((tradedPick) => {
-            let { round } = tradedPick;
-            round -= 1;
-            const { picks } = builtDraft[round];
-            const pickIndex = picks.findIndex((pick) => pick.roster_id === tradedPick.roster_id);
-            Object.assign(picks[pickIndex], {
-                owner_id: tradedPick.owner_id,
-                is_traded: true,
-            });
-            builtDraft[round].picks = picks;
+        const { liveDraft: newLiveDraft, playerInfo: newPlayerInfo } = syncLiveDraft({
+            liveDraft,
+            livePicks,
+            tradedPicks,
+            playerInfo,
+            rosterData,
+            draftType: leagueData.currentDraft.type,
         });
-        newLiveDraft.built_draft = builtDraft;
-        return newLiveDraft;
+
+        updatePlayerInfo('playerInfo', newPlayerInfo, 'filterPlayers', '');
+        setLiveDraft(newLiveDraft);
     };
 
     const getLiveDraftRef = useRef(getLiveDraft);
@@ -141,6 +114,7 @@ const DraftPanel = ({ leagueData, playerInfo, updateParentState: updatePlayerInf
                                 rankingPlayersIdsList={rankingPlayersIdsList}
                                 rosterData={rosterData}
                                 updatePlayerInfo={updatePlayerInfo}
+                                onPickChange={handlePickChange}
                             />
                         </div>
                     ))}

--- a/src/Panels/DraftRound.jsx
+++ b/src/Panels/DraftRound.jsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import Button from '../Components/Button';
+import { applyManualPick } from '../lib/liveDraft.js';
 
-const DraftRound = ({ round, playerInfo, rosterData, updatePlayerInfo, rankingPlayersIdsList }) => {
+const DraftRound = ({ round, playerInfo, rosterData, updatePlayerInfo, rankingPlayersIdsList, onPickChange }) => {
     const [showRound, setShowRound] = useState(true);
     const [showPickSelection, setShowPickSelection] = useState(false);
     const [currentManualPick, setCurrentManualPick] = useState();
@@ -13,20 +14,16 @@ const DraftRound = ({ round, playerInfo, rosterData, updatePlayerInfo, rankingPl
     };
 
     const updatePickSelection = async (playerID) => {
-        round.picks[round.picks.findIndex((pick) => pick.pick_number === currentManualPick.pick_number)].player_id =
-            playerID;
-        const newPlayerInfo = playerInfo;
-        if (playerID) {
-            newPlayerInfo[playerID].is_taken = true;
-            newPlayerInfo[playerID].rostered_by = rosterData.find(
-                (roster) => currentManualPick.owner_id === roster.roster_id,
-            ).manager_display_name;
-        } else {
-            newPlayerInfo[currentManualPick.player_id].is_taken = false;
-            newPlayerInfo[currentManualPick.player_id].rostered_by = null;
-        }
+        const { round: updatedRound, playerInfo: newPlayerInfo } = applyManualPick({
+            round,
+            playerInfo,
+            rosterData,
+            currentManualPick,
+            playerID,
+        });
+        onPickChange(updatedRound);
         setCurrentManualPick(null);
-        updatePlayerInfo('playerInfo', { ...newPlayerInfo });
+        updatePlayerInfo('playerInfo', newPlayerInfo);
         setShowPickSelection(!showPickSelection);
         setSearchValue('');
     };

--- a/src/lib/__fixtures__/golden-live-draft-sync.json
+++ b/src/lib/__fixtures__/golden-live-draft-sync.json
@@ -1,0 +1,10635 @@
+{
+    "linear": {
+        "liveDraft": {
+            "type": "linear",
+            "settings": {
+                "rounds": 4,
+                "player_type": 1
+            },
+            "slot_to_roster_id": {
+                "1": 5,
+                "2": 8,
+                "3": 1,
+                "4": 9,
+                "5": 2,
+                "6": 4,
+                "7": 11,
+                "8": 6,
+                "9": 3,
+                "10": 10,
+                "11": 12,
+                "12": 7
+            },
+            "built_draft": [
+                {
+                    "round": 1,
+                    "picks": [
+                        {
+                            "user_id": "989213899293569024",
+                            "roster_id": 5,
+                            "is_traded": false,
+                            "owner_id": 5,
+                            "pick_round": 1,
+                            "pick_number": 1,
+                            "board_spot": 1,
+                            "player_id": "13287",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "999040645685649408",
+                            "roster_id": 8,
+                            "is_traded": false,
+                            "owner_id": 8,
+                            "pick_round": 1,
+                            "pick_number": 2,
+                            "board_spot": 2,
+                            "player_id": "13269",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521035584588267520",
+                            "roster_id": 1,
+                            "is_traded": false,
+                            "owner_id": 1,
+                            "pick_round": 1,
+                            "pick_number": 3,
+                            "board_spot": 3,
+                            "player_id": "13279",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467766220007927808",
+                            "roster_id": 9,
+                            "is_traded": true,
+                            "owner_id": 6,
+                            "pick_round": 1,
+                            "pick_number": 4,
+                            "board_spot": 4,
+                            "player_id": "13281",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521424042611961856",
+                            "roster_id": 2,
+                            "is_traded": false,
+                            "owner_id": 2,
+                            "pick_round": 1,
+                            "pick_number": 5,
+                            "board_spot": 5,
+                            "player_id": "13294",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521485413219885056",
+                            "roster_id": 4,
+                            "is_traded": false,
+                            "owner_id": 4,
+                            "pick_round": 1,
+                            "pick_number": 6,
+                            "board_spot": 6,
+                            "player_id": "13286",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325371992242946048",
+                            "roster_id": 11,
+                            "is_traded": true,
+                            "owner_id": 4,
+                            "pick_round": 1,
+                            "pick_number": 7,
+                            "board_spot": 7,
+                            "player_id": "13298",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "665051007910236160",
+                            "roster_id": 6,
+                            "is_traded": true,
+                            "owner_id": 4,
+                            "pick_round": 1,
+                            "pick_number": 8,
+                            "board_spot": 8,
+                            "player_id": "13275",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467132282604351488",
+                            "roster_id": 3,
+                            "is_traded": false,
+                            "owner_id": 3,
+                            "pick_round": 1,
+                            "pick_number": 9,
+                            "board_spot": 9,
+                            "player_id": "13345",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325380343328686080",
+                            "roster_id": 10,
+                            "is_traded": true,
+                            "owner_id": 7,
+                            "pick_round": 1,
+                            "pick_number": 10,
+                            "board_spot": 10,
+                            "player_id": "13330",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "560984104439771136",
+                            "roster_id": 12,
+                            "is_traded": true,
+                            "owner_id": 5,
+                            "pick_round": 1,
+                            "pick_number": 11,
+                            "board_spot": 11,
+                            "player_id": "13276",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "464153930528452608",
+                            "roster_id": 7,
+                            "is_traded": true,
+                            "owner_id": 1,
+                            "pick_round": 1,
+                            "pick_number": 12,
+                            "board_spot": 12,
+                            "player_id": "13346",
+                            "picked": true
+                        }
+                    ]
+                },
+                {
+                    "round": 2,
+                    "picks": [
+                        {
+                            "user_id": "989213899293569024",
+                            "roster_id": 5,
+                            "is_traded": false,
+                            "owner_id": 5,
+                            "pick_round": 2,
+                            "pick_number": 1,
+                            "board_spot": 1,
+                            "player_id": "13349",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "999040645685649408",
+                            "roster_id": 8,
+                            "is_traded": false,
+                            "owner_id": 8,
+                            "pick_round": 2,
+                            "pick_number": 2,
+                            "board_spot": 2,
+                            "player_id": "13311",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521035584588267520",
+                            "roster_id": 1,
+                            "is_traded": false,
+                            "owner_id": 1,
+                            "pick_round": 2,
+                            "pick_number": 3,
+                            "board_spot": 3,
+                            "player_id": "13288",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467766220007927808",
+                            "roster_id": 9,
+                            "is_traded": false,
+                            "owner_id": 9,
+                            "pick_round": 2,
+                            "pick_number": 4,
+                            "board_spot": 4,
+                            "player_id": "13337",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521424042611961856",
+                            "roster_id": 2,
+                            "is_traded": true,
+                            "owner_id": 6,
+                            "pick_round": 2,
+                            "pick_number": 5,
+                            "board_spot": 5,
+                            "player_id": "13320",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521485413219885056",
+                            "roster_id": 4,
+                            "is_traded": true,
+                            "owner_id": 6,
+                            "pick_round": 2,
+                            "pick_number": 6,
+                            "board_spot": 6,
+                            "player_id": "13301",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325371992242946048",
+                            "roster_id": 11,
+                            "is_traded": true,
+                            "owner_id": 7,
+                            "pick_round": 2,
+                            "pick_number": 7,
+                            "board_spot": 7,
+                            "player_id": "13285",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "665051007910236160",
+                            "roster_id": 6,
+                            "is_traded": true,
+                            "owner_id": 9,
+                            "pick_round": 2,
+                            "pick_number": 8,
+                            "board_spot": 8,
+                            "player_id": "13268",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467132282604351488",
+                            "roster_id": 3,
+                            "is_traded": true,
+                            "owner_id": 9,
+                            "pick_round": 2,
+                            "pick_number": 9,
+                            "board_spot": 9,
+                            "player_id": "13353",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325380343328686080",
+                            "roster_id": 10,
+                            "is_traded": true,
+                            "owner_id": 2,
+                            "pick_round": 2,
+                            "pick_number": 10,
+                            "board_spot": 10,
+                            "player_id": "13272",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "560984104439771136",
+                            "roster_id": 12,
+                            "is_traded": true,
+                            "owner_id": 6,
+                            "pick_round": 2,
+                            "pick_number": 11,
+                            "board_spot": 11,
+                            "player_id": "13417",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "464153930528452608",
+                            "roster_id": 7,
+                            "is_traded": true,
+                            "owner_id": 1,
+                            "pick_round": 2,
+                            "pick_number": 12,
+                            "board_spot": 12,
+                            "player_id": "13274",
+                            "picked": true
+                        }
+                    ]
+                },
+                {
+                    "round": 3,
+                    "picks": [
+                        {
+                            "user_id": "989213899293569024",
+                            "roster_id": 5,
+                            "is_traded": true,
+                            "owner_id": 7,
+                            "pick_round": 3,
+                            "pick_number": 1,
+                            "board_spot": 1,
+                            "player_id": "13402",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "999040645685649408",
+                            "roster_id": 8,
+                            "is_traded": false,
+                            "owner_id": 8,
+                            "pick_round": 3,
+                            "pick_number": 2,
+                            "board_spot": 2,
+                            "player_id": "13305",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521035584588267520",
+                            "roster_id": 1,
+                            "is_traded": false,
+                            "owner_id": 1,
+                            "pick_round": 3,
+                            "pick_number": 3,
+                            "board_spot": 3,
+                            "player_id": "13405",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467766220007927808",
+                            "roster_id": 9,
+                            "is_traded": false,
+                            "owner_id": 9,
+                            "pick_round": 3,
+                            "pick_number": 4,
+                            "board_spot": 4,
+                            "player_id": "13293",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521424042611961856",
+                            "roster_id": 2,
+                            "is_traded": false,
+                            "owner_id": 2,
+                            "pick_round": 3,
+                            "pick_number": 5,
+                            "board_spot": 5,
+                            "player_id": "13317",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521485413219885056",
+                            "roster_id": 4,
+                            "is_traded": false,
+                            "owner_id": 4,
+                            "pick_round": 3,
+                            "pick_number": 6,
+                            "board_spot": 6,
+                            "player_id": "13302",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325371992242946048",
+                            "roster_id": 11,
+                            "is_traded": true,
+                            "owner_id": 5,
+                            "pick_round": 3,
+                            "pick_number": 7,
+                            "board_spot": 7,
+                            "player_id": "13347",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "665051007910236160",
+                            "roster_id": 6,
+                            "is_traded": false,
+                            "owner_id": 6,
+                            "pick_round": 3,
+                            "pick_number": 8,
+                            "board_spot": 8,
+                            "player_id": "13278",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467132282604351488",
+                            "roster_id": 3,
+                            "is_traded": false,
+                            "owner_id": 3,
+                            "pick_round": 3,
+                            "pick_number": 9,
+                            "board_spot": 9,
+                            "player_id": "13380",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325380343328686080",
+                            "roster_id": 10,
+                            "is_traded": false,
+                            "owner_id": 10,
+                            "pick_round": 3,
+                            "pick_number": 10,
+                            "board_spot": 10,
+                            "player_id": "13414",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "560984104439771136",
+                            "roster_id": 12,
+                            "is_traded": true,
+                            "owner_id": 5,
+                            "pick_round": 3,
+                            "pick_number": 11,
+                            "board_spot": 11,
+                            "player_id": "13289",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "464153930528452608",
+                            "roster_id": 7,
+                            "is_traded": true,
+                            "owner_id": 4,
+                            "pick_round": 3,
+                            "pick_number": 12,
+                            "board_spot": 12,
+                            "player_id": "13420",
+                            "picked": true
+                        }
+                    ]
+                },
+                {
+                    "round": 4,
+                    "picks": [
+                        {
+                            "user_id": "989213899293569024",
+                            "roster_id": 5,
+                            "is_traded": false,
+                            "owner_id": 5,
+                            "pick_round": 4,
+                            "pick_number": 1,
+                            "board_spot": 1,
+                            "player_id": "13296",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "999040645685649408",
+                            "roster_id": 8,
+                            "is_traded": false,
+                            "owner_id": 8,
+                            "pick_round": 4,
+                            "pick_number": 2,
+                            "board_spot": 2,
+                            "player_id": "13404",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521035584588267520",
+                            "roster_id": 1,
+                            "is_traded": false,
+                            "owner_id": 1,
+                            "pick_round": 4,
+                            "pick_number": 3,
+                            "board_spot": 3,
+                            "player_id": "13421",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467766220007927808",
+                            "roster_id": 9,
+                            "is_traded": true,
+                            "owner_id": 5,
+                            "pick_round": 4,
+                            "pick_number": 4,
+                            "board_spot": 4,
+                            "player_id": "13306",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521424042611961856",
+                            "roster_id": 2,
+                            "is_traded": false,
+                            "owner_id": 2,
+                            "pick_round": 4,
+                            "pick_number": 5,
+                            "board_spot": 5,
+                            "player_id": "13319",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521485413219885056",
+                            "roster_id": 4,
+                            "is_traded": true,
+                            "owner_id": 12,
+                            "pick_round": 4,
+                            "pick_number": 6,
+                            "board_spot": 6,
+                            "player_id": "13400",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325371992242946048",
+                            "roster_id": 11,
+                            "is_traded": false,
+                            "owner_id": 11,
+                            "pick_round": 4,
+                            "pick_number": 7,
+                            "board_spot": 7,
+                            "player_id": "13338",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "665051007910236160",
+                            "roster_id": 6,
+                            "is_traded": false,
+                            "owner_id": 6,
+                            "pick_round": 4,
+                            "pick_number": 8,
+                            "board_spot": 8,
+                            "player_id": "13333",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467132282604351488",
+                            "roster_id": 3,
+                            "is_traded": true,
+                            "owner_id": 9,
+                            "pick_round": 4,
+                            "pick_number": 9,
+                            "board_spot": 9,
+                            "player_id": "13303",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325380343328686080",
+                            "roster_id": 10,
+                            "is_traded": false,
+                            "owner_id": 10,
+                            "pick_round": 4,
+                            "pick_number": 10,
+                            "board_spot": 10,
+                            "player_id": "13423",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "560984104439771136",
+                            "roster_id": 12,
+                            "is_traded": false,
+                            "owner_id": 12,
+                            "pick_round": 4,
+                            "pick_number": 11,
+                            "board_spot": 11,
+                            "player_id": "13348",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "464153930528452608",
+                            "roster_id": 7,
+                            "is_traded": false,
+                            "owner_id": 7,
+                            "pick_round": 4,
+                            "pick_number": 12,
+                            "board_spot": 12,
+                            "player_id": "13403",
+                            "picked": true
+                        }
+                    ]
+                }
+            ],
+            "player_pool": "Rookie"
+        },
+        "playerInfo": {
+            "4984": {
+                "player_id": "4984",
+                "first_name": "Josh",
+                "last_name": "Allen",
+                "full_name": "Josh Allen",
+                "team": "BUF",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 1,
+                "years_exp": 8,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "6813": {
+                "player_id": "6813",
+                "first_name": "Jonathan",
+                "last_name": "Taylor",
+                "full_name": "Jonathan Taylor",
+                "team": "IND",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 4,
+                "years_exp": 6,
+                "is_taken": true,
+                "rostered_by": "crbiehl",
+                "in_lineup": false
+            },
+            "7564": {
+                "player_id": "7564",
+                "first_name": "Ja'Marr",
+                "last_name": "Chase",
+                "full_name": "Ja'Marr Chase",
+                "team": "CIN",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 3,
+                "years_exp": 5,
+                "is_taken": true,
+                "rostered_by": "OptimalPooper",
+                "in_lineup": false
+            },
+            "9221": {
+                "player_id": "9221",
+                "first_name": "Jahmyr",
+                "last_name": "Gibbs",
+                "full_name": "Jahmyr Gibbs",
+                "team": "DET",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 2,
+                "years_exp": 3,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "9509": {
+                "player_id": "9509",
+                "first_name": "Bijan",
+                "last_name": "Robinson",
+                "full_name": "Bijan Robinson",
+                "team": "ATL",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 1,
+                "years_exp": 3,
+                "is_taken": true,
+                "rostered_by": "kpresley",
+                "in_lineup": false
+            },
+            "11564": {
+                "player_id": "11564",
+                "first_name": "Drake",
+                "last_name": "Maye",
+                "full_name": "Drake Maye",
+                "team": "NE",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 3,
+                "years_exp": 2,
+                "is_taken": true,
+                "rostered_by": "OptimalPooper",
+                "in_lineup": false
+            },
+            "13268": {
+                "player_id": "13268",
+                "first_name": "Elijah",
+                "last_name": "Sarratt",
+                "full_name": "Elijah Sarratt",
+                "team": "BAL",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 201,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "gdavidson",
+                "in_lineup": false
+            },
+            "13269": {
+                "player_id": "13269",
+                "first_name": "Fernando",
+                "last_name": "Mendoza",
+                "full_name": "Fernando Mendoza",
+                "team": "LV",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 39,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "cmurtagh86",
+                "in_lineup": false
+            },
+            "13272": {
+                "player_id": "13272",
+                "first_name": "Carson",
+                "last_name": "Beck",
+                "full_name": "Carson Beck",
+                "team": "ARI",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 416,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "aphilliny21",
+                "in_lineup": false
+            },
+            "13274": {
+                "player_id": "13274",
+                "first_name": "Germie",
+                "last_name": "Bernard",
+                "full_name": "Germie Bernard",
+                "team": "PIT",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 194,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13275": {
+                "player_id": "13275",
+                "first_name": "Ty",
+                "last_name": "Simpson",
+                "full_name": "Ty Simpson",
+                "team": "LAR",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 141,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13276": {
+                "player_id": "13276",
+                "first_name": "Omar",
+                "last_name": "Cooper",
+                "full_name": "Omar Cooper",
+                "team": "NYJ",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 146,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13278": {
+                "player_id": "13278",
+                "first_name": "Max",
+                "last_name": "Klare",
+                "full_name": "Max Klare",
+                "team": "LAR",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 212,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13279": {
+                "player_id": "13279",
+                "first_name": "Carnell",
+                "last_name": "Tate",
+                "full_name": "Carnell Tate",
+                "team": "TEN",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 61,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13281": {
+                "player_id": "13281",
+                "first_name": "Jordyn",
+                "last_name": "Tyson",
+                "full_name": "Jordyn Tyson",
+                "team": "NO",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 69,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13285": {
+                "player_id": "13285",
+                "first_name": "Malachi",
+                "last_name": "Fields",
+                "full_name": "Malachi Fields",
+                "team": "NYG",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 210,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "crbiehl",
+                "in_lineup": false
+            },
+            "13286": {
+                "player_id": "13286",
+                "first_name": "Jadarian",
+                "last_name": "Price",
+                "full_name": "Jadarian Price",
+                "team": "SEA",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 63,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13287": {
+                "player_id": "13287",
+                "first_name": "Jeremiyah",
+                "last_name": "Love",
+                "full_name": "Jeremiyah Love",
+                "team": "ARI",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 15,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13288": {
+                "player_id": "13288",
+                "first_name": "Nicholas",
+                "last_name": "Singleton",
+                "full_name": "Nicholas Singleton",
+                "team": "TEN",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 167,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13289": {
+                "player_id": "13289",
+                "first_name": "Drew",
+                "last_name": "Allar",
+                "full_name": "Drew Allar",
+                "team": "PIT",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13293": {
+                "player_id": "13293",
+                "first_name": "Ja'Kobi",
+                "last_name": "Lane",
+                "full_name": "Ja'Kobi Lane",
+                "team": "BAL",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 182,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "gdavidson",
+                "in_lineup": false
+            },
+            "13294": {
+                "player_id": "13294",
+                "first_name": "Makai",
+                "last_name": "Lemon",
+                "full_name": "Makai Lemon",
+                "team": "PHI",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 77,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "aphilliny21",
+                "in_lineup": false
+            },
+            "13296": {
+                "player_id": "13296",
+                "first_name": "Caleb",
+                "last_name": "Douglas",
+                "full_name": "Caleb Douglas",
+                "team": "MIA",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13298": {
+                "player_id": "13298",
+                "first_name": "KC",
+                "last_name": "Concepcion",
+                "full_name": "KC Concepcion",
+                "team": "CLE",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 116,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13301": {
+                "player_id": "13301",
+                "first_name": "Antonio",
+                "last_name": "Williams",
+                "full_name": "Antonio Williams",
+                "team": "WAS",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 156,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13302": {
+                "player_id": "13302",
+                "first_name": "Adam",
+                "last_name": "Randall",
+                "full_name": "Adam Randall",
+                "team": "BAL",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13303": {
+                "player_id": "13303",
+                "first_name": "Cade",
+                "last_name": "Klubnik",
+                "full_name": "Cade Klubnik",
+                "team": "NYJ",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 398,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "gdavidson",
+                "in_lineup": false
+            },
+            "13305": {
+                "player_id": "13305",
+                "first_name": "Mike",
+                "last_name": "Washington",
+                "full_name": "Mike Washington",
+                "team": "LV",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 139,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "cmurtagh86",
+                "in_lineup": false
+            },
+            "13306": {
+                "player_id": "13306",
+                "first_name": "Taylen",
+                "last_name": "Green",
+                "full_name": "Taylen Green",
+                "team": "CLE",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13311": {
+                "player_id": "13311",
+                "first_name": "Chris",
+                "last_name": "Bell",
+                "full_name": "Chris Bell",
+                "team": "MIA",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 203,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "cmurtagh86",
+                "in_lineup": false
+            },
+            "13317": {
+                "player_id": "13317",
+                "first_name": "Ted",
+                "last_name": "Hurst",
+                "full_name": "Ted Hurst",
+                "team": "TB",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 196,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "aphilliny21",
+                "in_lineup": false
+            },
+            "13319": {
+                "player_id": "13319",
+                "first_name": "Oscar",
+                "last_name": "Delp",
+                "full_name": "Oscar Delp",
+                "team": "NO",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "aphilliny21",
+                "in_lineup": false
+            },
+            "13320": {
+                "player_id": "13320",
+                "first_name": "Zachariah",
+                "last_name": "Branch",
+                "full_name": "Zachariah Branch",
+                "team": "ATL",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 180,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13330": {
+                "player_id": "13330",
+                "first_name": "Kenyon",
+                "last_name": "Sadiq",
+                "full_name": "Kenyon Sadiq",
+                "team": "NYJ",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 109,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "crbiehl",
+                "in_lineup": false
+            },
+            "13333": {
+                "player_id": "13333",
+                "first_name": "Deion",
+                "last_name": "Burks",
+                "full_name": "Deion Burks",
+                "team": "IND",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13337": {
+                "player_id": "13337",
+                "first_name": "Emmett",
+                "last_name": "Johnson",
+                "full_name": "Emmett Johnson",
+                "team": "KC",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 113,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "gdavidson",
+                "in_lineup": false
+            },
+            "13338": {
+                "player_id": "13338",
+                "first_name": "Kevin",
+                "last_name": "Coleman",
+                "full_name": "Kevin Coleman",
+                "team": "MIA",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "kpresley",
+                "in_lineup": false
+            },
+            "13345": {
+                "player_id": "13345",
+                "first_name": "Jonah",
+                "last_name": "Coleman",
+                "full_name": "Jonah Coleman",
+                "team": "DEN",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 118,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "OptimalPooper",
+                "in_lineup": false
+            },
+            "13346": {
+                "player_id": "13346",
+                "first_name": "Denzel",
+                "last_name": "Boston",
+                "full_name": "Denzel Boston",
+                "team": "CLE",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 144,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13347": {
+                "player_id": "13347",
+                "first_name": "Demond",
+                "last_name": "Claiborne",
+                "full_name": "Demond Claiborne",
+                "team": "MIN",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 176,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13348": {
+                "player_id": "13348",
+                "first_name": "J'Mari",
+                "last_name": "Taylor",
+                "full_name": "J'Mari Taylor",
+                "team": "JAX",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "MaddensWok",
+                "in_lineup": false
+            },
+            "13349": {
+                "player_id": "13349",
+                "first_name": "Eli",
+                "last_name": "Stowers",
+                "full_name": "Eli Stowers",
+                "team": "PHI",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 140,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13353": {
+                "player_id": "13353",
+                "first_name": "Chris",
+                "last_name": "Brazzell",
+                "full_name": "Chris Brazzell",
+                "team": "CAR",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 202,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "gdavidson",
+                "in_lineup": false
+            },
+            "13380": {
+                "player_id": "13380",
+                "first_name": "Brenen",
+                "last_name": "Thompson",
+                "full_name": "Brenen Thompson",
+                "team": "LAC",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "OptimalPooper",
+                "in_lineup": false
+            },
+            "13400": {
+                "player_id": "13400",
+                "first_name": "Justin",
+                "last_name": "Joly",
+                "full_name": "Justin Joly",
+                "team": "DEN",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "MaddensWok",
+                "in_lineup": false
+            },
+            "13402": {
+                "player_id": "13402",
+                "first_name": "Skyler",
+                "last_name": "Bell",
+                "full_name": "Skyler Bell",
+                "team": "BUF",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "crbiehl",
+                "in_lineup": false
+            },
+            "13403": {
+                "player_id": "13403",
+                "first_name": "Jam",
+                "last_name": "Miller",
+                "full_name": "Jam Miller",
+                "team": "NE",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "crbiehl",
+                "in_lineup": false
+            },
+            "13404": {
+                "player_id": "13404",
+                "first_name": "Garrett",
+                "last_name": "Nussmeier",
+                "full_name": "Garrett Nussmeier",
+                "team": "KC",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 329,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "cmurtagh86",
+                "in_lineup": false
+            },
+            "13405": {
+                "player_id": "13405",
+                "first_name": "Kaytron",
+                "last_name": "Allen",
+                "full_name": "Kaytron Allen",
+                "team": "WAS",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 157,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13414": {
+                "player_id": "13414",
+                "first_name": "Kaelon",
+                "last_name": "Black",
+                "full_name": "Kaelon Black",
+                "team": "SF",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "spight",
+                "in_lineup": false
+            },
+            "13417": {
+                "player_id": "13417",
+                "first_name": "De'Zhaun",
+                "last_name": "Stribling",
+                "full_name": "De'Zhaun Stribling",
+                "team": "SF",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 202,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13420": {
+                "player_id": "13420",
+                "first_name": "Bryce",
+                "last_name": "Lance",
+                "full_name": "Bryce Lance",
+                "team": "NO",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13421": {
+                "player_id": "13421",
+                "first_name": "Eli",
+                "last_name": "Raridon",
+                "full_name": "Eli Raridon",
+                "team": "NE",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13423": {
+                "player_id": "13423",
+                "first_name": "Eli",
+                "last_name": "Heidenreich",
+                "full_name": "Eli Heidenreich",
+                "team": "PIT",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "spight",
+                "in_lineup": false
+            }
+        }
+    },
+    "linearTwice": {
+        "liveDraft": {
+            "type": "linear",
+            "settings": {
+                "rounds": 4,
+                "player_type": 1
+            },
+            "slot_to_roster_id": {
+                "1": 5,
+                "2": 8,
+                "3": 1,
+                "4": 9,
+                "5": 2,
+                "6": 4,
+                "7": 11,
+                "8": 6,
+                "9": 3,
+                "10": 10,
+                "11": 12,
+                "12": 7
+            },
+            "built_draft": [
+                {
+                    "round": 1,
+                    "picks": [
+                        {
+                            "user_id": "989213899293569024",
+                            "roster_id": 5,
+                            "is_traded": false,
+                            "owner_id": 5,
+                            "pick_round": 1,
+                            "pick_number": 1,
+                            "board_spot": 1,
+                            "player_id": "13287",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "999040645685649408",
+                            "roster_id": 8,
+                            "is_traded": false,
+                            "owner_id": 8,
+                            "pick_round": 1,
+                            "pick_number": 2,
+                            "board_spot": 2,
+                            "player_id": "13269",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521035584588267520",
+                            "roster_id": 1,
+                            "is_traded": false,
+                            "owner_id": 1,
+                            "pick_round": 1,
+                            "pick_number": 3,
+                            "board_spot": 3,
+                            "player_id": "13279",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467766220007927808",
+                            "roster_id": 9,
+                            "is_traded": true,
+                            "owner_id": 6,
+                            "pick_round": 1,
+                            "pick_number": 4,
+                            "board_spot": 4,
+                            "player_id": "13281",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521424042611961856",
+                            "roster_id": 2,
+                            "is_traded": false,
+                            "owner_id": 2,
+                            "pick_round": 1,
+                            "pick_number": 5,
+                            "board_spot": 5,
+                            "player_id": "13294",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521485413219885056",
+                            "roster_id": 4,
+                            "is_traded": false,
+                            "owner_id": 4,
+                            "pick_round": 1,
+                            "pick_number": 6,
+                            "board_spot": 6,
+                            "player_id": "13286",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325371992242946048",
+                            "roster_id": 11,
+                            "is_traded": true,
+                            "owner_id": 4,
+                            "pick_round": 1,
+                            "pick_number": 7,
+                            "board_spot": 7,
+                            "player_id": "13298",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "665051007910236160",
+                            "roster_id": 6,
+                            "is_traded": true,
+                            "owner_id": 4,
+                            "pick_round": 1,
+                            "pick_number": 8,
+                            "board_spot": 8,
+                            "player_id": "13275",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467132282604351488",
+                            "roster_id": 3,
+                            "is_traded": false,
+                            "owner_id": 3,
+                            "pick_round": 1,
+                            "pick_number": 9,
+                            "board_spot": 9,
+                            "player_id": "13345",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325380343328686080",
+                            "roster_id": 10,
+                            "is_traded": true,
+                            "owner_id": 7,
+                            "pick_round": 1,
+                            "pick_number": 10,
+                            "board_spot": 10,
+                            "player_id": "13330",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "560984104439771136",
+                            "roster_id": 12,
+                            "is_traded": true,
+                            "owner_id": 5,
+                            "pick_round": 1,
+                            "pick_number": 11,
+                            "board_spot": 11,
+                            "player_id": "13276",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "464153930528452608",
+                            "roster_id": 7,
+                            "is_traded": true,
+                            "owner_id": 1,
+                            "pick_round": 1,
+                            "pick_number": 12,
+                            "board_spot": 12,
+                            "player_id": "13346",
+                            "picked": true
+                        }
+                    ]
+                },
+                {
+                    "round": 2,
+                    "picks": [
+                        {
+                            "user_id": "989213899293569024",
+                            "roster_id": 5,
+                            "is_traded": false,
+                            "owner_id": 5,
+                            "pick_round": 2,
+                            "pick_number": 1,
+                            "board_spot": 1,
+                            "player_id": "13349",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "999040645685649408",
+                            "roster_id": 8,
+                            "is_traded": false,
+                            "owner_id": 8,
+                            "pick_round": 2,
+                            "pick_number": 2,
+                            "board_spot": 2,
+                            "player_id": "13311",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521035584588267520",
+                            "roster_id": 1,
+                            "is_traded": false,
+                            "owner_id": 1,
+                            "pick_round": 2,
+                            "pick_number": 3,
+                            "board_spot": 3,
+                            "player_id": "13288",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467766220007927808",
+                            "roster_id": 9,
+                            "is_traded": false,
+                            "owner_id": 9,
+                            "pick_round": 2,
+                            "pick_number": 4,
+                            "board_spot": 4,
+                            "player_id": "13337",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521424042611961856",
+                            "roster_id": 2,
+                            "is_traded": true,
+                            "owner_id": 6,
+                            "pick_round": 2,
+                            "pick_number": 5,
+                            "board_spot": 5,
+                            "player_id": "13320",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521485413219885056",
+                            "roster_id": 4,
+                            "is_traded": true,
+                            "owner_id": 6,
+                            "pick_round": 2,
+                            "pick_number": 6,
+                            "board_spot": 6,
+                            "player_id": "13301",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325371992242946048",
+                            "roster_id": 11,
+                            "is_traded": true,
+                            "owner_id": 7,
+                            "pick_round": 2,
+                            "pick_number": 7,
+                            "board_spot": 7,
+                            "player_id": "13285",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "665051007910236160",
+                            "roster_id": 6,
+                            "is_traded": true,
+                            "owner_id": 9,
+                            "pick_round": 2,
+                            "pick_number": 8,
+                            "board_spot": 8,
+                            "player_id": "13268",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467132282604351488",
+                            "roster_id": 3,
+                            "is_traded": true,
+                            "owner_id": 9,
+                            "pick_round": 2,
+                            "pick_number": 9,
+                            "board_spot": 9,
+                            "player_id": "13353",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325380343328686080",
+                            "roster_id": 10,
+                            "is_traded": true,
+                            "owner_id": 2,
+                            "pick_round": 2,
+                            "pick_number": 10,
+                            "board_spot": 10,
+                            "player_id": "13272",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "560984104439771136",
+                            "roster_id": 12,
+                            "is_traded": true,
+                            "owner_id": 6,
+                            "pick_round": 2,
+                            "pick_number": 11,
+                            "board_spot": 11,
+                            "player_id": "13417",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "464153930528452608",
+                            "roster_id": 7,
+                            "is_traded": true,
+                            "owner_id": 1,
+                            "pick_round": 2,
+                            "pick_number": 12,
+                            "board_spot": 12,
+                            "player_id": "13274",
+                            "picked": true
+                        }
+                    ]
+                },
+                {
+                    "round": 3,
+                    "picks": [
+                        {
+                            "user_id": "989213899293569024",
+                            "roster_id": 5,
+                            "is_traded": true,
+                            "owner_id": 7,
+                            "pick_round": 3,
+                            "pick_number": 1,
+                            "board_spot": 1,
+                            "player_id": "13402",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "999040645685649408",
+                            "roster_id": 8,
+                            "is_traded": false,
+                            "owner_id": 8,
+                            "pick_round": 3,
+                            "pick_number": 2,
+                            "board_spot": 2,
+                            "player_id": "13305",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521035584588267520",
+                            "roster_id": 1,
+                            "is_traded": false,
+                            "owner_id": 1,
+                            "pick_round": 3,
+                            "pick_number": 3,
+                            "board_spot": 3,
+                            "player_id": "13405",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467766220007927808",
+                            "roster_id": 9,
+                            "is_traded": false,
+                            "owner_id": 9,
+                            "pick_round": 3,
+                            "pick_number": 4,
+                            "board_spot": 4,
+                            "player_id": "13293",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521424042611961856",
+                            "roster_id": 2,
+                            "is_traded": false,
+                            "owner_id": 2,
+                            "pick_round": 3,
+                            "pick_number": 5,
+                            "board_spot": 5,
+                            "player_id": "13317",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521485413219885056",
+                            "roster_id": 4,
+                            "is_traded": false,
+                            "owner_id": 4,
+                            "pick_round": 3,
+                            "pick_number": 6,
+                            "board_spot": 6,
+                            "player_id": "13302",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325371992242946048",
+                            "roster_id": 11,
+                            "is_traded": true,
+                            "owner_id": 5,
+                            "pick_round": 3,
+                            "pick_number": 7,
+                            "board_spot": 7,
+                            "player_id": "13347",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "665051007910236160",
+                            "roster_id": 6,
+                            "is_traded": false,
+                            "owner_id": 6,
+                            "pick_round": 3,
+                            "pick_number": 8,
+                            "board_spot": 8,
+                            "player_id": "13278",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467132282604351488",
+                            "roster_id": 3,
+                            "is_traded": false,
+                            "owner_id": 3,
+                            "pick_round": 3,
+                            "pick_number": 9,
+                            "board_spot": 9,
+                            "player_id": "13380",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325380343328686080",
+                            "roster_id": 10,
+                            "is_traded": false,
+                            "owner_id": 10,
+                            "pick_round": 3,
+                            "pick_number": 10,
+                            "board_spot": 10,
+                            "player_id": "13414",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "560984104439771136",
+                            "roster_id": 12,
+                            "is_traded": true,
+                            "owner_id": 5,
+                            "pick_round": 3,
+                            "pick_number": 11,
+                            "board_spot": 11,
+                            "player_id": "13289",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "464153930528452608",
+                            "roster_id": 7,
+                            "is_traded": true,
+                            "owner_id": 4,
+                            "pick_round": 3,
+                            "pick_number": 12,
+                            "board_spot": 12,
+                            "player_id": "13420",
+                            "picked": true
+                        }
+                    ]
+                },
+                {
+                    "round": 4,
+                    "picks": [
+                        {
+                            "user_id": "989213899293569024",
+                            "roster_id": 5,
+                            "is_traded": false,
+                            "owner_id": 5,
+                            "pick_round": 4,
+                            "pick_number": 1,
+                            "board_spot": 1,
+                            "player_id": "13296",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "999040645685649408",
+                            "roster_id": 8,
+                            "is_traded": false,
+                            "owner_id": 8,
+                            "pick_round": 4,
+                            "pick_number": 2,
+                            "board_spot": 2,
+                            "player_id": "13404",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521035584588267520",
+                            "roster_id": 1,
+                            "is_traded": false,
+                            "owner_id": 1,
+                            "pick_round": 4,
+                            "pick_number": 3,
+                            "board_spot": 3,
+                            "player_id": "13421",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467766220007927808",
+                            "roster_id": 9,
+                            "is_traded": true,
+                            "owner_id": 5,
+                            "pick_round": 4,
+                            "pick_number": 4,
+                            "board_spot": 4,
+                            "player_id": "13306",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521424042611961856",
+                            "roster_id": 2,
+                            "is_traded": false,
+                            "owner_id": 2,
+                            "pick_round": 4,
+                            "pick_number": 5,
+                            "board_spot": 5,
+                            "player_id": "13319",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521485413219885056",
+                            "roster_id": 4,
+                            "is_traded": true,
+                            "owner_id": 12,
+                            "pick_round": 4,
+                            "pick_number": 6,
+                            "board_spot": 6,
+                            "player_id": "13400",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325371992242946048",
+                            "roster_id": 11,
+                            "is_traded": false,
+                            "owner_id": 11,
+                            "pick_round": 4,
+                            "pick_number": 7,
+                            "board_spot": 7,
+                            "player_id": "13338",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "665051007910236160",
+                            "roster_id": 6,
+                            "is_traded": false,
+                            "owner_id": 6,
+                            "pick_round": 4,
+                            "pick_number": 8,
+                            "board_spot": 8,
+                            "player_id": "13333",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467132282604351488",
+                            "roster_id": 3,
+                            "is_traded": true,
+                            "owner_id": 9,
+                            "pick_round": 4,
+                            "pick_number": 9,
+                            "board_spot": 9,
+                            "player_id": "13303",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325380343328686080",
+                            "roster_id": 10,
+                            "is_traded": false,
+                            "owner_id": 10,
+                            "pick_round": 4,
+                            "pick_number": 10,
+                            "board_spot": 10,
+                            "player_id": "13423",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "560984104439771136",
+                            "roster_id": 12,
+                            "is_traded": false,
+                            "owner_id": 12,
+                            "pick_round": 4,
+                            "pick_number": 11,
+                            "board_spot": 11,
+                            "player_id": "13348",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "464153930528452608",
+                            "roster_id": 7,
+                            "is_traded": false,
+                            "owner_id": 7,
+                            "pick_round": 4,
+                            "pick_number": 12,
+                            "board_spot": 12,
+                            "player_id": "13403",
+                            "picked": true
+                        }
+                    ]
+                }
+            ],
+            "player_pool": "Rookie"
+        },
+        "playerInfo": {
+            "4984": {
+                "player_id": "4984",
+                "first_name": "Josh",
+                "last_name": "Allen",
+                "full_name": "Josh Allen",
+                "team": "BUF",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 1,
+                "years_exp": 8,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "6813": {
+                "player_id": "6813",
+                "first_name": "Jonathan",
+                "last_name": "Taylor",
+                "full_name": "Jonathan Taylor",
+                "team": "IND",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 4,
+                "years_exp": 6,
+                "is_taken": true,
+                "rostered_by": "crbiehl",
+                "in_lineup": false
+            },
+            "7564": {
+                "player_id": "7564",
+                "first_name": "Ja'Marr",
+                "last_name": "Chase",
+                "full_name": "Ja'Marr Chase",
+                "team": "CIN",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 3,
+                "years_exp": 5,
+                "is_taken": true,
+                "rostered_by": "OptimalPooper",
+                "in_lineup": false
+            },
+            "9221": {
+                "player_id": "9221",
+                "first_name": "Jahmyr",
+                "last_name": "Gibbs",
+                "full_name": "Jahmyr Gibbs",
+                "team": "DET",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 2,
+                "years_exp": 3,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "9509": {
+                "player_id": "9509",
+                "first_name": "Bijan",
+                "last_name": "Robinson",
+                "full_name": "Bijan Robinson",
+                "team": "ATL",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 1,
+                "years_exp": 3,
+                "is_taken": true,
+                "rostered_by": "kpresley",
+                "in_lineup": false
+            },
+            "11564": {
+                "player_id": "11564",
+                "first_name": "Drake",
+                "last_name": "Maye",
+                "full_name": "Drake Maye",
+                "team": "NE",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 3,
+                "years_exp": 2,
+                "is_taken": true,
+                "rostered_by": "OptimalPooper",
+                "in_lineup": false
+            },
+            "13268": {
+                "player_id": "13268",
+                "first_name": "Elijah",
+                "last_name": "Sarratt",
+                "full_name": "Elijah Sarratt",
+                "team": "BAL",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 201,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "gdavidson",
+                "in_lineup": false
+            },
+            "13269": {
+                "player_id": "13269",
+                "first_name": "Fernando",
+                "last_name": "Mendoza",
+                "full_name": "Fernando Mendoza",
+                "team": "LV",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 39,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "cmurtagh86",
+                "in_lineup": false
+            },
+            "13272": {
+                "player_id": "13272",
+                "first_name": "Carson",
+                "last_name": "Beck",
+                "full_name": "Carson Beck",
+                "team": "ARI",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 416,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "aphilliny21",
+                "in_lineup": false
+            },
+            "13274": {
+                "player_id": "13274",
+                "first_name": "Germie",
+                "last_name": "Bernard",
+                "full_name": "Germie Bernard",
+                "team": "PIT",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 194,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13275": {
+                "player_id": "13275",
+                "first_name": "Ty",
+                "last_name": "Simpson",
+                "full_name": "Ty Simpson",
+                "team": "LAR",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 141,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13276": {
+                "player_id": "13276",
+                "first_name": "Omar",
+                "last_name": "Cooper",
+                "full_name": "Omar Cooper",
+                "team": "NYJ",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 146,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13278": {
+                "player_id": "13278",
+                "first_name": "Max",
+                "last_name": "Klare",
+                "full_name": "Max Klare",
+                "team": "LAR",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 212,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13279": {
+                "player_id": "13279",
+                "first_name": "Carnell",
+                "last_name": "Tate",
+                "full_name": "Carnell Tate",
+                "team": "TEN",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 61,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13281": {
+                "player_id": "13281",
+                "first_name": "Jordyn",
+                "last_name": "Tyson",
+                "full_name": "Jordyn Tyson",
+                "team": "NO",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 69,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13285": {
+                "player_id": "13285",
+                "first_name": "Malachi",
+                "last_name": "Fields",
+                "full_name": "Malachi Fields",
+                "team": "NYG",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 210,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "crbiehl",
+                "in_lineup": false
+            },
+            "13286": {
+                "player_id": "13286",
+                "first_name": "Jadarian",
+                "last_name": "Price",
+                "full_name": "Jadarian Price",
+                "team": "SEA",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 63,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13287": {
+                "player_id": "13287",
+                "first_name": "Jeremiyah",
+                "last_name": "Love",
+                "full_name": "Jeremiyah Love",
+                "team": "ARI",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 15,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13288": {
+                "player_id": "13288",
+                "first_name": "Nicholas",
+                "last_name": "Singleton",
+                "full_name": "Nicholas Singleton",
+                "team": "TEN",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 167,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13289": {
+                "player_id": "13289",
+                "first_name": "Drew",
+                "last_name": "Allar",
+                "full_name": "Drew Allar",
+                "team": "PIT",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13293": {
+                "player_id": "13293",
+                "first_name": "Ja'Kobi",
+                "last_name": "Lane",
+                "full_name": "Ja'Kobi Lane",
+                "team": "BAL",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 182,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "gdavidson",
+                "in_lineup": false
+            },
+            "13294": {
+                "player_id": "13294",
+                "first_name": "Makai",
+                "last_name": "Lemon",
+                "full_name": "Makai Lemon",
+                "team": "PHI",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 77,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "aphilliny21",
+                "in_lineup": false
+            },
+            "13296": {
+                "player_id": "13296",
+                "first_name": "Caleb",
+                "last_name": "Douglas",
+                "full_name": "Caleb Douglas",
+                "team": "MIA",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13298": {
+                "player_id": "13298",
+                "first_name": "KC",
+                "last_name": "Concepcion",
+                "full_name": "KC Concepcion",
+                "team": "CLE",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 116,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13301": {
+                "player_id": "13301",
+                "first_name": "Antonio",
+                "last_name": "Williams",
+                "full_name": "Antonio Williams",
+                "team": "WAS",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 156,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13302": {
+                "player_id": "13302",
+                "first_name": "Adam",
+                "last_name": "Randall",
+                "full_name": "Adam Randall",
+                "team": "BAL",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13303": {
+                "player_id": "13303",
+                "first_name": "Cade",
+                "last_name": "Klubnik",
+                "full_name": "Cade Klubnik",
+                "team": "NYJ",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 398,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "gdavidson",
+                "in_lineup": false
+            },
+            "13305": {
+                "player_id": "13305",
+                "first_name": "Mike",
+                "last_name": "Washington",
+                "full_name": "Mike Washington",
+                "team": "LV",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 139,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "cmurtagh86",
+                "in_lineup": false
+            },
+            "13306": {
+                "player_id": "13306",
+                "first_name": "Taylen",
+                "last_name": "Green",
+                "full_name": "Taylen Green",
+                "team": "CLE",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13311": {
+                "player_id": "13311",
+                "first_name": "Chris",
+                "last_name": "Bell",
+                "full_name": "Chris Bell",
+                "team": "MIA",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 203,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "cmurtagh86",
+                "in_lineup": false
+            },
+            "13317": {
+                "player_id": "13317",
+                "first_name": "Ted",
+                "last_name": "Hurst",
+                "full_name": "Ted Hurst",
+                "team": "TB",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 196,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "aphilliny21",
+                "in_lineup": false
+            },
+            "13319": {
+                "player_id": "13319",
+                "first_name": "Oscar",
+                "last_name": "Delp",
+                "full_name": "Oscar Delp",
+                "team": "NO",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "aphilliny21",
+                "in_lineup": false
+            },
+            "13320": {
+                "player_id": "13320",
+                "first_name": "Zachariah",
+                "last_name": "Branch",
+                "full_name": "Zachariah Branch",
+                "team": "ATL",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 180,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13330": {
+                "player_id": "13330",
+                "first_name": "Kenyon",
+                "last_name": "Sadiq",
+                "full_name": "Kenyon Sadiq",
+                "team": "NYJ",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 109,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "crbiehl",
+                "in_lineup": false
+            },
+            "13333": {
+                "player_id": "13333",
+                "first_name": "Deion",
+                "last_name": "Burks",
+                "full_name": "Deion Burks",
+                "team": "IND",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13337": {
+                "player_id": "13337",
+                "first_name": "Emmett",
+                "last_name": "Johnson",
+                "full_name": "Emmett Johnson",
+                "team": "KC",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 113,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "gdavidson",
+                "in_lineup": false
+            },
+            "13338": {
+                "player_id": "13338",
+                "first_name": "Kevin",
+                "last_name": "Coleman",
+                "full_name": "Kevin Coleman",
+                "team": "MIA",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "kpresley",
+                "in_lineup": false
+            },
+            "13345": {
+                "player_id": "13345",
+                "first_name": "Jonah",
+                "last_name": "Coleman",
+                "full_name": "Jonah Coleman",
+                "team": "DEN",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 118,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "OptimalPooper",
+                "in_lineup": false
+            },
+            "13346": {
+                "player_id": "13346",
+                "first_name": "Denzel",
+                "last_name": "Boston",
+                "full_name": "Denzel Boston",
+                "team": "CLE",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 144,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13347": {
+                "player_id": "13347",
+                "first_name": "Demond",
+                "last_name": "Claiborne",
+                "full_name": "Demond Claiborne",
+                "team": "MIN",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 176,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13348": {
+                "player_id": "13348",
+                "first_name": "J'Mari",
+                "last_name": "Taylor",
+                "full_name": "J'Mari Taylor",
+                "team": "JAX",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "MaddensWok",
+                "in_lineup": false
+            },
+            "13349": {
+                "player_id": "13349",
+                "first_name": "Eli",
+                "last_name": "Stowers",
+                "full_name": "Eli Stowers",
+                "team": "PHI",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 140,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13353": {
+                "player_id": "13353",
+                "first_name": "Chris",
+                "last_name": "Brazzell",
+                "full_name": "Chris Brazzell",
+                "team": "CAR",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 202,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "gdavidson",
+                "in_lineup": false
+            },
+            "13380": {
+                "player_id": "13380",
+                "first_name": "Brenen",
+                "last_name": "Thompson",
+                "full_name": "Brenen Thompson",
+                "team": "LAC",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "OptimalPooper",
+                "in_lineup": false
+            },
+            "13400": {
+                "player_id": "13400",
+                "first_name": "Justin",
+                "last_name": "Joly",
+                "full_name": "Justin Joly",
+                "team": "DEN",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "MaddensWok",
+                "in_lineup": false
+            },
+            "13402": {
+                "player_id": "13402",
+                "first_name": "Skyler",
+                "last_name": "Bell",
+                "full_name": "Skyler Bell",
+                "team": "BUF",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "crbiehl",
+                "in_lineup": false
+            },
+            "13403": {
+                "player_id": "13403",
+                "first_name": "Jam",
+                "last_name": "Miller",
+                "full_name": "Jam Miller",
+                "team": "NE",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "crbiehl",
+                "in_lineup": false
+            },
+            "13404": {
+                "player_id": "13404",
+                "first_name": "Garrett",
+                "last_name": "Nussmeier",
+                "full_name": "Garrett Nussmeier",
+                "team": "KC",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 329,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "cmurtagh86",
+                "in_lineup": false
+            },
+            "13405": {
+                "player_id": "13405",
+                "first_name": "Kaytron",
+                "last_name": "Allen",
+                "full_name": "Kaytron Allen",
+                "team": "WAS",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 157,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13414": {
+                "player_id": "13414",
+                "first_name": "Kaelon",
+                "last_name": "Black",
+                "full_name": "Kaelon Black",
+                "team": "SF",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "spight",
+                "in_lineup": false
+            },
+            "13417": {
+                "player_id": "13417",
+                "first_name": "De'Zhaun",
+                "last_name": "Stribling",
+                "full_name": "De'Zhaun Stribling",
+                "team": "SF",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 202,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13420": {
+                "player_id": "13420",
+                "first_name": "Bryce",
+                "last_name": "Lance",
+                "full_name": "Bryce Lance",
+                "team": "NO",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13421": {
+                "player_id": "13421",
+                "first_name": "Eli",
+                "last_name": "Raridon",
+                "full_name": "Eli Raridon",
+                "team": "NE",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13423": {
+                "player_id": "13423",
+                "first_name": "Eli",
+                "last_name": "Heidenreich",
+                "full_name": "Eli Heidenreich",
+                "team": "PIT",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "spight",
+                "in_lineup": false
+            }
+        }
+    },
+    "snake": {
+        "liveDraft": {
+            "type": "linear",
+            "settings": {
+                "rounds": 4,
+                "player_type": 1
+            },
+            "slot_to_roster_id": {
+                "1": 5,
+                "2": 8,
+                "3": 1,
+                "4": 9,
+                "5": 2,
+                "6": 4,
+                "7": 11,
+                "8": 6,
+                "9": 3,
+                "10": 10,
+                "11": 12,
+                "12": 7
+            },
+            "built_draft": [
+                {
+                    "round": 1,
+                    "picks": [
+                        {
+                            "user_id": "989213899293569024",
+                            "roster_id": 5,
+                            "is_traded": false,
+                            "owner_id": 5,
+                            "pick_round": 1,
+                            "pick_number": 1,
+                            "board_spot": 1,
+                            "player_id": "13287",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "999040645685649408",
+                            "roster_id": 8,
+                            "is_traded": false,
+                            "owner_id": 8,
+                            "pick_round": 1,
+                            "pick_number": 2,
+                            "board_spot": 2,
+                            "player_id": "13269",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521035584588267520",
+                            "roster_id": 1,
+                            "is_traded": false,
+                            "owner_id": 1,
+                            "pick_round": 1,
+                            "pick_number": 3,
+                            "board_spot": 3,
+                            "player_id": "13279",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467766220007927808",
+                            "roster_id": 9,
+                            "is_traded": true,
+                            "owner_id": 6,
+                            "pick_round": 1,
+                            "pick_number": 4,
+                            "board_spot": 4,
+                            "player_id": "13281",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521424042611961856",
+                            "roster_id": 2,
+                            "is_traded": false,
+                            "owner_id": 2,
+                            "pick_round": 1,
+                            "pick_number": 5,
+                            "board_spot": 5,
+                            "player_id": "13294",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521485413219885056",
+                            "roster_id": 4,
+                            "is_traded": false,
+                            "owner_id": 4,
+                            "pick_round": 1,
+                            "pick_number": 6,
+                            "board_spot": 6,
+                            "player_id": "13286",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325371992242946048",
+                            "roster_id": 11,
+                            "is_traded": true,
+                            "owner_id": 4,
+                            "pick_round": 1,
+                            "pick_number": 7,
+                            "board_spot": 7,
+                            "player_id": "13298",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "665051007910236160",
+                            "roster_id": 6,
+                            "is_traded": true,
+                            "owner_id": 4,
+                            "pick_round": 1,
+                            "pick_number": 8,
+                            "board_spot": 8,
+                            "player_id": "13275",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467132282604351488",
+                            "roster_id": 3,
+                            "is_traded": false,
+                            "owner_id": 3,
+                            "pick_round": 1,
+                            "pick_number": 9,
+                            "board_spot": 9,
+                            "player_id": "13345",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325380343328686080",
+                            "roster_id": 10,
+                            "is_traded": true,
+                            "owner_id": 7,
+                            "pick_round": 1,
+                            "pick_number": 10,
+                            "board_spot": 10,
+                            "player_id": "13330",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "560984104439771136",
+                            "roster_id": 12,
+                            "is_traded": true,
+                            "owner_id": 5,
+                            "pick_round": 1,
+                            "pick_number": 11,
+                            "board_spot": 11,
+                            "player_id": "13276",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "464153930528452608",
+                            "roster_id": 7,
+                            "is_traded": true,
+                            "owner_id": 1,
+                            "pick_round": 1,
+                            "pick_number": 12,
+                            "board_spot": 12,
+                            "player_id": "13346",
+                            "picked": true
+                        }
+                    ]
+                },
+                {
+                    "round": 2,
+                    "picks": [
+                        {
+                            "user_id": "989213899293569024",
+                            "roster_id": 5,
+                            "is_traded": false,
+                            "owner_id": 5,
+                            "pick_round": 2,
+                            "pick_number": 1,
+                            "board_spot": 1,
+                            "player_id": "13349",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "999040645685649408",
+                            "roster_id": 8,
+                            "is_traded": false,
+                            "owner_id": 8,
+                            "pick_round": 2,
+                            "pick_number": 2,
+                            "board_spot": 2,
+                            "player_id": "13311",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521035584588267520",
+                            "roster_id": 1,
+                            "is_traded": false,
+                            "owner_id": 1,
+                            "pick_round": 2,
+                            "pick_number": 3,
+                            "board_spot": 3,
+                            "player_id": "13288",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467766220007927808",
+                            "roster_id": 9,
+                            "is_traded": false,
+                            "owner_id": 9,
+                            "pick_round": 2,
+                            "pick_number": 4,
+                            "board_spot": 4,
+                            "player_id": "13337",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521424042611961856",
+                            "roster_id": 2,
+                            "is_traded": true,
+                            "owner_id": 6,
+                            "pick_round": 2,
+                            "pick_number": 5,
+                            "board_spot": 5,
+                            "player_id": "13320",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521485413219885056",
+                            "roster_id": 4,
+                            "is_traded": true,
+                            "owner_id": 6,
+                            "pick_round": 2,
+                            "pick_number": 6,
+                            "board_spot": 6,
+                            "player_id": "13301",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325371992242946048",
+                            "roster_id": 11,
+                            "is_traded": true,
+                            "owner_id": 7,
+                            "pick_round": 2,
+                            "pick_number": 7,
+                            "board_spot": 7,
+                            "player_id": "13285",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "665051007910236160",
+                            "roster_id": 6,
+                            "is_traded": true,
+                            "owner_id": 9,
+                            "pick_round": 2,
+                            "pick_number": 8,
+                            "board_spot": 8,
+                            "player_id": "13268",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467132282604351488",
+                            "roster_id": 3,
+                            "is_traded": true,
+                            "owner_id": 9,
+                            "pick_round": 2,
+                            "pick_number": 9,
+                            "board_spot": 9,
+                            "player_id": "13353",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325380343328686080",
+                            "roster_id": 10,
+                            "is_traded": true,
+                            "owner_id": 2,
+                            "pick_round": 2,
+                            "pick_number": 10,
+                            "board_spot": 10,
+                            "player_id": "13272",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "560984104439771136",
+                            "roster_id": 12,
+                            "is_traded": true,
+                            "owner_id": 6,
+                            "pick_round": 2,
+                            "pick_number": 11,
+                            "board_spot": 11,
+                            "player_id": "13417",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "464153930528452608",
+                            "roster_id": 7,
+                            "is_traded": true,
+                            "owner_id": 1,
+                            "pick_round": 2,
+                            "pick_number": 12,
+                            "board_spot": 12,
+                            "player_id": "13274",
+                            "picked": true
+                        }
+                    ]
+                },
+                {
+                    "round": 3,
+                    "picks": [
+                        {
+                            "user_id": "989213899293569024",
+                            "roster_id": 5,
+                            "is_traded": true,
+                            "owner_id": 7,
+                            "pick_round": 3,
+                            "pick_number": 1,
+                            "board_spot": 1,
+                            "player_id": "13402",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "999040645685649408",
+                            "roster_id": 8,
+                            "is_traded": false,
+                            "owner_id": 8,
+                            "pick_round": 3,
+                            "pick_number": 2,
+                            "board_spot": 2,
+                            "player_id": "13305",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521035584588267520",
+                            "roster_id": 1,
+                            "is_traded": false,
+                            "owner_id": 1,
+                            "pick_round": 3,
+                            "pick_number": 3,
+                            "board_spot": 3,
+                            "player_id": "13405",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467766220007927808",
+                            "roster_id": 9,
+                            "is_traded": false,
+                            "owner_id": 9,
+                            "pick_round": 3,
+                            "pick_number": 4,
+                            "board_spot": 4,
+                            "player_id": "13293",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521424042611961856",
+                            "roster_id": 2,
+                            "is_traded": false,
+                            "owner_id": 2,
+                            "pick_round": 3,
+                            "pick_number": 5,
+                            "board_spot": 5,
+                            "player_id": "13317",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521485413219885056",
+                            "roster_id": 4,
+                            "is_traded": false,
+                            "owner_id": 4,
+                            "pick_round": 3,
+                            "pick_number": 6,
+                            "board_spot": 6,
+                            "player_id": "13302",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325371992242946048",
+                            "roster_id": 11,
+                            "is_traded": true,
+                            "owner_id": 5,
+                            "pick_round": 3,
+                            "pick_number": 7,
+                            "board_spot": 7,
+                            "player_id": "13347",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "665051007910236160",
+                            "roster_id": 6,
+                            "is_traded": false,
+                            "owner_id": 6,
+                            "pick_round": 3,
+                            "pick_number": 8,
+                            "board_spot": 8,
+                            "player_id": "13278",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467132282604351488",
+                            "roster_id": 3,
+                            "is_traded": false,
+                            "owner_id": 3,
+                            "pick_round": 3,
+                            "pick_number": 9,
+                            "board_spot": 9,
+                            "player_id": "13380",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325380343328686080",
+                            "roster_id": 10,
+                            "is_traded": false,
+                            "owner_id": 10,
+                            "pick_round": 3,
+                            "pick_number": 10,
+                            "board_spot": 10,
+                            "player_id": "13414",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "560984104439771136",
+                            "roster_id": 12,
+                            "is_traded": true,
+                            "owner_id": 5,
+                            "pick_round": 3,
+                            "pick_number": 11,
+                            "board_spot": 11,
+                            "player_id": "13289",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "464153930528452608",
+                            "roster_id": 7,
+                            "is_traded": true,
+                            "owner_id": 4,
+                            "pick_round": 3,
+                            "pick_number": 12,
+                            "board_spot": 12,
+                            "player_id": "13420",
+                            "picked": true
+                        }
+                    ]
+                },
+                {
+                    "round": 4,
+                    "picks": [
+                        {
+                            "user_id": "989213899293569024",
+                            "roster_id": 5,
+                            "is_traded": false,
+                            "owner_id": 5,
+                            "pick_round": 4,
+                            "pick_number": 1,
+                            "board_spot": 1,
+                            "player_id": "13296",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "999040645685649408",
+                            "roster_id": 8,
+                            "is_traded": false,
+                            "owner_id": 8,
+                            "pick_round": 4,
+                            "pick_number": 2,
+                            "board_spot": 2,
+                            "player_id": "13404",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521035584588267520",
+                            "roster_id": 1,
+                            "is_traded": false,
+                            "owner_id": 1,
+                            "pick_round": 4,
+                            "pick_number": 3,
+                            "board_spot": 3,
+                            "player_id": "13421",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467766220007927808",
+                            "roster_id": 9,
+                            "is_traded": true,
+                            "owner_id": 5,
+                            "pick_round": 4,
+                            "pick_number": 4,
+                            "board_spot": 4,
+                            "player_id": "13306",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521424042611961856",
+                            "roster_id": 2,
+                            "is_traded": false,
+                            "owner_id": 2,
+                            "pick_round": 4,
+                            "pick_number": 5,
+                            "board_spot": 5,
+                            "player_id": "13319",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521485413219885056",
+                            "roster_id": 4,
+                            "is_traded": true,
+                            "owner_id": 12,
+                            "pick_round": 4,
+                            "pick_number": 6,
+                            "board_spot": 6,
+                            "player_id": "13400",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325371992242946048",
+                            "roster_id": 11,
+                            "is_traded": false,
+                            "owner_id": 11,
+                            "pick_round": 4,
+                            "pick_number": 7,
+                            "board_spot": 7,
+                            "player_id": "13338",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "665051007910236160",
+                            "roster_id": 6,
+                            "is_traded": false,
+                            "owner_id": 6,
+                            "pick_round": 4,
+                            "pick_number": 8,
+                            "board_spot": 8,
+                            "player_id": "13333",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467132282604351488",
+                            "roster_id": 3,
+                            "is_traded": true,
+                            "owner_id": 9,
+                            "pick_round": 4,
+                            "pick_number": 9,
+                            "board_spot": 9,
+                            "player_id": "13303",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325380343328686080",
+                            "roster_id": 10,
+                            "is_traded": false,
+                            "owner_id": 10,
+                            "pick_round": 4,
+                            "pick_number": 10,
+                            "board_spot": 10,
+                            "player_id": "13423",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "560984104439771136",
+                            "roster_id": 12,
+                            "is_traded": false,
+                            "owner_id": 12,
+                            "pick_round": 4,
+                            "pick_number": 11,
+                            "board_spot": 11,
+                            "player_id": "13348",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "464153930528452608",
+                            "roster_id": 7,
+                            "is_traded": false,
+                            "owner_id": 7,
+                            "pick_round": 4,
+                            "pick_number": 12,
+                            "board_spot": 12,
+                            "player_id": "13403",
+                            "picked": true
+                        }
+                    ]
+                }
+            ],
+            "player_pool": "Rookie"
+        },
+        "playerInfo": {
+            "4984": {
+                "player_id": "4984",
+                "first_name": "Josh",
+                "last_name": "Allen",
+                "full_name": "Josh Allen",
+                "team": "BUF",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 1,
+                "years_exp": 8,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "6813": {
+                "player_id": "6813",
+                "first_name": "Jonathan",
+                "last_name": "Taylor",
+                "full_name": "Jonathan Taylor",
+                "team": "IND",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 4,
+                "years_exp": 6,
+                "is_taken": true,
+                "rostered_by": "crbiehl",
+                "in_lineup": false
+            },
+            "7564": {
+                "player_id": "7564",
+                "first_name": "Ja'Marr",
+                "last_name": "Chase",
+                "full_name": "Ja'Marr Chase",
+                "team": "CIN",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 3,
+                "years_exp": 5,
+                "is_taken": true,
+                "rostered_by": "OptimalPooper",
+                "in_lineup": false
+            },
+            "9221": {
+                "player_id": "9221",
+                "first_name": "Jahmyr",
+                "last_name": "Gibbs",
+                "full_name": "Jahmyr Gibbs",
+                "team": "DET",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 2,
+                "years_exp": 3,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "9509": {
+                "player_id": "9509",
+                "first_name": "Bijan",
+                "last_name": "Robinson",
+                "full_name": "Bijan Robinson",
+                "team": "ATL",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 1,
+                "years_exp": 3,
+                "is_taken": true,
+                "rostered_by": "kpresley",
+                "in_lineup": false
+            },
+            "11564": {
+                "player_id": "11564",
+                "first_name": "Drake",
+                "last_name": "Maye",
+                "full_name": "Drake Maye",
+                "team": "NE",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 3,
+                "years_exp": 2,
+                "is_taken": true,
+                "rostered_by": "OptimalPooper",
+                "in_lineup": false
+            },
+            "13268": {
+                "player_id": "13268",
+                "first_name": "Elijah",
+                "last_name": "Sarratt",
+                "full_name": "Elijah Sarratt",
+                "team": "BAL",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 201,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "gdavidson",
+                "in_lineup": false
+            },
+            "13269": {
+                "player_id": "13269",
+                "first_name": "Fernando",
+                "last_name": "Mendoza",
+                "full_name": "Fernando Mendoza",
+                "team": "LV",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 39,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "cmurtagh86",
+                "in_lineup": false
+            },
+            "13272": {
+                "player_id": "13272",
+                "first_name": "Carson",
+                "last_name": "Beck",
+                "full_name": "Carson Beck",
+                "team": "ARI",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 416,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "aphilliny21",
+                "in_lineup": false
+            },
+            "13274": {
+                "player_id": "13274",
+                "first_name": "Germie",
+                "last_name": "Bernard",
+                "full_name": "Germie Bernard",
+                "team": "PIT",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 194,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13275": {
+                "player_id": "13275",
+                "first_name": "Ty",
+                "last_name": "Simpson",
+                "full_name": "Ty Simpson",
+                "team": "LAR",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 141,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13276": {
+                "player_id": "13276",
+                "first_name": "Omar",
+                "last_name": "Cooper",
+                "full_name": "Omar Cooper",
+                "team": "NYJ",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 146,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13278": {
+                "player_id": "13278",
+                "first_name": "Max",
+                "last_name": "Klare",
+                "full_name": "Max Klare",
+                "team": "LAR",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 212,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13279": {
+                "player_id": "13279",
+                "first_name": "Carnell",
+                "last_name": "Tate",
+                "full_name": "Carnell Tate",
+                "team": "TEN",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 61,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13281": {
+                "player_id": "13281",
+                "first_name": "Jordyn",
+                "last_name": "Tyson",
+                "full_name": "Jordyn Tyson",
+                "team": "NO",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 69,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13285": {
+                "player_id": "13285",
+                "first_name": "Malachi",
+                "last_name": "Fields",
+                "full_name": "Malachi Fields",
+                "team": "NYG",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 210,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "crbiehl",
+                "in_lineup": false
+            },
+            "13286": {
+                "player_id": "13286",
+                "first_name": "Jadarian",
+                "last_name": "Price",
+                "full_name": "Jadarian Price",
+                "team": "SEA",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 63,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13287": {
+                "player_id": "13287",
+                "first_name": "Jeremiyah",
+                "last_name": "Love",
+                "full_name": "Jeremiyah Love",
+                "team": "ARI",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 15,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13288": {
+                "player_id": "13288",
+                "first_name": "Nicholas",
+                "last_name": "Singleton",
+                "full_name": "Nicholas Singleton",
+                "team": "TEN",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 167,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13289": {
+                "player_id": "13289",
+                "first_name": "Drew",
+                "last_name": "Allar",
+                "full_name": "Drew Allar",
+                "team": "PIT",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13293": {
+                "player_id": "13293",
+                "first_name": "Ja'Kobi",
+                "last_name": "Lane",
+                "full_name": "Ja'Kobi Lane",
+                "team": "BAL",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 182,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "gdavidson",
+                "in_lineup": false
+            },
+            "13294": {
+                "player_id": "13294",
+                "first_name": "Makai",
+                "last_name": "Lemon",
+                "full_name": "Makai Lemon",
+                "team": "PHI",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 77,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "aphilliny21",
+                "in_lineup": false
+            },
+            "13296": {
+                "player_id": "13296",
+                "first_name": "Caleb",
+                "last_name": "Douglas",
+                "full_name": "Caleb Douglas",
+                "team": "MIA",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13298": {
+                "player_id": "13298",
+                "first_name": "KC",
+                "last_name": "Concepcion",
+                "full_name": "KC Concepcion",
+                "team": "CLE",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 116,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13301": {
+                "player_id": "13301",
+                "first_name": "Antonio",
+                "last_name": "Williams",
+                "full_name": "Antonio Williams",
+                "team": "WAS",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 156,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13302": {
+                "player_id": "13302",
+                "first_name": "Adam",
+                "last_name": "Randall",
+                "full_name": "Adam Randall",
+                "team": "BAL",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13303": {
+                "player_id": "13303",
+                "first_name": "Cade",
+                "last_name": "Klubnik",
+                "full_name": "Cade Klubnik",
+                "team": "NYJ",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 398,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "gdavidson",
+                "in_lineup": false
+            },
+            "13305": {
+                "player_id": "13305",
+                "first_name": "Mike",
+                "last_name": "Washington",
+                "full_name": "Mike Washington",
+                "team": "LV",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 139,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "cmurtagh86",
+                "in_lineup": false
+            },
+            "13306": {
+                "player_id": "13306",
+                "first_name": "Taylen",
+                "last_name": "Green",
+                "full_name": "Taylen Green",
+                "team": "CLE",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13311": {
+                "player_id": "13311",
+                "first_name": "Chris",
+                "last_name": "Bell",
+                "full_name": "Chris Bell",
+                "team": "MIA",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 203,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "cmurtagh86",
+                "in_lineup": false
+            },
+            "13317": {
+                "player_id": "13317",
+                "first_name": "Ted",
+                "last_name": "Hurst",
+                "full_name": "Ted Hurst",
+                "team": "TB",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 196,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "aphilliny21",
+                "in_lineup": false
+            },
+            "13319": {
+                "player_id": "13319",
+                "first_name": "Oscar",
+                "last_name": "Delp",
+                "full_name": "Oscar Delp",
+                "team": "NO",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "aphilliny21",
+                "in_lineup": false
+            },
+            "13320": {
+                "player_id": "13320",
+                "first_name": "Zachariah",
+                "last_name": "Branch",
+                "full_name": "Zachariah Branch",
+                "team": "ATL",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 180,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13330": {
+                "player_id": "13330",
+                "first_name": "Kenyon",
+                "last_name": "Sadiq",
+                "full_name": "Kenyon Sadiq",
+                "team": "NYJ",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 109,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "crbiehl",
+                "in_lineup": false
+            },
+            "13333": {
+                "player_id": "13333",
+                "first_name": "Deion",
+                "last_name": "Burks",
+                "full_name": "Deion Burks",
+                "team": "IND",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13337": {
+                "player_id": "13337",
+                "first_name": "Emmett",
+                "last_name": "Johnson",
+                "full_name": "Emmett Johnson",
+                "team": "KC",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 113,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "gdavidson",
+                "in_lineup": false
+            },
+            "13338": {
+                "player_id": "13338",
+                "first_name": "Kevin",
+                "last_name": "Coleman",
+                "full_name": "Kevin Coleman",
+                "team": "MIA",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "kpresley",
+                "in_lineup": false
+            },
+            "13345": {
+                "player_id": "13345",
+                "first_name": "Jonah",
+                "last_name": "Coleman",
+                "full_name": "Jonah Coleman",
+                "team": "DEN",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 118,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "OptimalPooper",
+                "in_lineup": false
+            },
+            "13346": {
+                "player_id": "13346",
+                "first_name": "Denzel",
+                "last_name": "Boston",
+                "full_name": "Denzel Boston",
+                "team": "CLE",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 144,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13347": {
+                "player_id": "13347",
+                "first_name": "Demond",
+                "last_name": "Claiborne",
+                "full_name": "Demond Claiborne",
+                "team": "MIN",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 176,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13348": {
+                "player_id": "13348",
+                "first_name": "J'Mari",
+                "last_name": "Taylor",
+                "full_name": "J'Mari Taylor",
+                "team": "JAX",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "MaddensWok",
+                "in_lineup": false
+            },
+            "13349": {
+                "player_id": "13349",
+                "first_name": "Eli",
+                "last_name": "Stowers",
+                "full_name": "Eli Stowers",
+                "team": "PHI",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 140,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13353": {
+                "player_id": "13353",
+                "first_name": "Chris",
+                "last_name": "Brazzell",
+                "full_name": "Chris Brazzell",
+                "team": "CAR",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 202,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "gdavidson",
+                "in_lineup": false
+            },
+            "13380": {
+                "player_id": "13380",
+                "first_name": "Brenen",
+                "last_name": "Thompson",
+                "full_name": "Brenen Thompson",
+                "team": "LAC",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "OptimalPooper",
+                "in_lineup": false
+            },
+            "13400": {
+                "player_id": "13400",
+                "first_name": "Justin",
+                "last_name": "Joly",
+                "full_name": "Justin Joly",
+                "team": "DEN",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "MaddensWok",
+                "in_lineup": false
+            },
+            "13402": {
+                "player_id": "13402",
+                "first_name": "Skyler",
+                "last_name": "Bell",
+                "full_name": "Skyler Bell",
+                "team": "BUF",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "crbiehl",
+                "in_lineup": false
+            },
+            "13403": {
+                "player_id": "13403",
+                "first_name": "Jam",
+                "last_name": "Miller",
+                "full_name": "Jam Miller",
+                "team": "NE",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "crbiehl",
+                "in_lineup": false
+            },
+            "13404": {
+                "player_id": "13404",
+                "first_name": "Garrett",
+                "last_name": "Nussmeier",
+                "full_name": "Garrett Nussmeier",
+                "team": "KC",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 329,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "cmurtagh86",
+                "in_lineup": false
+            },
+            "13405": {
+                "player_id": "13405",
+                "first_name": "Kaytron",
+                "last_name": "Allen",
+                "full_name": "Kaytron Allen",
+                "team": "WAS",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 157,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13414": {
+                "player_id": "13414",
+                "first_name": "Kaelon",
+                "last_name": "Black",
+                "full_name": "Kaelon Black",
+                "team": "SF",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "spight",
+                "in_lineup": false
+            },
+            "13417": {
+                "player_id": "13417",
+                "first_name": "De'Zhaun",
+                "last_name": "Stribling",
+                "full_name": "De'Zhaun Stribling",
+                "team": "SF",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 202,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13420": {
+                "player_id": "13420",
+                "first_name": "Bryce",
+                "last_name": "Lance",
+                "full_name": "Bryce Lance",
+                "team": "NO",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13421": {
+                "player_id": "13421",
+                "first_name": "Eli",
+                "last_name": "Raridon",
+                "full_name": "Eli Raridon",
+                "team": "NE",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13423": {
+                "player_id": "13423",
+                "first_name": "Eli",
+                "last_name": "Heidenreich",
+                "full_name": "Eli Heidenreich",
+                "team": "PIT",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "spight",
+                "in_lineup": false
+            }
+        }
+    },
+    "snakeTwice": {
+        "liveDraft": {
+            "type": "linear",
+            "settings": {
+                "rounds": 4,
+                "player_type": 1
+            },
+            "slot_to_roster_id": {
+                "1": 5,
+                "2": 8,
+                "3": 1,
+                "4": 9,
+                "5": 2,
+                "6": 4,
+                "7": 11,
+                "8": 6,
+                "9": 3,
+                "10": 10,
+                "11": 12,
+                "12": 7
+            },
+            "built_draft": [
+                {
+                    "round": 1,
+                    "picks": [
+                        {
+                            "user_id": "989213899293569024",
+                            "roster_id": 5,
+                            "is_traded": false,
+                            "owner_id": 5,
+                            "pick_round": 1,
+                            "pick_number": 1,
+                            "board_spot": 1,
+                            "player_id": "13287",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "999040645685649408",
+                            "roster_id": 8,
+                            "is_traded": false,
+                            "owner_id": 8,
+                            "pick_round": 1,
+                            "pick_number": 2,
+                            "board_spot": 2,
+                            "player_id": "13269",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521035584588267520",
+                            "roster_id": 1,
+                            "is_traded": false,
+                            "owner_id": 1,
+                            "pick_round": 1,
+                            "pick_number": 3,
+                            "board_spot": 3,
+                            "player_id": "13279",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467766220007927808",
+                            "roster_id": 9,
+                            "is_traded": true,
+                            "owner_id": 6,
+                            "pick_round": 1,
+                            "pick_number": 4,
+                            "board_spot": 4,
+                            "player_id": "13281",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521424042611961856",
+                            "roster_id": 2,
+                            "is_traded": false,
+                            "owner_id": 2,
+                            "pick_round": 1,
+                            "pick_number": 5,
+                            "board_spot": 5,
+                            "player_id": "13294",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521485413219885056",
+                            "roster_id": 4,
+                            "is_traded": false,
+                            "owner_id": 4,
+                            "pick_round": 1,
+                            "pick_number": 6,
+                            "board_spot": 6,
+                            "player_id": "13286",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325371992242946048",
+                            "roster_id": 11,
+                            "is_traded": true,
+                            "owner_id": 4,
+                            "pick_round": 1,
+                            "pick_number": 7,
+                            "board_spot": 7,
+                            "player_id": "13298",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "665051007910236160",
+                            "roster_id": 6,
+                            "is_traded": true,
+                            "owner_id": 4,
+                            "pick_round": 1,
+                            "pick_number": 8,
+                            "board_spot": 8,
+                            "player_id": "13275",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467132282604351488",
+                            "roster_id": 3,
+                            "is_traded": false,
+                            "owner_id": 3,
+                            "pick_round": 1,
+                            "pick_number": 9,
+                            "board_spot": 9,
+                            "player_id": "13345",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325380343328686080",
+                            "roster_id": 10,
+                            "is_traded": true,
+                            "owner_id": 7,
+                            "pick_round": 1,
+                            "pick_number": 10,
+                            "board_spot": 10,
+                            "player_id": "13330",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "560984104439771136",
+                            "roster_id": 12,
+                            "is_traded": true,
+                            "owner_id": 5,
+                            "pick_round": 1,
+                            "pick_number": 11,
+                            "board_spot": 11,
+                            "player_id": "13276",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "464153930528452608",
+                            "roster_id": 7,
+                            "is_traded": true,
+                            "owner_id": 1,
+                            "pick_round": 1,
+                            "pick_number": 12,
+                            "board_spot": 12,
+                            "player_id": "13346",
+                            "picked": true
+                        }
+                    ]
+                },
+                {
+                    "round": 2,
+                    "picks": [
+                        {
+                            "user_id": "989213899293569024",
+                            "roster_id": 5,
+                            "is_traded": false,
+                            "owner_id": 5,
+                            "pick_round": 2,
+                            "pick_number": 1,
+                            "board_spot": 1,
+                            "player_id": "13349",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "999040645685649408",
+                            "roster_id": 8,
+                            "is_traded": false,
+                            "owner_id": 8,
+                            "pick_round": 2,
+                            "pick_number": 2,
+                            "board_spot": 2,
+                            "player_id": "13311",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521035584588267520",
+                            "roster_id": 1,
+                            "is_traded": false,
+                            "owner_id": 1,
+                            "pick_round": 2,
+                            "pick_number": 3,
+                            "board_spot": 3,
+                            "player_id": "13288",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467766220007927808",
+                            "roster_id": 9,
+                            "is_traded": false,
+                            "owner_id": 9,
+                            "pick_round": 2,
+                            "pick_number": 4,
+                            "board_spot": 4,
+                            "player_id": "13337",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521424042611961856",
+                            "roster_id": 2,
+                            "is_traded": true,
+                            "owner_id": 6,
+                            "pick_round": 2,
+                            "pick_number": 5,
+                            "board_spot": 5,
+                            "player_id": "13320",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521485413219885056",
+                            "roster_id": 4,
+                            "is_traded": true,
+                            "owner_id": 6,
+                            "pick_round": 2,
+                            "pick_number": 6,
+                            "board_spot": 6,
+                            "player_id": "13301",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325371992242946048",
+                            "roster_id": 11,
+                            "is_traded": true,
+                            "owner_id": 7,
+                            "pick_round": 2,
+                            "pick_number": 7,
+                            "board_spot": 7,
+                            "player_id": "13285",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "665051007910236160",
+                            "roster_id": 6,
+                            "is_traded": true,
+                            "owner_id": 9,
+                            "pick_round": 2,
+                            "pick_number": 8,
+                            "board_spot": 8,
+                            "player_id": "13268",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467132282604351488",
+                            "roster_id": 3,
+                            "is_traded": true,
+                            "owner_id": 9,
+                            "pick_round": 2,
+                            "pick_number": 9,
+                            "board_spot": 9,
+                            "player_id": "13353",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325380343328686080",
+                            "roster_id": 10,
+                            "is_traded": true,
+                            "owner_id": 2,
+                            "pick_round": 2,
+                            "pick_number": 10,
+                            "board_spot": 10,
+                            "player_id": "13272",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "560984104439771136",
+                            "roster_id": 12,
+                            "is_traded": true,
+                            "owner_id": 6,
+                            "pick_round": 2,
+                            "pick_number": 11,
+                            "board_spot": 11,
+                            "player_id": "13417",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "464153930528452608",
+                            "roster_id": 7,
+                            "is_traded": true,
+                            "owner_id": 1,
+                            "pick_round": 2,
+                            "pick_number": 12,
+                            "board_spot": 12,
+                            "player_id": "13274",
+                            "picked": true
+                        }
+                    ]
+                },
+                {
+                    "round": 3,
+                    "picks": [
+                        {
+                            "user_id": "989213899293569024",
+                            "roster_id": 5,
+                            "is_traded": true,
+                            "owner_id": 7,
+                            "pick_round": 3,
+                            "pick_number": 1,
+                            "board_spot": 1,
+                            "player_id": "13402",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "999040645685649408",
+                            "roster_id": 8,
+                            "is_traded": false,
+                            "owner_id": 8,
+                            "pick_round": 3,
+                            "pick_number": 2,
+                            "board_spot": 2,
+                            "player_id": "13305",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521035584588267520",
+                            "roster_id": 1,
+                            "is_traded": false,
+                            "owner_id": 1,
+                            "pick_round": 3,
+                            "pick_number": 3,
+                            "board_spot": 3,
+                            "player_id": "13405",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467766220007927808",
+                            "roster_id": 9,
+                            "is_traded": false,
+                            "owner_id": 9,
+                            "pick_round": 3,
+                            "pick_number": 4,
+                            "board_spot": 4,
+                            "player_id": "13293",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521424042611961856",
+                            "roster_id": 2,
+                            "is_traded": false,
+                            "owner_id": 2,
+                            "pick_round": 3,
+                            "pick_number": 5,
+                            "board_spot": 5,
+                            "player_id": "13317",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521485413219885056",
+                            "roster_id": 4,
+                            "is_traded": false,
+                            "owner_id": 4,
+                            "pick_round": 3,
+                            "pick_number": 6,
+                            "board_spot": 6,
+                            "player_id": "13302",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325371992242946048",
+                            "roster_id": 11,
+                            "is_traded": true,
+                            "owner_id": 5,
+                            "pick_round": 3,
+                            "pick_number": 7,
+                            "board_spot": 7,
+                            "player_id": "13347",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "665051007910236160",
+                            "roster_id": 6,
+                            "is_traded": false,
+                            "owner_id": 6,
+                            "pick_round": 3,
+                            "pick_number": 8,
+                            "board_spot": 8,
+                            "player_id": "13278",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467132282604351488",
+                            "roster_id": 3,
+                            "is_traded": false,
+                            "owner_id": 3,
+                            "pick_round": 3,
+                            "pick_number": 9,
+                            "board_spot": 9,
+                            "player_id": "13380",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325380343328686080",
+                            "roster_id": 10,
+                            "is_traded": false,
+                            "owner_id": 10,
+                            "pick_round": 3,
+                            "pick_number": 10,
+                            "board_spot": 10,
+                            "player_id": "13414",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "560984104439771136",
+                            "roster_id": 12,
+                            "is_traded": true,
+                            "owner_id": 5,
+                            "pick_round": 3,
+                            "pick_number": 11,
+                            "board_spot": 11,
+                            "player_id": "13289",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "464153930528452608",
+                            "roster_id": 7,
+                            "is_traded": true,
+                            "owner_id": 4,
+                            "pick_round": 3,
+                            "pick_number": 12,
+                            "board_spot": 12,
+                            "player_id": "13420",
+                            "picked": true
+                        }
+                    ]
+                },
+                {
+                    "round": 4,
+                    "picks": [
+                        {
+                            "user_id": "989213899293569024",
+                            "roster_id": 5,
+                            "is_traded": false,
+                            "owner_id": 5,
+                            "pick_round": 4,
+                            "pick_number": 1,
+                            "board_spot": 1,
+                            "player_id": "13296",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "999040645685649408",
+                            "roster_id": 8,
+                            "is_traded": false,
+                            "owner_id": 8,
+                            "pick_round": 4,
+                            "pick_number": 2,
+                            "board_spot": 2,
+                            "player_id": "13404",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521035584588267520",
+                            "roster_id": 1,
+                            "is_traded": false,
+                            "owner_id": 1,
+                            "pick_round": 4,
+                            "pick_number": 3,
+                            "board_spot": 3,
+                            "player_id": "13421",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467766220007927808",
+                            "roster_id": 9,
+                            "is_traded": true,
+                            "owner_id": 5,
+                            "pick_round": 4,
+                            "pick_number": 4,
+                            "board_spot": 4,
+                            "player_id": "13306",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521424042611961856",
+                            "roster_id": 2,
+                            "is_traded": false,
+                            "owner_id": 2,
+                            "pick_round": 4,
+                            "pick_number": 5,
+                            "board_spot": 5,
+                            "player_id": "13319",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521485413219885056",
+                            "roster_id": 4,
+                            "is_traded": true,
+                            "owner_id": 12,
+                            "pick_round": 4,
+                            "pick_number": 6,
+                            "board_spot": 6,
+                            "player_id": "13400",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325371992242946048",
+                            "roster_id": 11,
+                            "is_traded": false,
+                            "owner_id": 11,
+                            "pick_round": 4,
+                            "pick_number": 7,
+                            "board_spot": 7,
+                            "player_id": "13338",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "665051007910236160",
+                            "roster_id": 6,
+                            "is_traded": false,
+                            "owner_id": 6,
+                            "pick_round": 4,
+                            "pick_number": 8,
+                            "board_spot": 8,
+                            "player_id": "13333",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467132282604351488",
+                            "roster_id": 3,
+                            "is_traded": true,
+                            "owner_id": 9,
+                            "pick_round": 4,
+                            "pick_number": 9,
+                            "board_spot": 9,
+                            "player_id": "13303",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325380343328686080",
+                            "roster_id": 10,
+                            "is_traded": false,
+                            "owner_id": 10,
+                            "pick_round": 4,
+                            "pick_number": 10,
+                            "board_spot": 10,
+                            "player_id": "13423",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "560984104439771136",
+                            "roster_id": 12,
+                            "is_traded": false,
+                            "owner_id": 12,
+                            "pick_round": 4,
+                            "pick_number": 11,
+                            "board_spot": 11,
+                            "player_id": "13348",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "464153930528452608",
+                            "roster_id": 7,
+                            "is_traded": false,
+                            "owner_id": 7,
+                            "pick_round": 4,
+                            "pick_number": 12,
+                            "board_spot": 12,
+                            "player_id": "13403",
+                            "picked": true
+                        }
+                    ]
+                }
+            ],
+            "player_pool": "Rookie"
+        },
+        "playerInfo": {
+            "4984": {
+                "player_id": "4984",
+                "first_name": "Josh",
+                "last_name": "Allen",
+                "full_name": "Josh Allen",
+                "team": "BUF",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 1,
+                "years_exp": 8,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "6813": {
+                "player_id": "6813",
+                "first_name": "Jonathan",
+                "last_name": "Taylor",
+                "full_name": "Jonathan Taylor",
+                "team": "IND",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 4,
+                "years_exp": 6,
+                "is_taken": true,
+                "rostered_by": "crbiehl",
+                "in_lineup": false
+            },
+            "7564": {
+                "player_id": "7564",
+                "first_name": "Ja'Marr",
+                "last_name": "Chase",
+                "full_name": "Ja'Marr Chase",
+                "team": "CIN",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 3,
+                "years_exp": 5,
+                "is_taken": true,
+                "rostered_by": "OptimalPooper",
+                "in_lineup": false
+            },
+            "9221": {
+                "player_id": "9221",
+                "first_name": "Jahmyr",
+                "last_name": "Gibbs",
+                "full_name": "Jahmyr Gibbs",
+                "team": "DET",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 2,
+                "years_exp": 3,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "9509": {
+                "player_id": "9509",
+                "first_name": "Bijan",
+                "last_name": "Robinson",
+                "full_name": "Bijan Robinson",
+                "team": "ATL",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 1,
+                "years_exp": 3,
+                "is_taken": true,
+                "rostered_by": "kpresley",
+                "in_lineup": false
+            },
+            "11564": {
+                "player_id": "11564",
+                "first_name": "Drake",
+                "last_name": "Maye",
+                "full_name": "Drake Maye",
+                "team": "NE",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 3,
+                "years_exp": 2,
+                "is_taken": true,
+                "rostered_by": "OptimalPooper",
+                "in_lineup": false
+            },
+            "13268": {
+                "player_id": "13268",
+                "first_name": "Elijah",
+                "last_name": "Sarratt",
+                "full_name": "Elijah Sarratt",
+                "team": "BAL",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 201,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "gdavidson",
+                "in_lineup": false
+            },
+            "13269": {
+                "player_id": "13269",
+                "first_name": "Fernando",
+                "last_name": "Mendoza",
+                "full_name": "Fernando Mendoza",
+                "team": "LV",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 39,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "cmurtagh86",
+                "in_lineup": false
+            },
+            "13272": {
+                "player_id": "13272",
+                "first_name": "Carson",
+                "last_name": "Beck",
+                "full_name": "Carson Beck",
+                "team": "ARI",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 416,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "aphilliny21",
+                "in_lineup": false
+            },
+            "13274": {
+                "player_id": "13274",
+                "first_name": "Germie",
+                "last_name": "Bernard",
+                "full_name": "Germie Bernard",
+                "team": "PIT",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 194,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13275": {
+                "player_id": "13275",
+                "first_name": "Ty",
+                "last_name": "Simpson",
+                "full_name": "Ty Simpson",
+                "team": "LAR",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 141,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13276": {
+                "player_id": "13276",
+                "first_name": "Omar",
+                "last_name": "Cooper",
+                "full_name": "Omar Cooper",
+                "team": "NYJ",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 146,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13278": {
+                "player_id": "13278",
+                "first_name": "Max",
+                "last_name": "Klare",
+                "full_name": "Max Klare",
+                "team": "LAR",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 212,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13279": {
+                "player_id": "13279",
+                "first_name": "Carnell",
+                "last_name": "Tate",
+                "full_name": "Carnell Tate",
+                "team": "TEN",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 61,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13281": {
+                "player_id": "13281",
+                "first_name": "Jordyn",
+                "last_name": "Tyson",
+                "full_name": "Jordyn Tyson",
+                "team": "NO",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 69,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13285": {
+                "player_id": "13285",
+                "first_name": "Malachi",
+                "last_name": "Fields",
+                "full_name": "Malachi Fields",
+                "team": "NYG",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 210,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "crbiehl",
+                "in_lineup": false
+            },
+            "13286": {
+                "player_id": "13286",
+                "first_name": "Jadarian",
+                "last_name": "Price",
+                "full_name": "Jadarian Price",
+                "team": "SEA",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 63,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13287": {
+                "player_id": "13287",
+                "first_name": "Jeremiyah",
+                "last_name": "Love",
+                "full_name": "Jeremiyah Love",
+                "team": "ARI",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 15,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13288": {
+                "player_id": "13288",
+                "first_name": "Nicholas",
+                "last_name": "Singleton",
+                "full_name": "Nicholas Singleton",
+                "team": "TEN",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 167,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13289": {
+                "player_id": "13289",
+                "first_name": "Drew",
+                "last_name": "Allar",
+                "full_name": "Drew Allar",
+                "team": "PIT",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13293": {
+                "player_id": "13293",
+                "first_name": "Ja'Kobi",
+                "last_name": "Lane",
+                "full_name": "Ja'Kobi Lane",
+                "team": "BAL",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 182,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "gdavidson",
+                "in_lineup": false
+            },
+            "13294": {
+                "player_id": "13294",
+                "first_name": "Makai",
+                "last_name": "Lemon",
+                "full_name": "Makai Lemon",
+                "team": "PHI",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 77,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "aphilliny21",
+                "in_lineup": false
+            },
+            "13296": {
+                "player_id": "13296",
+                "first_name": "Caleb",
+                "last_name": "Douglas",
+                "full_name": "Caleb Douglas",
+                "team": "MIA",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13298": {
+                "player_id": "13298",
+                "first_name": "KC",
+                "last_name": "Concepcion",
+                "full_name": "KC Concepcion",
+                "team": "CLE",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 116,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13301": {
+                "player_id": "13301",
+                "first_name": "Antonio",
+                "last_name": "Williams",
+                "full_name": "Antonio Williams",
+                "team": "WAS",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 156,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13302": {
+                "player_id": "13302",
+                "first_name": "Adam",
+                "last_name": "Randall",
+                "full_name": "Adam Randall",
+                "team": "BAL",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13303": {
+                "player_id": "13303",
+                "first_name": "Cade",
+                "last_name": "Klubnik",
+                "full_name": "Cade Klubnik",
+                "team": "NYJ",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 398,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "gdavidson",
+                "in_lineup": false
+            },
+            "13305": {
+                "player_id": "13305",
+                "first_name": "Mike",
+                "last_name": "Washington",
+                "full_name": "Mike Washington",
+                "team": "LV",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 139,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "cmurtagh86",
+                "in_lineup": false
+            },
+            "13306": {
+                "player_id": "13306",
+                "first_name": "Taylen",
+                "last_name": "Green",
+                "full_name": "Taylen Green",
+                "team": "CLE",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13311": {
+                "player_id": "13311",
+                "first_name": "Chris",
+                "last_name": "Bell",
+                "full_name": "Chris Bell",
+                "team": "MIA",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 203,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "cmurtagh86",
+                "in_lineup": false
+            },
+            "13317": {
+                "player_id": "13317",
+                "first_name": "Ted",
+                "last_name": "Hurst",
+                "full_name": "Ted Hurst",
+                "team": "TB",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 196,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "aphilliny21",
+                "in_lineup": false
+            },
+            "13319": {
+                "player_id": "13319",
+                "first_name": "Oscar",
+                "last_name": "Delp",
+                "full_name": "Oscar Delp",
+                "team": "NO",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "aphilliny21",
+                "in_lineup": false
+            },
+            "13320": {
+                "player_id": "13320",
+                "first_name": "Zachariah",
+                "last_name": "Branch",
+                "full_name": "Zachariah Branch",
+                "team": "ATL",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 180,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13330": {
+                "player_id": "13330",
+                "first_name": "Kenyon",
+                "last_name": "Sadiq",
+                "full_name": "Kenyon Sadiq",
+                "team": "NYJ",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 109,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "crbiehl",
+                "in_lineup": false
+            },
+            "13333": {
+                "player_id": "13333",
+                "first_name": "Deion",
+                "last_name": "Burks",
+                "full_name": "Deion Burks",
+                "team": "IND",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13337": {
+                "player_id": "13337",
+                "first_name": "Emmett",
+                "last_name": "Johnson",
+                "full_name": "Emmett Johnson",
+                "team": "KC",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 113,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "gdavidson",
+                "in_lineup": false
+            },
+            "13338": {
+                "player_id": "13338",
+                "first_name": "Kevin",
+                "last_name": "Coleman",
+                "full_name": "Kevin Coleman",
+                "team": "MIA",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "kpresley",
+                "in_lineup": false
+            },
+            "13345": {
+                "player_id": "13345",
+                "first_name": "Jonah",
+                "last_name": "Coleman",
+                "full_name": "Jonah Coleman",
+                "team": "DEN",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 118,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "OptimalPooper",
+                "in_lineup": false
+            },
+            "13346": {
+                "player_id": "13346",
+                "first_name": "Denzel",
+                "last_name": "Boston",
+                "full_name": "Denzel Boston",
+                "team": "CLE",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 144,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13347": {
+                "player_id": "13347",
+                "first_name": "Demond",
+                "last_name": "Claiborne",
+                "full_name": "Demond Claiborne",
+                "team": "MIN",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 176,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13348": {
+                "player_id": "13348",
+                "first_name": "J'Mari",
+                "last_name": "Taylor",
+                "full_name": "J'Mari Taylor",
+                "team": "JAX",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "MaddensWok",
+                "in_lineup": false
+            },
+            "13349": {
+                "player_id": "13349",
+                "first_name": "Eli",
+                "last_name": "Stowers",
+                "full_name": "Eli Stowers",
+                "team": "PHI",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 140,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13353": {
+                "player_id": "13353",
+                "first_name": "Chris",
+                "last_name": "Brazzell",
+                "full_name": "Chris Brazzell",
+                "team": "CAR",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 202,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "gdavidson",
+                "in_lineup": false
+            },
+            "13380": {
+                "player_id": "13380",
+                "first_name": "Brenen",
+                "last_name": "Thompson",
+                "full_name": "Brenen Thompson",
+                "team": "LAC",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "OptimalPooper",
+                "in_lineup": false
+            },
+            "13400": {
+                "player_id": "13400",
+                "first_name": "Justin",
+                "last_name": "Joly",
+                "full_name": "Justin Joly",
+                "team": "DEN",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "MaddensWok",
+                "in_lineup": false
+            },
+            "13402": {
+                "player_id": "13402",
+                "first_name": "Skyler",
+                "last_name": "Bell",
+                "full_name": "Skyler Bell",
+                "team": "BUF",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "crbiehl",
+                "in_lineup": false
+            },
+            "13403": {
+                "player_id": "13403",
+                "first_name": "Jam",
+                "last_name": "Miller",
+                "full_name": "Jam Miller",
+                "team": "NE",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "crbiehl",
+                "in_lineup": false
+            },
+            "13404": {
+                "player_id": "13404",
+                "first_name": "Garrett",
+                "last_name": "Nussmeier",
+                "full_name": "Garrett Nussmeier",
+                "team": "KC",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 329,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "cmurtagh86",
+                "in_lineup": false
+            },
+            "13405": {
+                "player_id": "13405",
+                "first_name": "Kaytron",
+                "last_name": "Allen",
+                "full_name": "Kaytron Allen",
+                "team": "WAS",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 157,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13414": {
+                "player_id": "13414",
+                "first_name": "Kaelon",
+                "last_name": "Black",
+                "full_name": "Kaelon Black",
+                "team": "SF",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "spight",
+                "in_lineup": false
+            },
+            "13417": {
+                "player_id": "13417",
+                "first_name": "De'Zhaun",
+                "last_name": "Stribling",
+                "full_name": "De'Zhaun Stribling",
+                "team": "SF",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 202,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13420": {
+                "player_id": "13420",
+                "first_name": "Bryce",
+                "last_name": "Lance",
+                "full_name": "Bryce Lance",
+                "team": "NO",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13421": {
+                "player_id": "13421",
+                "first_name": "Eli",
+                "last_name": "Raridon",
+                "full_name": "Eli Raridon",
+                "team": "NE",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13423": {
+                "player_id": "13423",
+                "first_name": "Eli",
+                "last_name": "Heidenreich",
+                "full_name": "Eli Heidenreich",
+                "team": "PIT",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "spight",
+                "in_lineup": false
+            }
+        }
+    },
+    "partialFromClean": {
+        "liveDraft": {
+            "type": "linear",
+            "settings": {
+                "rounds": 4,
+                "player_type": 1
+            },
+            "slot_to_roster_id": {
+                "1": 5,
+                "2": 8,
+                "3": 1,
+                "4": 9,
+                "5": 2,
+                "6": 4,
+                "7": 11,
+                "8": 6,
+                "9": 3,
+                "10": 10,
+                "11": 12,
+                "12": 7
+            },
+            "built_draft": [
+                {
+                    "round": 1,
+                    "picks": [
+                        {
+                            "user_id": "989213899293569024",
+                            "roster_id": 5,
+                            "is_traded": false,
+                            "owner_id": 5,
+                            "pick_round": 1,
+                            "pick_number": 1,
+                            "board_spot": 1,
+                            "player_id": "13287",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "999040645685649408",
+                            "roster_id": 8,
+                            "is_traded": false,
+                            "owner_id": 8,
+                            "pick_round": 1,
+                            "pick_number": 2,
+                            "board_spot": 2,
+                            "player_id": "13269",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521035584588267520",
+                            "roster_id": 1,
+                            "is_traded": false,
+                            "owner_id": 1,
+                            "pick_round": 1,
+                            "pick_number": 3,
+                            "board_spot": 3,
+                            "player_id": "13279",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467766220007927808",
+                            "roster_id": 9,
+                            "is_traded": true,
+                            "owner_id": 6,
+                            "pick_round": 1,
+                            "pick_number": 4,
+                            "board_spot": 4,
+                            "player_id": "13281",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521424042611961856",
+                            "roster_id": 2,
+                            "is_traded": false,
+                            "owner_id": 2,
+                            "pick_round": 1,
+                            "pick_number": 5,
+                            "board_spot": 5,
+                            "player_id": "13294",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521485413219885056",
+                            "roster_id": 4,
+                            "is_traded": false,
+                            "owner_id": 4,
+                            "pick_round": 1,
+                            "pick_number": 6,
+                            "board_spot": 6,
+                            "player_id": "13286",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325371992242946048",
+                            "roster_id": 11,
+                            "is_traded": true,
+                            "owner_id": 4,
+                            "pick_round": 1,
+                            "pick_number": 7,
+                            "board_spot": 7,
+                            "player_id": "13298",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "665051007910236160",
+                            "roster_id": 6,
+                            "is_traded": true,
+                            "owner_id": 4,
+                            "pick_round": 1,
+                            "pick_number": 8,
+                            "board_spot": 8,
+                            "player_id": "13275",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467132282604351488",
+                            "roster_id": 3,
+                            "is_traded": false,
+                            "owner_id": 3,
+                            "pick_round": 1,
+                            "pick_number": 9,
+                            "board_spot": 9,
+                            "player_id": "13345",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325380343328686080",
+                            "roster_id": 10,
+                            "is_traded": true,
+                            "owner_id": 7,
+                            "pick_round": 1,
+                            "pick_number": 10,
+                            "board_spot": 10,
+                            "player_id": "13330",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "560984104439771136",
+                            "roster_id": 12,
+                            "is_traded": true,
+                            "owner_id": 5,
+                            "pick_round": 1,
+                            "pick_number": 11,
+                            "board_spot": 11,
+                            "player_id": "13276",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "464153930528452608",
+                            "roster_id": 7,
+                            "is_traded": true,
+                            "owner_id": 1,
+                            "pick_round": 1,
+                            "pick_number": 12,
+                            "board_spot": 12,
+                            "player_id": "13346",
+                            "picked": true
+                        }
+                    ]
+                },
+                {
+                    "round": 2,
+                    "picks": [
+                        {
+                            "user_id": "989213899293569024",
+                            "roster_id": 5,
+                            "is_traded": false,
+                            "owner_id": 5,
+                            "pick_round": 2,
+                            "pick_number": 1,
+                            "board_spot": 1,
+                            "player_id": "13349",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "999040645685649408",
+                            "roster_id": 8,
+                            "is_traded": false,
+                            "owner_id": 8,
+                            "pick_round": 2,
+                            "pick_number": 2,
+                            "board_spot": 2,
+                            "player_id": "13311",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521035584588267520",
+                            "roster_id": 1,
+                            "is_traded": false,
+                            "owner_id": 1,
+                            "pick_round": 2,
+                            "pick_number": 3,
+                            "board_spot": 3,
+                            "player_id": "13288",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467766220007927808",
+                            "roster_id": 9,
+                            "is_traded": false,
+                            "owner_id": 9,
+                            "pick_round": 2,
+                            "pick_number": 4,
+                            "board_spot": 4,
+                            "player_id": "13337",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521424042611961856",
+                            "roster_id": 2,
+                            "is_traded": true,
+                            "owner_id": 6,
+                            "pick_round": 2,
+                            "pick_number": 5,
+                            "board_spot": 5,
+                            "player_id": "13320",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521485413219885056",
+                            "roster_id": 4,
+                            "is_traded": true,
+                            "owner_id": 6,
+                            "pick_round": 2,
+                            "pick_number": 6,
+                            "board_spot": 6,
+                            "player_id": "13301",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325371992242946048",
+                            "roster_id": 11,
+                            "is_traded": true,
+                            "owner_id": 7,
+                            "pick_round": 2,
+                            "pick_number": 7,
+                            "board_spot": 7,
+                            "player_id": "13285",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "665051007910236160",
+                            "roster_id": 6,
+                            "is_traded": true,
+                            "owner_id": 9,
+                            "pick_round": 2,
+                            "pick_number": 8,
+                            "board_spot": 8,
+                            "player_id": "13268",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467132282604351488",
+                            "roster_id": 3,
+                            "is_traded": true,
+                            "owner_id": 9,
+                            "pick_round": 2,
+                            "pick_number": 9,
+                            "board_spot": 9,
+                            "player_id": null
+                        },
+                        {
+                            "user_id": "325380343328686080",
+                            "roster_id": 10,
+                            "is_traded": true,
+                            "owner_id": 2,
+                            "pick_round": 2,
+                            "pick_number": 10,
+                            "board_spot": 10,
+                            "player_id": null
+                        },
+                        {
+                            "user_id": "560984104439771136",
+                            "roster_id": 12,
+                            "is_traded": true,
+                            "owner_id": 6,
+                            "pick_round": 2,
+                            "pick_number": 11,
+                            "board_spot": 11,
+                            "player_id": null
+                        },
+                        {
+                            "user_id": "464153930528452608",
+                            "roster_id": 7,
+                            "is_traded": true,
+                            "owner_id": 1,
+                            "pick_round": 2,
+                            "pick_number": 12,
+                            "board_spot": 12,
+                            "player_id": null
+                        }
+                    ]
+                },
+                {
+                    "round": 3,
+                    "picks": [
+                        {
+                            "user_id": "989213899293569024",
+                            "roster_id": 5,
+                            "is_traded": true,
+                            "owner_id": 7,
+                            "pick_round": 3,
+                            "pick_number": 1,
+                            "board_spot": 1,
+                            "player_id": null
+                        },
+                        {
+                            "user_id": "999040645685649408",
+                            "roster_id": 8,
+                            "is_traded": false,
+                            "owner_id": 8,
+                            "pick_round": 3,
+                            "pick_number": 2,
+                            "board_spot": 2,
+                            "player_id": null
+                        },
+                        {
+                            "user_id": "521035584588267520",
+                            "roster_id": 1,
+                            "is_traded": false,
+                            "owner_id": 1,
+                            "pick_round": 3,
+                            "pick_number": 3,
+                            "board_spot": 3,
+                            "player_id": null
+                        },
+                        {
+                            "user_id": "467766220007927808",
+                            "roster_id": 9,
+                            "is_traded": false,
+                            "owner_id": 9,
+                            "pick_round": 3,
+                            "pick_number": 4,
+                            "board_spot": 4,
+                            "player_id": null
+                        },
+                        {
+                            "user_id": "521424042611961856",
+                            "roster_id": 2,
+                            "is_traded": false,
+                            "owner_id": 2,
+                            "pick_round": 3,
+                            "pick_number": 5,
+                            "board_spot": 5,
+                            "player_id": null
+                        },
+                        {
+                            "user_id": "521485413219885056",
+                            "roster_id": 4,
+                            "is_traded": false,
+                            "owner_id": 4,
+                            "pick_round": 3,
+                            "pick_number": 6,
+                            "board_spot": 6,
+                            "player_id": null
+                        },
+                        {
+                            "user_id": "325371992242946048",
+                            "roster_id": 11,
+                            "is_traded": true,
+                            "owner_id": 5,
+                            "pick_round": 3,
+                            "pick_number": 7,
+                            "board_spot": 7,
+                            "player_id": null
+                        },
+                        {
+                            "user_id": "665051007910236160",
+                            "roster_id": 6,
+                            "is_traded": false,
+                            "owner_id": 6,
+                            "pick_round": 3,
+                            "pick_number": 8,
+                            "board_spot": 8,
+                            "player_id": null
+                        },
+                        {
+                            "user_id": "467132282604351488",
+                            "roster_id": 3,
+                            "is_traded": false,
+                            "owner_id": 3,
+                            "pick_round": 3,
+                            "pick_number": 9,
+                            "board_spot": 9,
+                            "player_id": null
+                        },
+                        {
+                            "user_id": "325380343328686080",
+                            "roster_id": 10,
+                            "is_traded": false,
+                            "owner_id": 10,
+                            "pick_round": 3,
+                            "pick_number": 10,
+                            "board_spot": 10,
+                            "player_id": null
+                        },
+                        {
+                            "user_id": "560984104439771136",
+                            "roster_id": 12,
+                            "is_traded": true,
+                            "owner_id": 5,
+                            "pick_round": 3,
+                            "pick_number": 11,
+                            "board_spot": 11,
+                            "player_id": null
+                        },
+                        {
+                            "user_id": "464153930528452608",
+                            "roster_id": 7,
+                            "is_traded": true,
+                            "owner_id": 4,
+                            "pick_round": 3,
+                            "pick_number": 12,
+                            "board_spot": 12,
+                            "player_id": null
+                        }
+                    ]
+                },
+                {
+                    "round": 4,
+                    "picks": [
+                        {
+                            "user_id": "989213899293569024",
+                            "roster_id": 5,
+                            "is_traded": false,
+                            "owner_id": 5,
+                            "pick_round": 4,
+                            "pick_number": 1,
+                            "board_spot": 1,
+                            "player_id": null
+                        },
+                        {
+                            "user_id": "999040645685649408",
+                            "roster_id": 8,
+                            "is_traded": false,
+                            "owner_id": 8,
+                            "pick_round": 4,
+                            "pick_number": 2,
+                            "board_spot": 2,
+                            "player_id": null
+                        },
+                        {
+                            "user_id": "521035584588267520",
+                            "roster_id": 1,
+                            "is_traded": false,
+                            "owner_id": 1,
+                            "pick_round": 4,
+                            "pick_number": 3,
+                            "board_spot": 3,
+                            "player_id": null
+                        },
+                        {
+                            "user_id": "467766220007927808",
+                            "roster_id": 9,
+                            "is_traded": true,
+                            "owner_id": 5,
+                            "pick_round": 4,
+                            "pick_number": 4,
+                            "board_spot": 4,
+                            "player_id": null
+                        },
+                        {
+                            "user_id": "521424042611961856",
+                            "roster_id": 2,
+                            "is_traded": false,
+                            "owner_id": 2,
+                            "pick_round": 4,
+                            "pick_number": 5,
+                            "board_spot": 5,
+                            "player_id": null
+                        },
+                        {
+                            "user_id": "521485413219885056",
+                            "roster_id": 4,
+                            "is_traded": true,
+                            "owner_id": 12,
+                            "pick_round": 4,
+                            "pick_number": 6,
+                            "board_spot": 6,
+                            "player_id": null
+                        },
+                        {
+                            "user_id": "325371992242946048",
+                            "roster_id": 11,
+                            "is_traded": false,
+                            "owner_id": 11,
+                            "pick_round": 4,
+                            "pick_number": 7,
+                            "board_spot": 7,
+                            "player_id": null
+                        },
+                        {
+                            "user_id": "665051007910236160",
+                            "roster_id": 6,
+                            "is_traded": false,
+                            "owner_id": 6,
+                            "pick_round": 4,
+                            "pick_number": 8,
+                            "board_spot": 8,
+                            "player_id": null
+                        },
+                        {
+                            "user_id": "467132282604351488",
+                            "roster_id": 3,
+                            "is_traded": true,
+                            "owner_id": 9,
+                            "pick_round": 4,
+                            "pick_number": 9,
+                            "board_spot": 9,
+                            "player_id": null
+                        },
+                        {
+                            "user_id": "325380343328686080",
+                            "roster_id": 10,
+                            "is_traded": false,
+                            "owner_id": 10,
+                            "pick_round": 4,
+                            "pick_number": 10,
+                            "board_spot": 10,
+                            "player_id": null
+                        },
+                        {
+                            "user_id": "560984104439771136",
+                            "roster_id": 12,
+                            "is_traded": false,
+                            "owner_id": 12,
+                            "pick_round": 4,
+                            "pick_number": 11,
+                            "board_spot": 11,
+                            "player_id": null
+                        },
+                        {
+                            "user_id": "464153930528452608",
+                            "roster_id": 7,
+                            "is_traded": false,
+                            "owner_id": 7,
+                            "pick_round": 4,
+                            "pick_number": 12,
+                            "board_spot": 12,
+                            "player_id": null
+                        }
+                    ]
+                }
+            ],
+            "player_pool": "Rookie"
+        },
+        "playerInfo": {
+            "4984": {
+                "player_id": "4984",
+                "first_name": "Josh",
+                "last_name": "Allen",
+                "full_name": "Josh Allen",
+                "team": "BUF",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 1,
+                "years_exp": 8,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "6813": {
+                "player_id": "6813",
+                "first_name": "Jonathan",
+                "last_name": "Taylor",
+                "full_name": "Jonathan Taylor",
+                "team": "IND",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 4,
+                "years_exp": 6,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "7564": {
+                "player_id": "7564",
+                "first_name": "Ja'Marr",
+                "last_name": "Chase",
+                "full_name": "Ja'Marr Chase",
+                "team": "CIN",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 3,
+                "years_exp": 5,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "9221": {
+                "player_id": "9221",
+                "first_name": "Jahmyr",
+                "last_name": "Gibbs",
+                "full_name": "Jahmyr Gibbs",
+                "team": "DET",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 2,
+                "years_exp": 3,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "9509": {
+                "player_id": "9509",
+                "first_name": "Bijan",
+                "last_name": "Robinson",
+                "full_name": "Bijan Robinson",
+                "team": "ATL",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 1,
+                "years_exp": 3,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "11564": {
+                "player_id": "11564",
+                "first_name": "Drake",
+                "last_name": "Maye",
+                "full_name": "Drake Maye",
+                "team": "NE",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 3,
+                "years_exp": 2,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13268": {
+                "player_id": "13268",
+                "first_name": "Elijah",
+                "last_name": "Sarratt",
+                "full_name": "Elijah Sarratt",
+                "team": "BAL",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 201,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "gdavidson",
+                "in_lineup": false
+            },
+            "13269": {
+                "player_id": "13269",
+                "first_name": "Fernando",
+                "last_name": "Mendoza",
+                "full_name": "Fernando Mendoza",
+                "team": "LV",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 39,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "cmurtagh86",
+                "in_lineup": false
+            },
+            "13272": {
+                "player_id": "13272",
+                "first_name": "Carson",
+                "last_name": "Beck",
+                "full_name": "Carson Beck",
+                "team": "ARI",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 416,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13274": {
+                "player_id": "13274",
+                "first_name": "Germie",
+                "last_name": "Bernard",
+                "full_name": "Germie Bernard",
+                "team": "PIT",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 194,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13275": {
+                "player_id": "13275",
+                "first_name": "Ty",
+                "last_name": "Simpson",
+                "full_name": "Ty Simpson",
+                "team": "LAR",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 141,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13276": {
+                "player_id": "13276",
+                "first_name": "Omar",
+                "last_name": "Cooper",
+                "full_name": "Omar Cooper",
+                "team": "NYJ",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 146,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13278": {
+                "player_id": "13278",
+                "first_name": "Max",
+                "last_name": "Klare",
+                "full_name": "Max Klare",
+                "team": "LAR",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 212,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13279": {
+                "player_id": "13279",
+                "first_name": "Carnell",
+                "last_name": "Tate",
+                "full_name": "Carnell Tate",
+                "team": "TEN",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 61,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13281": {
+                "player_id": "13281",
+                "first_name": "Jordyn",
+                "last_name": "Tyson",
+                "full_name": "Jordyn Tyson",
+                "team": "NO",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 69,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13285": {
+                "player_id": "13285",
+                "first_name": "Malachi",
+                "last_name": "Fields",
+                "full_name": "Malachi Fields",
+                "team": "NYG",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 210,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "crbiehl",
+                "in_lineup": false
+            },
+            "13286": {
+                "player_id": "13286",
+                "first_name": "Jadarian",
+                "last_name": "Price",
+                "full_name": "Jadarian Price",
+                "team": "SEA",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 63,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13287": {
+                "player_id": "13287",
+                "first_name": "Jeremiyah",
+                "last_name": "Love",
+                "full_name": "Jeremiyah Love",
+                "team": "ARI",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 15,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13288": {
+                "player_id": "13288",
+                "first_name": "Nicholas",
+                "last_name": "Singleton",
+                "full_name": "Nicholas Singleton",
+                "team": "TEN",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 167,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13289": {
+                "player_id": "13289",
+                "first_name": "Drew",
+                "last_name": "Allar",
+                "full_name": "Drew Allar",
+                "team": "PIT",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13293": {
+                "player_id": "13293",
+                "first_name": "Ja'Kobi",
+                "last_name": "Lane",
+                "full_name": "Ja'Kobi Lane",
+                "team": "BAL",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 182,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13294": {
+                "player_id": "13294",
+                "first_name": "Makai",
+                "last_name": "Lemon",
+                "full_name": "Makai Lemon",
+                "team": "PHI",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 77,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "aphilliny21",
+                "in_lineup": false
+            },
+            "13296": {
+                "player_id": "13296",
+                "first_name": "Caleb",
+                "last_name": "Douglas",
+                "full_name": "Caleb Douglas",
+                "team": "MIA",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13298": {
+                "player_id": "13298",
+                "first_name": "KC",
+                "last_name": "Concepcion",
+                "full_name": "KC Concepcion",
+                "team": "CLE",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 116,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13301": {
+                "player_id": "13301",
+                "first_name": "Antonio",
+                "last_name": "Williams",
+                "full_name": "Antonio Williams",
+                "team": "WAS",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 156,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13302": {
+                "player_id": "13302",
+                "first_name": "Adam",
+                "last_name": "Randall",
+                "full_name": "Adam Randall",
+                "team": "BAL",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13303": {
+                "player_id": "13303",
+                "first_name": "Cade",
+                "last_name": "Klubnik",
+                "full_name": "Cade Klubnik",
+                "team": "NYJ",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 398,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13305": {
+                "player_id": "13305",
+                "first_name": "Mike",
+                "last_name": "Washington",
+                "full_name": "Mike Washington",
+                "team": "LV",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 139,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13306": {
+                "player_id": "13306",
+                "first_name": "Taylen",
+                "last_name": "Green",
+                "full_name": "Taylen Green",
+                "team": "CLE",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13311": {
+                "player_id": "13311",
+                "first_name": "Chris",
+                "last_name": "Bell",
+                "full_name": "Chris Bell",
+                "team": "MIA",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 203,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "cmurtagh86",
+                "in_lineup": false
+            },
+            "13317": {
+                "player_id": "13317",
+                "first_name": "Ted",
+                "last_name": "Hurst",
+                "full_name": "Ted Hurst",
+                "team": "TB",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 196,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13319": {
+                "player_id": "13319",
+                "first_name": "Oscar",
+                "last_name": "Delp",
+                "full_name": "Oscar Delp",
+                "team": "NO",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13320": {
+                "player_id": "13320",
+                "first_name": "Zachariah",
+                "last_name": "Branch",
+                "full_name": "Zachariah Branch",
+                "team": "ATL",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 180,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13330": {
+                "player_id": "13330",
+                "first_name": "Kenyon",
+                "last_name": "Sadiq",
+                "full_name": "Kenyon Sadiq",
+                "team": "NYJ",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 109,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "crbiehl",
+                "in_lineup": false
+            },
+            "13333": {
+                "player_id": "13333",
+                "first_name": "Deion",
+                "last_name": "Burks",
+                "full_name": "Deion Burks",
+                "team": "IND",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13337": {
+                "player_id": "13337",
+                "first_name": "Emmett",
+                "last_name": "Johnson",
+                "full_name": "Emmett Johnson",
+                "team": "KC",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 113,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "gdavidson",
+                "in_lineup": false
+            },
+            "13338": {
+                "player_id": "13338",
+                "first_name": "Kevin",
+                "last_name": "Coleman",
+                "full_name": "Kevin Coleman",
+                "team": "MIA",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13345": {
+                "player_id": "13345",
+                "first_name": "Jonah",
+                "last_name": "Coleman",
+                "full_name": "Jonah Coleman",
+                "team": "DEN",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 118,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "OptimalPooper",
+                "in_lineup": false
+            },
+            "13346": {
+                "player_id": "13346",
+                "first_name": "Denzel",
+                "last_name": "Boston",
+                "full_name": "Denzel Boston",
+                "team": "CLE",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 144,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13347": {
+                "player_id": "13347",
+                "first_name": "Demond",
+                "last_name": "Claiborne",
+                "full_name": "Demond Claiborne",
+                "team": "MIN",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 176,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13348": {
+                "player_id": "13348",
+                "first_name": "J'Mari",
+                "last_name": "Taylor",
+                "full_name": "J'Mari Taylor",
+                "team": "JAX",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13349": {
+                "player_id": "13349",
+                "first_name": "Eli",
+                "last_name": "Stowers",
+                "full_name": "Eli Stowers",
+                "team": "PHI",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 140,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13353": {
+                "player_id": "13353",
+                "first_name": "Chris",
+                "last_name": "Brazzell",
+                "full_name": "Chris Brazzell",
+                "team": "CAR",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 202,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13380": {
+                "player_id": "13380",
+                "first_name": "Brenen",
+                "last_name": "Thompson",
+                "full_name": "Brenen Thompson",
+                "team": "LAC",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13400": {
+                "player_id": "13400",
+                "first_name": "Justin",
+                "last_name": "Joly",
+                "full_name": "Justin Joly",
+                "team": "DEN",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13402": {
+                "player_id": "13402",
+                "first_name": "Skyler",
+                "last_name": "Bell",
+                "full_name": "Skyler Bell",
+                "team": "BUF",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13403": {
+                "player_id": "13403",
+                "first_name": "Jam",
+                "last_name": "Miller",
+                "full_name": "Jam Miller",
+                "team": "NE",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13404": {
+                "player_id": "13404",
+                "first_name": "Garrett",
+                "last_name": "Nussmeier",
+                "full_name": "Garrett Nussmeier",
+                "team": "KC",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 329,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13405": {
+                "player_id": "13405",
+                "first_name": "Kaytron",
+                "last_name": "Allen",
+                "full_name": "Kaytron Allen",
+                "team": "WAS",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 157,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13414": {
+                "player_id": "13414",
+                "first_name": "Kaelon",
+                "last_name": "Black",
+                "full_name": "Kaelon Black",
+                "team": "SF",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13417": {
+                "player_id": "13417",
+                "first_name": "De'Zhaun",
+                "last_name": "Stribling",
+                "full_name": "De'Zhaun Stribling",
+                "team": "SF",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 202,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13420": {
+                "player_id": "13420",
+                "first_name": "Bryce",
+                "last_name": "Lance",
+                "full_name": "Bryce Lance",
+                "team": "NO",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13421": {
+                "player_id": "13421",
+                "first_name": "Eli",
+                "last_name": "Raridon",
+                "full_name": "Eli Raridon",
+                "team": "NE",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13423": {
+                "player_id": "13423",
+                "first_name": "Eli",
+                "last_name": "Heidenreich",
+                "full_name": "Eli Heidenreich",
+                "team": "PIT",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            }
+        }
+    },
+    "linearFromClean": {
+        "liveDraft": {
+            "type": "linear",
+            "settings": {
+                "rounds": 4,
+                "player_type": 1
+            },
+            "slot_to_roster_id": {
+                "1": 5,
+                "2": 8,
+                "3": 1,
+                "4": 9,
+                "5": 2,
+                "6": 4,
+                "7": 11,
+                "8": 6,
+                "9": 3,
+                "10": 10,
+                "11": 12,
+                "12": 7
+            },
+            "built_draft": [
+                {
+                    "round": 1,
+                    "picks": [
+                        {
+                            "user_id": "989213899293569024",
+                            "roster_id": 5,
+                            "is_traded": false,
+                            "owner_id": 5,
+                            "pick_round": 1,
+                            "pick_number": 1,
+                            "board_spot": 1,
+                            "player_id": "13287",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "999040645685649408",
+                            "roster_id": 8,
+                            "is_traded": false,
+                            "owner_id": 8,
+                            "pick_round": 1,
+                            "pick_number": 2,
+                            "board_spot": 2,
+                            "player_id": "13269",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521035584588267520",
+                            "roster_id": 1,
+                            "is_traded": false,
+                            "owner_id": 1,
+                            "pick_round": 1,
+                            "pick_number": 3,
+                            "board_spot": 3,
+                            "player_id": "13279",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467766220007927808",
+                            "roster_id": 9,
+                            "is_traded": true,
+                            "owner_id": 6,
+                            "pick_round": 1,
+                            "pick_number": 4,
+                            "board_spot": 4,
+                            "player_id": "13281",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521424042611961856",
+                            "roster_id": 2,
+                            "is_traded": false,
+                            "owner_id": 2,
+                            "pick_round": 1,
+                            "pick_number": 5,
+                            "board_spot": 5,
+                            "player_id": "13294",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521485413219885056",
+                            "roster_id": 4,
+                            "is_traded": false,
+                            "owner_id": 4,
+                            "pick_round": 1,
+                            "pick_number": 6,
+                            "board_spot": 6,
+                            "player_id": "13286",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325371992242946048",
+                            "roster_id": 11,
+                            "is_traded": true,
+                            "owner_id": 4,
+                            "pick_round": 1,
+                            "pick_number": 7,
+                            "board_spot": 7,
+                            "player_id": "13298",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "665051007910236160",
+                            "roster_id": 6,
+                            "is_traded": true,
+                            "owner_id": 4,
+                            "pick_round": 1,
+                            "pick_number": 8,
+                            "board_spot": 8,
+                            "player_id": "13275",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467132282604351488",
+                            "roster_id": 3,
+                            "is_traded": false,
+                            "owner_id": 3,
+                            "pick_round": 1,
+                            "pick_number": 9,
+                            "board_spot": 9,
+                            "player_id": "13345",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325380343328686080",
+                            "roster_id": 10,
+                            "is_traded": true,
+                            "owner_id": 7,
+                            "pick_round": 1,
+                            "pick_number": 10,
+                            "board_spot": 10,
+                            "player_id": "13330",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "560984104439771136",
+                            "roster_id": 12,
+                            "is_traded": true,
+                            "owner_id": 5,
+                            "pick_round": 1,
+                            "pick_number": 11,
+                            "board_spot": 11,
+                            "player_id": "13276",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "464153930528452608",
+                            "roster_id": 7,
+                            "is_traded": true,
+                            "owner_id": 1,
+                            "pick_round": 1,
+                            "pick_number": 12,
+                            "board_spot": 12,
+                            "player_id": "13346",
+                            "picked": true
+                        }
+                    ]
+                },
+                {
+                    "round": 2,
+                    "picks": [
+                        {
+                            "user_id": "989213899293569024",
+                            "roster_id": 5,
+                            "is_traded": false,
+                            "owner_id": 5,
+                            "pick_round": 2,
+                            "pick_number": 1,
+                            "board_spot": 1,
+                            "player_id": "13349",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "999040645685649408",
+                            "roster_id": 8,
+                            "is_traded": false,
+                            "owner_id": 8,
+                            "pick_round": 2,
+                            "pick_number": 2,
+                            "board_spot": 2,
+                            "player_id": "13311",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521035584588267520",
+                            "roster_id": 1,
+                            "is_traded": false,
+                            "owner_id": 1,
+                            "pick_round": 2,
+                            "pick_number": 3,
+                            "board_spot": 3,
+                            "player_id": "13288",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467766220007927808",
+                            "roster_id": 9,
+                            "is_traded": false,
+                            "owner_id": 9,
+                            "pick_round": 2,
+                            "pick_number": 4,
+                            "board_spot": 4,
+                            "player_id": "13337",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521424042611961856",
+                            "roster_id": 2,
+                            "is_traded": true,
+                            "owner_id": 6,
+                            "pick_round": 2,
+                            "pick_number": 5,
+                            "board_spot": 5,
+                            "player_id": "13320",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521485413219885056",
+                            "roster_id": 4,
+                            "is_traded": true,
+                            "owner_id": 6,
+                            "pick_round": 2,
+                            "pick_number": 6,
+                            "board_spot": 6,
+                            "player_id": "13301",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325371992242946048",
+                            "roster_id": 11,
+                            "is_traded": true,
+                            "owner_id": 7,
+                            "pick_round": 2,
+                            "pick_number": 7,
+                            "board_spot": 7,
+                            "player_id": "13285",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "665051007910236160",
+                            "roster_id": 6,
+                            "is_traded": true,
+                            "owner_id": 9,
+                            "pick_round": 2,
+                            "pick_number": 8,
+                            "board_spot": 8,
+                            "player_id": "13268",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467132282604351488",
+                            "roster_id": 3,
+                            "is_traded": true,
+                            "owner_id": 9,
+                            "pick_round": 2,
+                            "pick_number": 9,
+                            "board_spot": 9,
+                            "player_id": "13353",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325380343328686080",
+                            "roster_id": 10,
+                            "is_traded": true,
+                            "owner_id": 2,
+                            "pick_round": 2,
+                            "pick_number": 10,
+                            "board_spot": 10,
+                            "player_id": "13272",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "560984104439771136",
+                            "roster_id": 12,
+                            "is_traded": true,
+                            "owner_id": 6,
+                            "pick_round": 2,
+                            "pick_number": 11,
+                            "board_spot": 11,
+                            "player_id": "13417",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "464153930528452608",
+                            "roster_id": 7,
+                            "is_traded": true,
+                            "owner_id": 1,
+                            "pick_round": 2,
+                            "pick_number": 12,
+                            "board_spot": 12,
+                            "player_id": "13274",
+                            "picked": true
+                        }
+                    ]
+                },
+                {
+                    "round": 3,
+                    "picks": [
+                        {
+                            "user_id": "989213899293569024",
+                            "roster_id": 5,
+                            "is_traded": true,
+                            "owner_id": 7,
+                            "pick_round": 3,
+                            "pick_number": 1,
+                            "board_spot": 1,
+                            "player_id": "13402",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "999040645685649408",
+                            "roster_id": 8,
+                            "is_traded": false,
+                            "owner_id": 8,
+                            "pick_round": 3,
+                            "pick_number": 2,
+                            "board_spot": 2,
+                            "player_id": "13305",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521035584588267520",
+                            "roster_id": 1,
+                            "is_traded": false,
+                            "owner_id": 1,
+                            "pick_round": 3,
+                            "pick_number": 3,
+                            "board_spot": 3,
+                            "player_id": "13405",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467766220007927808",
+                            "roster_id": 9,
+                            "is_traded": false,
+                            "owner_id": 9,
+                            "pick_round": 3,
+                            "pick_number": 4,
+                            "board_spot": 4,
+                            "player_id": "13293",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521424042611961856",
+                            "roster_id": 2,
+                            "is_traded": false,
+                            "owner_id": 2,
+                            "pick_round": 3,
+                            "pick_number": 5,
+                            "board_spot": 5,
+                            "player_id": "13317",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521485413219885056",
+                            "roster_id": 4,
+                            "is_traded": false,
+                            "owner_id": 4,
+                            "pick_round": 3,
+                            "pick_number": 6,
+                            "board_spot": 6,
+                            "player_id": "13302",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325371992242946048",
+                            "roster_id": 11,
+                            "is_traded": true,
+                            "owner_id": 5,
+                            "pick_round": 3,
+                            "pick_number": 7,
+                            "board_spot": 7,
+                            "player_id": "13347",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "665051007910236160",
+                            "roster_id": 6,
+                            "is_traded": false,
+                            "owner_id": 6,
+                            "pick_round": 3,
+                            "pick_number": 8,
+                            "board_spot": 8,
+                            "player_id": "13278",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467132282604351488",
+                            "roster_id": 3,
+                            "is_traded": false,
+                            "owner_id": 3,
+                            "pick_round": 3,
+                            "pick_number": 9,
+                            "board_spot": 9,
+                            "player_id": "13380",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325380343328686080",
+                            "roster_id": 10,
+                            "is_traded": false,
+                            "owner_id": 10,
+                            "pick_round": 3,
+                            "pick_number": 10,
+                            "board_spot": 10,
+                            "player_id": "13414",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "560984104439771136",
+                            "roster_id": 12,
+                            "is_traded": true,
+                            "owner_id": 5,
+                            "pick_round": 3,
+                            "pick_number": 11,
+                            "board_spot": 11,
+                            "player_id": "13289",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "464153930528452608",
+                            "roster_id": 7,
+                            "is_traded": true,
+                            "owner_id": 4,
+                            "pick_round": 3,
+                            "pick_number": 12,
+                            "board_spot": 12,
+                            "player_id": "13420",
+                            "picked": true
+                        }
+                    ]
+                },
+                {
+                    "round": 4,
+                    "picks": [
+                        {
+                            "user_id": "989213899293569024",
+                            "roster_id": 5,
+                            "is_traded": false,
+                            "owner_id": 5,
+                            "pick_round": 4,
+                            "pick_number": 1,
+                            "board_spot": 1,
+                            "player_id": "13296",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "999040645685649408",
+                            "roster_id": 8,
+                            "is_traded": false,
+                            "owner_id": 8,
+                            "pick_round": 4,
+                            "pick_number": 2,
+                            "board_spot": 2,
+                            "player_id": "13404",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521035584588267520",
+                            "roster_id": 1,
+                            "is_traded": false,
+                            "owner_id": 1,
+                            "pick_round": 4,
+                            "pick_number": 3,
+                            "board_spot": 3,
+                            "player_id": "13421",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467766220007927808",
+                            "roster_id": 9,
+                            "is_traded": true,
+                            "owner_id": 5,
+                            "pick_round": 4,
+                            "pick_number": 4,
+                            "board_spot": 4,
+                            "player_id": "13306",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521424042611961856",
+                            "roster_id": 2,
+                            "is_traded": false,
+                            "owner_id": 2,
+                            "pick_round": 4,
+                            "pick_number": 5,
+                            "board_spot": 5,
+                            "player_id": "13319",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "521485413219885056",
+                            "roster_id": 4,
+                            "is_traded": true,
+                            "owner_id": 12,
+                            "pick_round": 4,
+                            "pick_number": 6,
+                            "board_spot": 6,
+                            "player_id": "13400",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325371992242946048",
+                            "roster_id": 11,
+                            "is_traded": false,
+                            "owner_id": 11,
+                            "pick_round": 4,
+                            "pick_number": 7,
+                            "board_spot": 7,
+                            "player_id": "13338",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "665051007910236160",
+                            "roster_id": 6,
+                            "is_traded": false,
+                            "owner_id": 6,
+                            "pick_round": 4,
+                            "pick_number": 8,
+                            "board_spot": 8,
+                            "player_id": "13333",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "467132282604351488",
+                            "roster_id": 3,
+                            "is_traded": true,
+                            "owner_id": 9,
+                            "pick_round": 4,
+                            "pick_number": 9,
+                            "board_spot": 9,
+                            "player_id": "13303",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "325380343328686080",
+                            "roster_id": 10,
+                            "is_traded": false,
+                            "owner_id": 10,
+                            "pick_round": 4,
+                            "pick_number": 10,
+                            "board_spot": 10,
+                            "player_id": "13423",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "560984104439771136",
+                            "roster_id": 12,
+                            "is_traded": false,
+                            "owner_id": 12,
+                            "pick_round": 4,
+                            "pick_number": 11,
+                            "board_spot": 11,
+                            "player_id": "13348",
+                            "picked": true
+                        },
+                        {
+                            "user_id": "464153930528452608",
+                            "roster_id": 7,
+                            "is_traded": false,
+                            "owner_id": 7,
+                            "pick_round": 4,
+                            "pick_number": 12,
+                            "board_spot": 12,
+                            "player_id": "13403",
+                            "picked": true
+                        }
+                    ]
+                }
+            ],
+            "player_pool": "Rookie"
+        },
+        "playerInfo": {
+            "4984": {
+                "player_id": "4984",
+                "first_name": "Josh",
+                "last_name": "Allen",
+                "full_name": "Josh Allen",
+                "team": "BUF",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 1,
+                "years_exp": 8,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "6813": {
+                "player_id": "6813",
+                "first_name": "Jonathan",
+                "last_name": "Taylor",
+                "full_name": "Jonathan Taylor",
+                "team": "IND",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 4,
+                "years_exp": 6,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "7564": {
+                "player_id": "7564",
+                "first_name": "Ja'Marr",
+                "last_name": "Chase",
+                "full_name": "Ja'Marr Chase",
+                "team": "CIN",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 3,
+                "years_exp": 5,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "9221": {
+                "player_id": "9221",
+                "first_name": "Jahmyr",
+                "last_name": "Gibbs",
+                "full_name": "Jahmyr Gibbs",
+                "team": "DET",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 2,
+                "years_exp": 3,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "9509": {
+                "player_id": "9509",
+                "first_name": "Bijan",
+                "last_name": "Robinson",
+                "full_name": "Bijan Robinson",
+                "team": "ATL",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 1,
+                "years_exp": 3,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "11564": {
+                "player_id": "11564",
+                "first_name": "Drake",
+                "last_name": "Maye",
+                "full_name": "Drake Maye",
+                "team": "NE",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 3,
+                "years_exp": 2,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13268": {
+                "player_id": "13268",
+                "first_name": "Elijah",
+                "last_name": "Sarratt",
+                "full_name": "Elijah Sarratt",
+                "team": "BAL",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 201,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "gdavidson",
+                "in_lineup": false
+            },
+            "13269": {
+                "player_id": "13269",
+                "first_name": "Fernando",
+                "last_name": "Mendoza",
+                "full_name": "Fernando Mendoza",
+                "team": "LV",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 39,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "cmurtagh86",
+                "in_lineup": false
+            },
+            "13272": {
+                "player_id": "13272",
+                "first_name": "Carson",
+                "last_name": "Beck",
+                "full_name": "Carson Beck",
+                "team": "ARI",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 416,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "aphilliny21",
+                "in_lineup": false
+            },
+            "13274": {
+                "player_id": "13274",
+                "first_name": "Germie",
+                "last_name": "Bernard",
+                "full_name": "Germie Bernard",
+                "team": "PIT",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 194,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13275": {
+                "player_id": "13275",
+                "first_name": "Ty",
+                "last_name": "Simpson",
+                "full_name": "Ty Simpson",
+                "team": "LAR",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 141,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13276": {
+                "player_id": "13276",
+                "first_name": "Omar",
+                "last_name": "Cooper",
+                "full_name": "Omar Cooper",
+                "team": "NYJ",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 146,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13278": {
+                "player_id": "13278",
+                "first_name": "Max",
+                "last_name": "Klare",
+                "full_name": "Max Klare",
+                "team": "LAR",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 212,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13279": {
+                "player_id": "13279",
+                "first_name": "Carnell",
+                "last_name": "Tate",
+                "full_name": "Carnell Tate",
+                "team": "TEN",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 61,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13281": {
+                "player_id": "13281",
+                "first_name": "Jordyn",
+                "last_name": "Tyson",
+                "full_name": "Jordyn Tyson",
+                "team": "NO",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 69,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13285": {
+                "player_id": "13285",
+                "first_name": "Malachi",
+                "last_name": "Fields",
+                "full_name": "Malachi Fields",
+                "team": "NYG",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 210,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "crbiehl",
+                "in_lineup": false
+            },
+            "13286": {
+                "player_id": "13286",
+                "first_name": "Jadarian",
+                "last_name": "Price",
+                "full_name": "Jadarian Price",
+                "team": "SEA",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 63,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13287": {
+                "player_id": "13287",
+                "first_name": "Jeremiyah",
+                "last_name": "Love",
+                "full_name": "Jeremiyah Love",
+                "team": "ARI",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 15,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13288": {
+                "player_id": "13288",
+                "first_name": "Nicholas",
+                "last_name": "Singleton",
+                "full_name": "Nicholas Singleton",
+                "team": "TEN",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 167,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13289": {
+                "player_id": "13289",
+                "first_name": "Drew",
+                "last_name": "Allar",
+                "full_name": "Drew Allar",
+                "team": "PIT",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13293": {
+                "player_id": "13293",
+                "first_name": "Ja'Kobi",
+                "last_name": "Lane",
+                "full_name": "Ja'Kobi Lane",
+                "team": "BAL",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 182,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "gdavidson",
+                "in_lineup": false
+            },
+            "13294": {
+                "player_id": "13294",
+                "first_name": "Makai",
+                "last_name": "Lemon",
+                "full_name": "Makai Lemon",
+                "team": "PHI",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 77,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "aphilliny21",
+                "in_lineup": false
+            },
+            "13296": {
+                "player_id": "13296",
+                "first_name": "Caleb",
+                "last_name": "Douglas",
+                "full_name": "Caleb Douglas",
+                "team": "MIA",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13298": {
+                "player_id": "13298",
+                "first_name": "KC",
+                "last_name": "Concepcion",
+                "full_name": "KC Concepcion",
+                "team": "CLE",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 116,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13301": {
+                "player_id": "13301",
+                "first_name": "Antonio",
+                "last_name": "Williams",
+                "full_name": "Antonio Williams",
+                "team": "WAS",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 156,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13302": {
+                "player_id": "13302",
+                "first_name": "Adam",
+                "last_name": "Randall",
+                "full_name": "Adam Randall",
+                "team": "BAL",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13303": {
+                "player_id": "13303",
+                "first_name": "Cade",
+                "last_name": "Klubnik",
+                "full_name": "Cade Klubnik",
+                "team": "NYJ",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 398,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "gdavidson",
+                "in_lineup": false
+            },
+            "13305": {
+                "player_id": "13305",
+                "first_name": "Mike",
+                "last_name": "Washington",
+                "full_name": "Mike Washington",
+                "team": "LV",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 139,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "cmurtagh86",
+                "in_lineup": false
+            },
+            "13306": {
+                "player_id": "13306",
+                "first_name": "Taylen",
+                "last_name": "Green",
+                "full_name": "Taylen Green",
+                "team": "CLE",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13311": {
+                "player_id": "13311",
+                "first_name": "Chris",
+                "last_name": "Bell",
+                "full_name": "Chris Bell",
+                "team": "MIA",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 203,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "cmurtagh86",
+                "in_lineup": false
+            },
+            "13317": {
+                "player_id": "13317",
+                "first_name": "Ted",
+                "last_name": "Hurst",
+                "full_name": "Ted Hurst",
+                "team": "TB",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 196,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "aphilliny21",
+                "in_lineup": false
+            },
+            "13319": {
+                "player_id": "13319",
+                "first_name": "Oscar",
+                "last_name": "Delp",
+                "full_name": "Oscar Delp",
+                "team": "NO",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "aphilliny21",
+                "in_lineup": false
+            },
+            "13320": {
+                "player_id": "13320",
+                "first_name": "Zachariah",
+                "last_name": "Branch",
+                "full_name": "Zachariah Branch",
+                "team": "ATL",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 180,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13330": {
+                "player_id": "13330",
+                "first_name": "Kenyon",
+                "last_name": "Sadiq",
+                "full_name": "Kenyon Sadiq",
+                "team": "NYJ",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 109,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "crbiehl",
+                "in_lineup": false
+            },
+            "13333": {
+                "player_id": "13333",
+                "first_name": "Deion",
+                "last_name": "Burks",
+                "full_name": "Deion Burks",
+                "team": "IND",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13337": {
+                "player_id": "13337",
+                "first_name": "Emmett",
+                "last_name": "Johnson",
+                "full_name": "Emmett Johnson",
+                "team": "KC",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 113,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "gdavidson",
+                "in_lineup": false
+            },
+            "13338": {
+                "player_id": "13338",
+                "first_name": "Kevin",
+                "last_name": "Coleman",
+                "full_name": "Kevin Coleman",
+                "team": "MIA",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "kpresley",
+                "in_lineup": false
+            },
+            "13345": {
+                "player_id": "13345",
+                "first_name": "Jonah",
+                "last_name": "Coleman",
+                "full_name": "Jonah Coleman",
+                "team": "DEN",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 118,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "OptimalPooper",
+                "in_lineup": false
+            },
+            "13346": {
+                "player_id": "13346",
+                "first_name": "Denzel",
+                "last_name": "Boston",
+                "full_name": "Denzel Boston",
+                "team": "CLE",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 144,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13347": {
+                "player_id": "13347",
+                "first_name": "Demond",
+                "last_name": "Claiborne",
+                "full_name": "Demond Claiborne",
+                "team": "MIN",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 176,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13348": {
+                "player_id": "13348",
+                "first_name": "J'Mari",
+                "last_name": "Taylor",
+                "full_name": "J'Mari Taylor",
+                "team": "JAX",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "MaddensWok",
+                "in_lineup": false
+            },
+            "13349": {
+                "player_id": "13349",
+                "first_name": "Eli",
+                "last_name": "Stowers",
+                "full_name": "Eli Stowers",
+                "team": "PHI",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 140,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13353": {
+                "player_id": "13353",
+                "first_name": "Chris",
+                "last_name": "Brazzell",
+                "full_name": "Chris Brazzell",
+                "team": "CAR",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 202,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "gdavidson",
+                "in_lineup": false
+            },
+            "13380": {
+                "player_id": "13380",
+                "first_name": "Brenen",
+                "last_name": "Thompson",
+                "full_name": "Brenen Thompson",
+                "team": "LAC",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "OptimalPooper",
+                "in_lineup": false
+            },
+            "13400": {
+                "player_id": "13400",
+                "first_name": "Justin",
+                "last_name": "Joly",
+                "full_name": "Justin Joly",
+                "team": "DEN",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "MaddensWok",
+                "in_lineup": false
+            },
+            "13402": {
+                "player_id": "13402",
+                "first_name": "Skyler",
+                "last_name": "Bell",
+                "full_name": "Skyler Bell",
+                "team": "BUF",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "crbiehl",
+                "in_lineup": false
+            },
+            "13403": {
+                "player_id": "13403",
+                "first_name": "Jam",
+                "last_name": "Miller",
+                "full_name": "Jam Miller",
+                "team": "NE",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "crbiehl",
+                "in_lineup": false
+            },
+            "13404": {
+                "player_id": "13404",
+                "first_name": "Garrett",
+                "last_name": "Nussmeier",
+                "full_name": "Garrett Nussmeier",
+                "team": "KC",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 329,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "cmurtagh86",
+                "in_lineup": false
+            },
+            "13405": {
+                "player_id": "13405",
+                "first_name": "Kaytron",
+                "last_name": "Allen",
+                "full_name": "Kaytron Allen",
+                "team": "WAS",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 157,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13414": {
+                "player_id": "13414",
+                "first_name": "Kaelon",
+                "last_name": "Black",
+                "full_name": "Kaelon Black",
+                "team": "SF",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "spight",
+                "in_lineup": false
+            },
+            "13417": {
+                "player_id": "13417",
+                "first_name": "De'Zhaun",
+                "last_name": "Stribling",
+                "full_name": "De'Zhaun Stribling",
+                "team": "SF",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 202,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13420": {
+                "player_id": "13420",
+                "first_name": "Bryce",
+                "last_name": "Lance",
+                "full_name": "Bryce Lance",
+                "team": "NO",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13421": {
+                "player_id": "13421",
+                "first_name": "Eli",
+                "last_name": "Raridon",
+                "full_name": "Eli Raridon",
+                "team": "NE",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13423": {
+                "player_id": "13423",
+                "first_name": "Eli",
+                "last_name": "Heidenreich",
+                "full_name": "Eli Heidenreich",
+                "team": "PIT",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "spight",
+                "in_lineup": false
+            }
+        }
+    },
+    "manualAssign": {
+        "currentManualPick": {
+            "user_id": "521035584588267520",
+            "roster_id": 1,
+            "is_traded": false,
+            "owner_id": 1,
+            "pick_round": 1,
+            "pick_number": 3,
+            "board_spot": 3,
+            "player_id": null
+        },
+        "playerID": "4984",
+        "round": {
+            "round": 1,
+            "picks": [
+                {
+                    "user_id": "989213899293569024",
+                    "roster_id": 5,
+                    "is_traded": false,
+                    "owner_id": 5,
+                    "pick_round": 1,
+                    "pick_number": 1,
+                    "board_spot": 1,
+                    "player_id": null
+                },
+                {
+                    "user_id": "999040645685649408",
+                    "roster_id": 8,
+                    "is_traded": false,
+                    "owner_id": 8,
+                    "pick_round": 1,
+                    "pick_number": 2,
+                    "board_spot": 2,
+                    "player_id": null
+                },
+                {
+                    "user_id": "521035584588267520",
+                    "roster_id": 1,
+                    "is_traded": false,
+                    "owner_id": 1,
+                    "pick_round": 1,
+                    "pick_number": 3,
+                    "board_spot": 3,
+                    "player_id": "4984"
+                },
+                {
+                    "user_id": "467766220007927808",
+                    "roster_id": 9,
+                    "is_traded": true,
+                    "owner_id": 6,
+                    "pick_round": 1,
+                    "pick_number": 4,
+                    "board_spot": 4,
+                    "player_id": null
+                },
+                {
+                    "user_id": "521424042611961856",
+                    "roster_id": 2,
+                    "is_traded": false,
+                    "owner_id": 2,
+                    "pick_round": 1,
+                    "pick_number": 5,
+                    "board_spot": 5,
+                    "player_id": null
+                },
+                {
+                    "user_id": "521485413219885056",
+                    "roster_id": 4,
+                    "is_traded": false,
+                    "owner_id": 4,
+                    "pick_round": 1,
+                    "pick_number": 6,
+                    "board_spot": 6,
+                    "player_id": null
+                },
+                {
+                    "user_id": "325371992242946048",
+                    "roster_id": 11,
+                    "is_traded": true,
+                    "owner_id": 4,
+                    "pick_round": 1,
+                    "pick_number": 7,
+                    "board_spot": 7,
+                    "player_id": null
+                },
+                {
+                    "user_id": "665051007910236160",
+                    "roster_id": 6,
+                    "is_traded": true,
+                    "owner_id": 4,
+                    "pick_round": 1,
+                    "pick_number": 8,
+                    "board_spot": 8,
+                    "player_id": null
+                },
+                {
+                    "user_id": "467132282604351488",
+                    "roster_id": 3,
+                    "is_traded": false,
+                    "owner_id": 3,
+                    "pick_round": 1,
+                    "pick_number": 9,
+                    "board_spot": 9,
+                    "player_id": null
+                },
+                {
+                    "user_id": "325380343328686080",
+                    "roster_id": 10,
+                    "is_traded": true,
+                    "owner_id": 7,
+                    "pick_round": 1,
+                    "pick_number": 10,
+                    "board_spot": 10,
+                    "player_id": null
+                },
+                {
+                    "user_id": "560984104439771136",
+                    "roster_id": 12,
+                    "is_traded": true,
+                    "owner_id": 5,
+                    "pick_round": 1,
+                    "pick_number": 11,
+                    "board_spot": 11,
+                    "player_id": null
+                },
+                {
+                    "user_id": "464153930528452608",
+                    "roster_id": 7,
+                    "is_traded": true,
+                    "owner_id": 1,
+                    "pick_round": 1,
+                    "pick_number": 12,
+                    "board_spot": 12,
+                    "player_id": null
+                }
+            ]
+        },
+        "playerInfo": {
+            "4984": {
+                "player_id": "4984",
+                "first_name": "Josh",
+                "last_name": "Allen",
+                "full_name": "Josh Allen",
+                "team": "BUF",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 1,
+                "years_exp": 8,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "6813": {
+                "player_id": "6813",
+                "first_name": "Jonathan",
+                "last_name": "Taylor",
+                "full_name": "Jonathan Taylor",
+                "team": "IND",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 4,
+                "years_exp": 6,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "7564": {
+                "player_id": "7564",
+                "first_name": "Ja'Marr",
+                "last_name": "Chase",
+                "full_name": "Ja'Marr Chase",
+                "team": "CIN",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 3,
+                "years_exp": 5,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "9221": {
+                "player_id": "9221",
+                "first_name": "Jahmyr",
+                "last_name": "Gibbs",
+                "full_name": "Jahmyr Gibbs",
+                "team": "DET",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 2,
+                "years_exp": 3,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "9509": {
+                "player_id": "9509",
+                "first_name": "Bijan",
+                "last_name": "Robinson",
+                "full_name": "Bijan Robinson",
+                "team": "ATL",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 1,
+                "years_exp": 3,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "11564": {
+                "player_id": "11564",
+                "first_name": "Drake",
+                "last_name": "Maye",
+                "full_name": "Drake Maye",
+                "team": "NE",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 3,
+                "years_exp": 2,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13268": {
+                "player_id": "13268",
+                "first_name": "Elijah",
+                "last_name": "Sarratt",
+                "full_name": "Elijah Sarratt",
+                "team": "BAL",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 201,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13269": {
+                "player_id": "13269",
+                "first_name": "Fernando",
+                "last_name": "Mendoza",
+                "full_name": "Fernando Mendoza",
+                "team": "LV",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 39,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13272": {
+                "player_id": "13272",
+                "first_name": "Carson",
+                "last_name": "Beck",
+                "full_name": "Carson Beck",
+                "team": "ARI",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 416,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13274": {
+                "player_id": "13274",
+                "first_name": "Germie",
+                "last_name": "Bernard",
+                "full_name": "Germie Bernard",
+                "team": "PIT",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 194,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13275": {
+                "player_id": "13275",
+                "first_name": "Ty",
+                "last_name": "Simpson",
+                "full_name": "Ty Simpson",
+                "team": "LAR",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 141,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13276": {
+                "player_id": "13276",
+                "first_name": "Omar",
+                "last_name": "Cooper",
+                "full_name": "Omar Cooper",
+                "team": "NYJ",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 146,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13278": {
+                "player_id": "13278",
+                "first_name": "Max",
+                "last_name": "Klare",
+                "full_name": "Max Klare",
+                "team": "LAR",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 212,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13279": {
+                "player_id": "13279",
+                "first_name": "Carnell",
+                "last_name": "Tate",
+                "full_name": "Carnell Tate",
+                "team": "TEN",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 61,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13281": {
+                "player_id": "13281",
+                "first_name": "Jordyn",
+                "last_name": "Tyson",
+                "full_name": "Jordyn Tyson",
+                "team": "NO",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 69,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13285": {
+                "player_id": "13285",
+                "first_name": "Malachi",
+                "last_name": "Fields",
+                "full_name": "Malachi Fields",
+                "team": "NYG",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 210,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13286": {
+                "player_id": "13286",
+                "first_name": "Jadarian",
+                "last_name": "Price",
+                "full_name": "Jadarian Price",
+                "team": "SEA",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 63,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13287": {
+                "player_id": "13287",
+                "first_name": "Jeremiyah",
+                "last_name": "Love",
+                "full_name": "Jeremiyah Love",
+                "team": "ARI",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 15,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13288": {
+                "player_id": "13288",
+                "first_name": "Nicholas",
+                "last_name": "Singleton",
+                "full_name": "Nicholas Singleton",
+                "team": "TEN",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 167,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13289": {
+                "player_id": "13289",
+                "first_name": "Drew",
+                "last_name": "Allar",
+                "full_name": "Drew Allar",
+                "team": "PIT",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13293": {
+                "player_id": "13293",
+                "first_name": "Ja'Kobi",
+                "last_name": "Lane",
+                "full_name": "Ja'Kobi Lane",
+                "team": "BAL",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 182,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13294": {
+                "player_id": "13294",
+                "first_name": "Makai",
+                "last_name": "Lemon",
+                "full_name": "Makai Lemon",
+                "team": "PHI",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 77,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13296": {
+                "player_id": "13296",
+                "first_name": "Caleb",
+                "last_name": "Douglas",
+                "full_name": "Caleb Douglas",
+                "team": "MIA",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13298": {
+                "player_id": "13298",
+                "first_name": "KC",
+                "last_name": "Concepcion",
+                "full_name": "KC Concepcion",
+                "team": "CLE",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 116,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13301": {
+                "player_id": "13301",
+                "first_name": "Antonio",
+                "last_name": "Williams",
+                "full_name": "Antonio Williams",
+                "team": "WAS",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 156,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13302": {
+                "player_id": "13302",
+                "first_name": "Adam",
+                "last_name": "Randall",
+                "full_name": "Adam Randall",
+                "team": "BAL",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13303": {
+                "player_id": "13303",
+                "first_name": "Cade",
+                "last_name": "Klubnik",
+                "full_name": "Cade Klubnik",
+                "team": "NYJ",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 398,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13305": {
+                "player_id": "13305",
+                "first_name": "Mike",
+                "last_name": "Washington",
+                "full_name": "Mike Washington",
+                "team": "LV",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 139,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13306": {
+                "player_id": "13306",
+                "first_name": "Taylen",
+                "last_name": "Green",
+                "full_name": "Taylen Green",
+                "team": "CLE",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13311": {
+                "player_id": "13311",
+                "first_name": "Chris",
+                "last_name": "Bell",
+                "full_name": "Chris Bell",
+                "team": "MIA",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 203,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13317": {
+                "player_id": "13317",
+                "first_name": "Ted",
+                "last_name": "Hurst",
+                "full_name": "Ted Hurst",
+                "team": "TB",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 196,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13319": {
+                "player_id": "13319",
+                "first_name": "Oscar",
+                "last_name": "Delp",
+                "full_name": "Oscar Delp",
+                "team": "NO",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13320": {
+                "player_id": "13320",
+                "first_name": "Zachariah",
+                "last_name": "Branch",
+                "full_name": "Zachariah Branch",
+                "team": "ATL",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 180,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13330": {
+                "player_id": "13330",
+                "first_name": "Kenyon",
+                "last_name": "Sadiq",
+                "full_name": "Kenyon Sadiq",
+                "team": "NYJ",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 109,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13333": {
+                "player_id": "13333",
+                "first_name": "Deion",
+                "last_name": "Burks",
+                "full_name": "Deion Burks",
+                "team": "IND",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13337": {
+                "player_id": "13337",
+                "first_name": "Emmett",
+                "last_name": "Johnson",
+                "full_name": "Emmett Johnson",
+                "team": "KC",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 113,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13338": {
+                "player_id": "13338",
+                "first_name": "Kevin",
+                "last_name": "Coleman",
+                "full_name": "Kevin Coleman",
+                "team": "MIA",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13345": {
+                "player_id": "13345",
+                "first_name": "Jonah",
+                "last_name": "Coleman",
+                "full_name": "Jonah Coleman",
+                "team": "DEN",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 118,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13346": {
+                "player_id": "13346",
+                "first_name": "Denzel",
+                "last_name": "Boston",
+                "full_name": "Denzel Boston",
+                "team": "CLE",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 144,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13347": {
+                "player_id": "13347",
+                "first_name": "Demond",
+                "last_name": "Claiborne",
+                "full_name": "Demond Claiborne",
+                "team": "MIN",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 176,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13348": {
+                "player_id": "13348",
+                "first_name": "J'Mari",
+                "last_name": "Taylor",
+                "full_name": "J'Mari Taylor",
+                "team": "JAX",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13349": {
+                "player_id": "13349",
+                "first_name": "Eli",
+                "last_name": "Stowers",
+                "full_name": "Eli Stowers",
+                "team": "PHI",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 140,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13353": {
+                "player_id": "13353",
+                "first_name": "Chris",
+                "last_name": "Brazzell",
+                "full_name": "Chris Brazzell",
+                "team": "CAR",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 202,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13380": {
+                "player_id": "13380",
+                "first_name": "Brenen",
+                "last_name": "Thompson",
+                "full_name": "Brenen Thompson",
+                "team": "LAC",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13400": {
+                "player_id": "13400",
+                "first_name": "Justin",
+                "last_name": "Joly",
+                "full_name": "Justin Joly",
+                "team": "DEN",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13402": {
+                "player_id": "13402",
+                "first_name": "Skyler",
+                "last_name": "Bell",
+                "full_name": "Skyler Bell",
+                "team": "BUF",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13403": {
+                "player_id": "13403",
+                "first_name": "Jam",
+                "last_name": "Miller",
+                "full_name": "Jam Miller",
+                "team": "NE",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13404": {
+                "player_id": "13404",
+                "first_name": "Garrett",
+                "last_name": "Nussmeier",
+                "full_name": "Garrett Nussmeier",
+                "team": "KC",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 329,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13405": {
+                "player_id": "13405",
+                "first_name": "Kaytron",
+                "last_name": "Allen",
+                "full_name": "Kaytron Allen",
+                "team": "WAS",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 157,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13414": {
+                "player_id": "13414",
+                "first_name": "Kaelon",
+                "last_name": "Black",
+                "full_name": "Kaelon Black",
+                "team": "SF",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13417": {
+                "player_id": "13417",
+                "first_name": "De'Zhaun",
+                "last_name": "Stribling",
+                "full_name": "De'Zhaun Stribling",
+                "team": "SF",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 202,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13420": {
+                "player_id": "13420",
+                "first_name": "Bryce",
+                "last_name": "Lance",
+                "full_name": "Bryce Lance",
+                "team": "NO",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13421": {
+                "player_id": "13421",
+                "first_name": "Eli",
+                "last_name": "Raridon",
+                "full_name": "Eli Raridon",
+                "team": "NE",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13423": {
+                "player_id": "13423",
+                "first_name": "Eli",
+                "last_name": "Heidenreich",
+                "full_name": "Eli Heidenreich",
+                "team": "PIT",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            }
+        }
+    },
+    "manualRemove": {
+        "currentManualPick": {
+            "user_id": "521035584588267520",
+            "roster_id": 1,
+            "is_traded": false,
+            "owner_id": 1,
+            "pick_round": 1,
+            "pick_number": 3,
+            "board_spot": 3,
+            "player_id": "13279",
+            "picked": true
+        },
+        "playerID": null,
+        "round": {
+            "round": 1,
+            "picks": [
+                {
+                    "user_id": "989213899293569024",
+                    "roster_id": 5,
+                    "is_traded": false,
+                    "owner_id": 5,
+                    "pick_round": 1,
+                    "pick_number": 1,
+                    "board_spot": 1,
+                    "player_id": "13287",
+                    "picked": true
+                },
+                {
+                    "user_id": "999040645685649408",
+                    "roster_id": 8,
+                    "is_traded": false,
+                    "owner_id": 8,
+                    "pick_round": 1,
+                    "pick_number": 2,
+                    "board_spot": 2,
+                    "player_id": "13269",
+                    "picked": true
+                },
+                {
+                    "user_id": "521035584588267520",
+                    "roster_id": 1,
+                    "is_traded": false,
+                    "owner_id": 1,
+                    "pick_round": 1,
+                    "pick_number": 3,
+                    "board_spot": 3,
+                    "player_id": null,
+                    "picked": true
+                },
+                {
+                    "user_id": "467766220007927808",
+                    "roster_id": 9,
+                    "is_traded": true,
+                    "owner_id": 6,
+                    "pick_round": 1,
+                    "pick_number": 4,
+                    "board_spot": 4,
+                    "player_id": "13281",
+                    "picked": true
+                },
+                {
+                    "user_id": "521424042611961856",
+                    "roster_id": 2,
+                    "is_traded": false,
+                    "owner_id": 2,
+                    "pick_round": 1,
+                    "pick_number": 5,
+                    "board_spot": 5,
+                    "player_id": "13294",
+                    "picked": true
+                },
+                {
+                    "user_id": "521485413219885056",
+                    "roster_id": 4,
+                    "is_traded": false,
+                    "owner_id": 4,
+                    "pick_round": 1,
+                    "pick_number": 6,
+                    "board_spot": 6,
+                    "player_id": "13286",
+                    "picked": true
+                },
+                {
+                    "user_id": "325371992242946048",
+                    "roster_id": 11,
+                    "is_traded": true,
+                    "owner_id": 4,
+                    "pick_round": 1,
+                    "pick_number": 7,
+                    "board_spot": 7,
+                    "player_id": "13298",
+                    "picked": true
+                },
+                {
+                    "user_id": "665051007910236160",
+                    "roster_id": 6,
+                    "is_traded": true,
+                    "owner_id": 4,
+                    "pick_round": 1,
+                    "pick_number": 8,
+                    "board_spot": 8,
+                    "player_id": "13275",
+                    "picked": true
+                },
+                {
+                    "user_id": "467132282604351488",
+                    "roster_id": 3,
+                    "is_traded": false,
+                    "owner_id": 3,
+                    "pick_round": 1,
+                    "pick_number": 9,
+                    "board_spot": 9,
+                    "player_id": "13345",
+                    "picked": true
+                },
+                {
+                    "user_id": "325380343328686080",
+                    "roster_id": 10,
+                    "is_traded": true,
+                    "owner_id": 7,
+                    "pick_round": 1,
+                    "pick_number": 10,
+                    "board_spot": 10,
+                    "player_id": "13330",
+                    "picked": true
+                },
+                {
+                    "user_id": "560984104439771136",
+                    "roster_id": 12,
+                    "is_traded": true,
+                    "owner_id": 5,
+                    "pick_round": 1,
+                    "pick_number": 11,
+                    "board_spot": 11,
+                    "player_id": "13276",
+                    "picked": true
+                },
+                {
+                    "user_id": "464153930528452608",
+                    "roster_id": 7,
+                    "is_traded": true,
+                    "owner_id": 1,
+                    "pick_round": 1,
+                    "pick_number": 12,
+                    "board_spot": 12,
+                    "player_id": "13346",
+                    "picked": true
+                }
+            ]
+        },
+        "playerInfo": {
+            "4984": {
+                "player_id": "4984",
+                "first_name": "Josh",
+                "last_name": "Allen",
+                "full_name": "Josh Allen",
+                "team": "BUF",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 1,
+                "years_exp": 8,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "6813": {
+                "player_id": "6813",
+                "first_name": "Jonathan",
+                "last_name": "Taylor",
+                "full_name": "Jonathan Taylor",
+                "team": "IND",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 4,
+                "years_exp": 6,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "7564": {
+                "player_id": "7564",
+                "first_name": "Ja'Marr",
+                "last_name": "Chase",
+                "full_name": "Ja'Marr Chase",
+                "team": "CIN",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 3,
+                "years_exp": 5,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "9221": {
+                "player_id": "9221",
+                "first_name": "Jahmyr",
+                "last_name": "Gibbs",
+                "full_name": "Jahmyr Gibbs",
+                "team": "DET",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 2,
+                "years_exp": 3,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "9509": {
+                "player_id": "9509",
+                "first_name": "Bijan",
+                "last_name": "Robinson",
+                "full_name": "Bijan Robinson",
+                "team": "ATL",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 1,
+                "years_exp": 3,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "11564": {
+                "player_id": "11564",
+                "first_name": "Drake",
+                "last_name": "Maye",
+                "full_name": "Drake Maye",
+                "team": "NE",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 3,
+                "years_exp": 2,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13268": {
+                "player_id": "13268",
+                "first_name": "Elijah",
+                "last_name": "Sarratt",
+                "full_name": "Elijah Sarratt",
+                "team": "BAL",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 201,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "gdavidson",
+                "in_lineup": false
+            },
+            "13269": {
+                "player_id": "13269",
+                "first_name": "Fernando",
+                "last_name": "Mendoza",
+                "full_name": "Fernando Mendoza",
+                "team": "LV",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 39,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "cmurtagh86",
+                "in_lineup": false
+            },
+            "13272": {
+                "player_id": "13272",
+                "first_name": "Carson",
+                "last_name": "Beck",
+                "full_name": "Carson Beck",
+                "team": "ARI",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 416,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "aphilliny21",
+                "in_lineup": false
+            },
+            "13274": {
+                "player_id": "13274",
+                "first_name": "Germie",
+                "last_name": "Bernard",
+                "full_name": "Germie Bernard",
+                "team": "PIT",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 194,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13275": {
+                "player_id": "13275",
+                "first_name": "Ty",
+                "last_name": "Simpson",
+                "full_name": "Ty Simpson",
+                "team": "LAR",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 141,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13276": {
+                "player_id": "13276",
+                "first_name": "Omar",
+                "last_name": "Cooper",
+                "full_name": "Omar Cooper",
+                "team": "NYJ",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 146,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13278": {
+                "player_id": "13278",
+                "first_name": "Max",
+                "last_name": "Klare",
+                "full_name": "Max Klare",
+                "team": "LAR",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 212,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13279": {
+                "player_id": "13279",
+                "first_name": "Carnell",
+                "last_name": "Tate",
+                "full_name": "Carnell Tate",
+                "team": "TEN",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 61,
+                "years_exp": 0,
+                "is_taken": false,
+                "rostered_by": null,
+                "in_lineup": false
+            },
+            "13281": {
+                "player_id": "13281",
+                "first_name": "Jordyn",
+                "last_name": "Tyson",
+                "full_name": "Jordyn Tyson",
+                "team": "NO",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 69,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13285": {
+                "player_id": "13285",
+                "first_name": "Malachi",
+                "last_name": "Fields",
+                "full_name": "Malachi Fields",
+                "team": "NYG",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 210,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "crbiehl",
+                "in_lineup": false
+            },
+            "13286": {
+                "player_id": "13286",
+                "first_name": "Jadarian",
+                "last_name": "Price",
+                "full_name": "Jadarian Price",
+                "team": "SEA",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 63,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13287": {
+                "player_id": "13287",
+                "first_name": "Jeremiyah",
+                "last_name": "Love",
+                "full_name": "Jeremiyah Love",
+                "team": "ARI",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 15,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13288": {
+                "player_id": "13288",
+                "first_name": "Nicholas",
+                "last_name": "Singleton",
+                "full_name": "Nicholas Singleton",
+                "team": "TEN",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 167,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13289": {
+                "player_id": "13289",
+                "first_name": "Drew",
+                "last_name": "Allar",
+                "full_name": "Drew Allar",
+                "team": "PIT",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13293": {
+                "player_id": "13293",
+                "first_name": "Ja'Kobi",
+                "last_name": "Lane",
+                "full_name": "Ja'Kobi Lane",
+                "team": "BAL",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 182,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "gdavidson",
+                "in_lineup": false
+            },
+            "13294": {
+                "player_id": "13294",
+                "first_name": "Makai",
+                "last_name": "Lemon",
+                "full_name": "Makai Lemon",
+                "team": "PHI",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 77,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "aphilliny21",
+                "in_lineup": false
+            },
+            "13296": {
+                "player_id": "13296",
+                "first_name": "Caleb",
+                "last_name": "Douglas",
+                "full_name": "Caleb Douglas",
+                "team": "MIA",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13298": {
+                "player_id": "13298",
+                "first_name": "KC",
+                "last_name": "Concepcion",
+                "full_name": "KC Concepcion",
+                "team": "CLE",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 116,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13301": {
+                "player_id": "13301",
+                "first_name": "Antonio",
+                "last_name": "Williams",
+                "full_name": "Antonio Williams",
+                "team": "WAS",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 156,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13302": {
+                "player_id": "13302",
+                "first_name": "Adam",
+                "last_name": "Randall",
+                "full_name": "Adam Randall",
+                "team": "BAL",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13303": {
+                "player_id": "13303",
+                "first_name": "Cade",
+                "last_name": "Klubnik",
+                "full_name": "Cade Klubnik",
+                "team": "NYJ",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 398,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "gdavidson",
+                "in_lineup": false
+            },
+            "13305": {
+                "player_id": "13305",
+                "first_name": "Mike",
+                "last_name": "Washington",
+                "full_name": "Mike Washington",
+                "team": "LV",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 139,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "cmurtagh86",
+                "in_lineup": false
+            },
+            "13306": {
+                "player_id": "13306",
+                "first_name": "Taylen",
+                "last_name": "Green",
+                "full_name": "Taylen Green",
+                "team": "CLE",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13311": {
+                "player_id": "13311",
+                "first_name": "Chris",
+                "last_name": "Bell",
+                "full_name": "Chris Bell",
+                "team": "MIA",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 203,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "cmurtagh86",
+                "in_lineup": false
+            },
+            "13317": {
+                "player_id": "13317",
+                "first_name": "Ted",
+                "last_name": "Hurst",
+                "full_name": "Ted Hurst",
+                "team": "TB",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 196,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "aphilliny21",
+                "in_lineup": false
+            },
+            "13319": {
+                "player_id": "13319",
+                "first_name": "Oscar",
+                "last_name": "Delp",
+                "full_name": "Oscar Delp",
+                "team": "NO",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "aphilliny21",
+                "in_lineup": false
+            },
+            "13320": {
+                "player_id": "13320",
+                "first_name": "Zachariah",
+                "last_name": "Branch",
+                "full_name": "Zachariah Branch",
+                "team": "ATL",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 180,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13330": {
+                "player_id": "13330",
+                "first_name": "Kenyon",
+                "last_name": "Sadiq",
+                "full_name": "Kenyon Sadiq",
+                "team": "NYJ",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 109,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "crbiehl",
+                "in_lineup": false
+            },
+            "13333": {
+                "player_id": "13333",
+                "first_name": "Deion",
+                "last_name": "Burks",
+                "full_name": "Deion Burks",
+                "team": "IND",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13337": {
+                "player_id": "13337",
+                "first_name": "Emmett",
+                "last_name": "Johnson",
+                "full_name": "Emmett Johnson",
+                "team": "KC",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 113,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "gdavidson",
+                "in_lineup": false
+            },
+            "13338": {
+                "player_id": "13338",
+                "first_name": "Kevin",
+                "last_name": "Coleman",
+                "full_name": "Kevin Coleman",
+                "team": "MIA",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "kpresley",
+                "in_lineup": false
+            },
+            "13345": {
+                "player_id": "13345",
+                "first_name": "Jonah",
+                "last_name": "Coleman",
+                "full_name": "Jonah Coleman",
+                "team": "DEN",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 118,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "OptimalPooper",
+                "in_lineup": false
+            },
+            "13346": {
+                "player_id": "13346",
+                "first_name": "Denzel",
+                "last_name": "Boston",
+                "full_name": "Denzel Boston",
+                "team": "CLE",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 144,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13347": {
+                "player_id": "13347",
+                "first_name": "Demond",
+                "last_name": "Claiborne",
+                "full_name": "Demond Claiborne",
+                "team": "MIN",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 176,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13348": {
+                "player_id": "13348",
+                "first_name": "J'Mari",
+                "last_name": "Taylor",
+                "full_name": "J'Mari Taylor",
+                "team": "JAX",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "MaddensWok",
+                "in_lineup": false
+            },
+            "13349": {
+                "player_id": "13349",
+                "first_name": "Eli",
+                "last_name": "Stowers",
+                "full_name": "Eli Stowers",
+                "team": "PHI",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 140,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "HEFFinAround305",
+                "in_lineup": false
+            },
+            "13353": {
+                "player_id": "13353",
+                "first_name": "Chris",
+                "last_name": "Brazzell",
+                "full_name": "Chris Brazzell",
+                "team": "CAR",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 202,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "gdavidson",
+                "in_lineup": false
+            },
+            "13380": {
+                "player_id": "13380",
+                "first_name": "Brenen",
+                "last_name": "Thompson",
+                "full_name": "Brenen Thompson",
+                "team": "LAC",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "OptimalPooper",
+                "in_lineup": false
+            },
+            "13400": {
+                "player_id": "13400",
+                "first_name": "Justin",
+                "last_name": "Joly",
+                "full_name": "Justin Joly",
+                "team": "DEN",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "MaddensWok",
+                "in_lineup": false
+            },
+            "13402": {
+                "player_id": "13402",
+                "first_name": "Skyler",
+                "last_name": "Bell",
+                "full_name": "Skyler Bell",
+                "team": "BUF",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "crbiehl",
+                "in_lineup": false
+            },
+            "13403": {
+                "player_id": "13403",
+                "first_name": "Jam",
+                "last_name": "Miller",
+                "full_name": "Jam Miller",
+                "team": "NE",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "crbiehl",
+                "in_lineup": false
+            },
+            "13404": {
+                "player_id": "13404",
+                "first_name": "Garrett",
+                "last_name": "Nussmeier",
+                "full_name": "Garrett Nussmeier",
+                "team": "KC",
+                "position": "QB",
+                "fantasy_positions": [
+                    "QB"
+                ],
+                "search_rank": 329,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "cmurtagh86",
+                "in_lineup": false
+            },
+            "13405": {
+                "player_id": "13405",
+                "first_name": "Kaytron",
+                "last_name": "Allen",
+                "full_name": "Kaytron Allen",
+                "team": "WAS",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 157,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13414": {
+                "player_id": "13414",
+                "first_name": "Kaelon",
+                "last_name": "Black",
+                "full_name": "Kaelon Black",
+                "team": "SF",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "spight",
+                "in_lineup": false
+            },
+            "13417": {
+                "player_id": "13417",
+                "first_name": "De'Zhaun",
+                "last_name": "Stribling",
+                "full_name": "De'Zhaun Stribling",
+                "team": "SF",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 202,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "Bloomberg4",
+                "in_lineup": false
+            },
+            "13420": {
+                "player_id": "13420",
+                "first_name": "Bryce",
+                "last_name": "Lance",
+                "full_name": "Bryce Lance",
+                "team": "NO",
+                "position": "WR",
+                "fantasy_positions": [
+                    "WR"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "CHood20",
+                "in_lineup": false
+            },
+            "13421": {
+                "player_id": "13421",
+                "first_name": "Eli",
+                "last_name": "Raridon",
+                "full_name": "Eli Raridon",
+                "team": "NE",
+                "position": "TE",
+                "fantasy_positions": [
+                    "TE"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "ryangh",
+                "in_lineup": false
+            },
+            "13423": {
+                "player_id": "13423",
+                "first_name": "Eli",
+                "last_name": "Heidenreich",
+                "full_name": "Eli Heidenreich",
+                "team": "PIT",
+                "position": "RB",
+                "fantasy_positions": [
+                    "RB"
+                ],
+                "search_rank": 999,
+                "years_exp": 0,
+                "is_taken": true,
+                "rostered_by": "spight",
+                "in_lineup": false
+            }
+        }
+    }
+}

--- a/src/lib/__fixtures__/live-draft-sync-2026.json
+++ b/src/lib/__fixtures__/live-draft-sync-2026.json
@@ -1,0 +1,3262 @@
+{
+    "liveDraft": {
+        "type": "linear",
+        "settings": {
+            "rounds": 4,
+            "player_type": 1
+        },
+        "slot_to_roster_id": {
+            "1": 5,
+            "2": 8,
+            "3": 1,
+            "4": 9,
+            "5": 2,
+            "6": 4,
+            "7": 11,
+            "8": 6,
+            "9": 3,
+            "10": 10,
+            "11": 12,
+            "12": 7
+        },
+        "built_draft": [
+            {
+                "round": 1,
+                "picks": [
+                    {
+                        "user_id": "989213899293569024",
+                        "roster_id": 5,
+                        "is_traded": false,
+                        "owner_id": 5,
+                        "pick_round": 1,
+                        "pick_number": 1,
+                        "board_spot": 1,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "999040645685649408",
+                        "roster_id": 8,
+                        "is_traded": false,
+                        "owner_id": 8,
+                        "pick_round": 1,
+                        "pick_number": 2,
+                        "board_spot": 2,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "521035584588267520",
+                        "roster_id": 1,
+                        "is_traded": false,
+                        "owner_id": 1,
+                        "pick_round": 1,
+                        "pick_number": 3,
+                        "board_spot": 3,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "467766220007927808",
+                        "roster_id": 9,
+                        "is_traded": true,
+                        "owner_id": 6,
+                        "pick_round": 1,
+                        "pick_number": 4,
+                        "board_spot": 4,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "521424042611961856",
+                        "roster_id": 2,
+                        "is_traded": false,
+                        "owner_id": 2,
+                        "pick_round": 1,
+                        "pick_number": 5,
+                        "board_spot": 5,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "521485413219885056",
+                        "roster_id": 4,
+                        "is_traded": false,
+                        "owner_id": 4,
+                        "pick_round": 1,
+                        "pick_number": 6,
+                        "board_spot": 6,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "325371992242946048",
+                        "roster_id": 11,
+                        "is_traded": true,
+                        "owner_id": 4,
+                        "pick_round": 1,
+                        "pick_number": 7,
+                        "board_spot": 7,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "665051007910236160",
+                        "roster_id": 6,
+                        "is_traded": true,
+                        "owner_id": 4,
+                        "pick_round": 1,
+                        "pick_number": 8,
+                        "board_spot": 8,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "467132282604351488",
+                        "roster_id": 3,
+                        "is_traded": false,
+                        "owner_id": 3,
+                        "pick_round": 1,
+                        "pick_number": 9,
+                        "board_spot": 9,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "325380343328686080",
+                        "roster_id": 10,
+                        "is_traded": true,
+                        "owner_id": 7,
+                        "pick_round": 1,
+                        "pick_number": 10,
+                        "board_spot": 10,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "560984104439771136",
+                        "roster_id": 12,
+                        "is_traded": true,
+                        "owner_id": 5,
+                        "pick_round": 1,
+                        "pick_number": 11,
+                        "board_spot": 11,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "464153930528452608",
+                        "roster_id": 7,
+                        "is_traded": true,
+                        "owner_id": 1,
+                        "pick_round": 1,
+                        "pick_number": 12,
+                        "board_spot": 12,
+                        "player_id": null
+                    }
+                ]
+            },
+            {
+                "round": 2,
+                "picks": [
+                    {
+                        "user_id": "989213899293569024",
+                        "roster_id": 5,
+                        "is_traded": false,
+                        "owner_id": 5,
+                        "pick_round": 2,
+                        "pick_number": 1,
+                        "board_spot": 1,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "999040645685649408",
+                        "roster_id": 8,
+                        "is_traded": false,
+                        "owner_id": 8,
+                        "pick_round": 2,
+                        "pick_number": 2,
+                        "board_spot": 2,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "521035584588267520",
+                        "roster_id": 1,
+                        "is_traded": false,
+                        "owner_id": 1,
+                        "pick_round": 2,
+                        "pick_number": 3,
+                        "board_spot": 3,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "467766220007927808",
+                        "roster_id": 9,
+                        "is_traded": false,
+                        "owner_id": 9,
+                        "pick_round": 2,
+                        "pick_number": 4,
+                        "board_spot": 4,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "521424042611961856",
+                        "roster_id": 2,
+                        "is_traded": true,
+                        "owner_id": 6,
+                        "pick_round": 2,
+                        "pick_number": 5,
+                        "board_spot": 5,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "521485413219885056",
+                        "roster_id": 4,
+                        "is_traded": true,
+                        "owner_id": 6,
+                        "pick_round": 2,
+                        "pick_number": 6,
+                        "board_spot": 6,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "325371992242946048",
+                        "roster_id": 11,
+                        "is_traded": true,
+                        "owner_id": 7,
+                        "pick_round": 2,
+                        "pick_number": 7,
+                        "board_spot": 7,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "665051007910236160",
+                        "roster_id": 6,
+                        "is_traded": true,
+                        "owner_id": 9,
+                        "pick_round": 2,
+                        "pick_number": 8,
+                        "board_spot": 8,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "467132282604351488",
+                        "roster_id": 3,
+                        "is_traded": true,
+                        "owner_id": 9,
+                        "pick_round": 2,
+                        "pick_number": 9,
+                        "board_spot": 9,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "325380343328686080",
+                        "roster_id": 10,
+                        "is_traded": true,
+                        "owner_id": 2,
+                        "pick_round": 2,
+                        "pick_number": 10,
+                        "board_spot": 10,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "560984104439771136",
+                        "roster_id": 12,
+                        "is_traded": true,
+                        "owner_id": 6,
+                        "pick_round": 2,
+                        "pick_number": 11,
+                        "board_spot": 11,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "464153930528452608",
+                        "roster_id": 7,
+                        "is_traded": true,
+                        "owner_id": 1,
+                        "pick_round": 2,
+                        "pick_number": 12,
+                        "board_spot": 12,
+                        "player_id": null
+                    }
+                ]
+            },
+            {
+                "round": 3,
+                "picks": [
+                    {
+                        "user_id": "989213899293569024",
+                        "roster_id": 5,
+                        "is_traded": true,
+                        "owner_id": 7,
+                        "pick_round": 3,
+                        "pick_number": 1,
+                        "board_spot": 1,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "999040645685649408",
+                        "roster_id": 8,
+                        "is_traded": false,
+                        "owner_id": 8,
+                        "pick_round": 3,
+                        "pick_number": 2,
+                        "board_spot": 2,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "521035584588267520",
+                        "roster_id": 1,
+                        "is_traded": false,
+                        "owner_id": 1,
+                        "pick_round": 3,
+                        "pick_number": 3,
+                        "board_spot": 3,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "467766220007927808",
+                        "roster_id": 9,
+                        "is_traded": false,
+                        "owner_id": 9,
+                        "pick_round": 3,
+                        "pick_number": 4,
+                        "board_spot": 4,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "521424042611961856",
+                        "roster_id": 2,
+                        "is_traded": false,
+                        "owner_id": 2,
+                        "pick_round": 3,
+                        "pick_number": 5,
+                        "board_spot": 5,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "521485413219885056",
+                        "roster_id": 4,
+                        "is_traded": false,
+                        "owner_id": 4,
+                        "pick_round": 3,
+                        "pick_number": 6,
+                        "board_spot": 6,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "325371992242946048",
+                        "roster_id": 11,
+                        "is_traded": true,
+                        "owner_id": 5,
+                        "pick_round": 3,
+                        "pick_number": 7,
+                        "board_spot": 7,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "665051007910236160",
+                        "roster_id": 6,
+                        "is_traded": false,
+                        "owner_id": 6,
+                        "pick_round": 3,
+                        "pick_number": 8,
+                        "board_spot": 8,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "467132282604351488",
+                        "roster_id": 3,
+                        "is_traded": false,
+                        "owner_id": 3,
+                        "pick_round": 3,
+                        "pick_number": 9,
+                        "board_spot": 9,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "325380343328686080",
+                        "roster_id": 10,
+                        "is_traded": false,
+                        "owner_id": 10,
+                        "pick_round": 3,
+                        "pick_number": 10,
+                        "board_spot": 10,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "560984104439771136",
+                        "roster_id": 12,
+                        "is_traded": true,
+                        "owner_id": 5,
+                        "pick_round": 3,
+                        "pick_number": 11,
+                        "board_spot": 11,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "464153930528452608",
+                        "roster_id": 7,
+                        "is_traded": true,
+                        "owner_id": 4,
+                        "pick_round": 3,
+                        "pick_number": 12,
+                        "board_spot": 12,
+                        "player_id": null
+                    }
+                ]
+            },
+            {
+                "round": 4,
+                "picks": [
+                    {
+                        "user_id": "989213899293569024",
+                        "roster_id": 5,
+                        "is_traded": false,
+                        "owner_id": 5,
+                        "pick_round": 4,
+                        "pick_number": 1,
+                        "board_spot": 1,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "999040645685649408",
+                        "roster_id": 8,
+                        "is_traded": false,
+                        "owner_id": 8,
+                        "pick_round": 4,
+                        "pick_number": 2,
+                        "board_spot": 2,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "521035584588267520",
+                        "roster_id": 1,
+                        "is_traded": false,
+                        "owner_id": 1,
+                        "pick_round": 4,
+                        "pick_number": 3,
+                        "board_spot": 3,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "467766220007927808",
+                        "roster_id": 9,
+                        "is_traded": true,
+                        "owner_id": 5,
+                        "pick_round": 4,
+                        "pick_number": 4,
+                        "board_spot": 4,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "521424042611961856",
+                        "roster_id": 2,
+                        "is_traded": false,
+                        "owner_id": 2,
+                        "pick_round": 4,
+                        "pick_number": 5,
+                        "board_spot": 5,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "521485413219885056",
+                        "roster_id": 4,
+                        "is_traded": true,
+                        "owner_id": 12,
+                        "pick_round": 4,
+                        "pick_number": 6,
+                        "board_spot": 6,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "325371992242946048",
+                        "roster_id": 11,
+                        "is_traded": false,
+                        "owner_id": 11,
+                        "pick_round": 4,
+                        "pick_number": 7,
+                        "board_spot": 7,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "665051007910236160",
+                        "roster_id": 6,
+                        "is_traded": false,
+                        "owner_id": 6,
+                        "pick_round": 4,
+                        "pick_number": 8,
+                        "board_spot": 8,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "467132282604351488",
+                        "roster_id": 3,
+                        "is_traded": true,
+                        "owner_id": 9,
+                        "pick_round": 4,
+                        "pick_number": 9,
+                        "board_spot": 9,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "325380343328686080",
+                        "roster_id": 10,
+                        "is_traded": false,
+                        "owner_id": 10,
+                        "pick_round": 4,
+                        "pick_number": 10,
+                        "board_spot": 10,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "560984104439771136",
+                        "roster_id": 12,
+                        "is_traded": false,
+                        "owner_id": 12,
+                        "pick_round": 4,
+                        "pick_number": 11,
+                        "board_spot": 11,
+                        "player_id": null
+                    },
+                    {
+                        "user_id": "464153930528452608",
+                        "roster_id": 7,
+                        "is_traded": false,
+                        "owner_id": 7,
+                        "pick_round": 4,
+                        "pick_number": 12,
+                        "board_spot": 12,
+                        "player_id": null
+                    }
+                ]
+            }
+        ],
+        "player_pool": "Rookie"
+    },
+    "livePicks": [
+        {
+            "round": 1,
+            "draft_slot": 1,
+            "player_id": "13287"
+        },
+        {
+            "round": 1,
+            "draft_slot": 2,
+            "player_id": "13269"
+        },
+        {
+            "round": 1,
+            "draft_slot": 3,
+            "player_id": "13279"
+        },
+        {
+            "round": 1,
+            "draft_slot": 4,
+            "player_id": "13281"
+        },
+        {
+            "round": 1,
+            "draft_slot": 5,
+            "player_id": "13294"
+        },
+        {
+            "round": 1,
+            "draft_slot": 6,
+            "player_id": "13286"
+        },
+        {
+            "round": 1,
+            "draft_slot": 7,
+            "player_id": "13298"
+        },
+        {
+            "round": 1,
+            "draft_slot": 8,
+            "player_id": "13275"
+        },
+        {
+            "round": 1,
+            "draft_slot": 9,
+            "player_id": "13345"
+        },
+        {
+            "round": 1,
+            "draft_slot": 10,
+            "player_id": "13330"
+        },
+        {
+            "round": 1,
+            "draft_slot": 11,
+            "player_id": "13276"
+        },
+        {
+            "round": 1,
+            "draft_slot": 12,
+            "player_id": "13346"
+        },
+        {
+            "round": 2,
+            "draft_slot": 1,
+            "player_id": "13349"
+        },
+        {
+            "round": 2,
+            "draft_slot": 2,
+            "player_id": "13311"
+        },
+        {
+            "round": 2,
+            "draft_slot": 3,
+            "player_id": "13288"
+        },
+        {
+            "round": 2,
+            "draft_slot": 4,
+            "player_id": "13337"
+        },
+        {
+            "round": 2,
+            "draft_slot": 5,
+            "player_id": "13320"
+        },
+        {
+            "round": 2,
+            "draft_slot": 6,
+            "player_id": "13301"
+        },
+        {
+            "round": 2,
+            "draft_slot": 7,
+            "player_id": "13285"
+        },
+        {
+            "round": 2,
+            "draft_slot": 8,
+            "player_id": "13268"
+        },
+        {
+            "round": 2,
+            "draft_slot": 9,
+            "player_id": "13353"
+        },
+        {
+            "round": 2,
+            "draft_slot": 10,
+            "player_id": "13272"
+        },
+        {
+            "round": 2,
+            "draft_slot": 11,
+            "player_id": "13417"
+        },
+        {
+            "round": 2,
+            "draft_slot": 12,
+            "player_id": "13274"
+        },
+        {
+            "round": 3,
+            "draft_slot": 1,
+            "player_id": "13402"
+        },
+        {
+            "round": 3,
+            "draft_slot": 2,
+            "player_id": "13305"
+        },
+        {
+            "round": 3,
+            "draft_slot": 3,
+            "player_id": "13405"
+        },
+        {
+            "round": 3,
+            "draft_slot": 4,
+            "player_id": "13293"
+        },
+        {
+            "round": 3,
+            "draft_slot": 5,
+            "player_id": "13317"
+        },
+        {
+            "round": 3,
+            "draft_slot": 6,
+            "player_id": "13302"
+        },
+        {
+            "round": 3,
+            "draft_slot": 7,
+            "player_id": "13347"
+        },
+        {
+            "round": 3,
+            "draft_slot": 8,
+            "player_id": "13278"
+        },
+        {
+            "round": 3,
+            "draft_slot": 9,
+            "player_id": "13380"
+        },
+        {
+            "round": 3,
+            "draft_slot": 10,
+            "player_id": "13414"
+        },
+        {
+            "round": 3,
+            "draft_slot": 11,
+            "player_id": "13289"
+        },
+        {
+            "round": 3,
+            "draft_slot": 12,
+            "player_id": "13420"
+        },
+        {
+            "round": 4,
+            "draft_slot": 1,
+            "player_id": "13296"
+        },
+        {
+            "round": 4,
+            "draft_slot": 2,
+            "player_id": "13404"
+        },
+        {
+            "round": 4,
+            "draft_slot": 3,
+            "player_id": "13421"
+        },
+        {
+            "round": 4,
+            "draft_slot": 4,
+            "player_id": "13306"
+        },
+        {
+            "round": 4,
+            "draft_slot": 5,
+            "player_id": "13319"
+        },
+        {
+            "round": 4,
+            "draft_slot": 6,
+            "player_id": "13400"
+        },
+        {
+            "round": 4,
+            "draft_slot": 7,
+            "player_id": "13338"
+        },
+        {
+            "round": 4,
+            "draft_slot": 8,
+            "player_id": "13333"
+        },
+        {
+            "round": 4,
+            "draft_slot": 9,
+            "player_id": "13303"
+        },
+        {
+            "round": 4,
+            "draft_slot": 10,
+            "player_id": "13423"
+        },
+        {
+            "round": 4,
+            "draft_slot": 11,
+            "player_id": "13348"
+        },
+        {
+            "round": 4,
+            "draft_slot": 12,
+            "player_id": "13403"
+        }
+    ],
+    "livePicksPartial": [
+        {
+            "round": 1,
+            "draft_slot": 1,
+            "player_id": "13287"
+        },
+        {
+            "round": 1,
+            "draft_slot": 2,
+            "player_id": "13269"
+        },
+        {
+            "round": 1,
+            "draft_slot": 3,
+            "player_id": "13279"
+        },
+        {
+            "round": 1,
+            "draft_slot": 4,
+            "player_id": "13281"
+        },
+        {
+            "round": 1,
+            "draft_slot": 5,
+            "player_id": "13294"
+        },
+        {
+            "round": 1,
+            "draft_slot": 6,
+            "player_id": "13286"
+        },
+        {
+            "round": 1,
+            "draft_slot": 7,
+            "player_id": "13298"
+        },
+        {
+            "round": 1,
+            "draft_slot": 8,
+            "player_id": "13275"
+        },
+        {
+            "round": 1,
+            "draft_slot": 9,
+            "player_id": "13345"
+        },
+        {
+            "round": 1,
+            "draft_slot": 10,
+            "player_id": "13330"
+        },
+        {
+            "round": 1,
+            "draft_slot": 11,
+            "player_id": "13276"
+        },
+        {
+            "round": 1,
+            "draft_slot": 12,
+            "player_id": "13346"
+        },
+        {
+            "round": 2,
+            "draft_slot": 1,
+            "player_id": "13349"
+        },
+        {
+            "round": 2,
+            "draft_slot": 2,
+            "player_id": "13311"
+        },
+        {
+            "round": 2,
+            "draft_slot": 3,
+            "player_id": "13288"
+        },
+        {
+            "round": 2,
+            "draft_slot": 4,
+            "player_id": "13337"
+        },
+        {
+            "round": 2,
+            "draft_slot": 5,
+            "player_id": "13320"
+        },
+        {
+            "round": 2,
+            "draft_slot": 6,
+            "player_id": "13301"
+        },
+        {
+            "round": 2,
+            "draft_slot": 7,
+            "player_id": "13285"
+        },
+        {
+            "round": 2,
+            "draft_slot": 8,
+            "player_id": "13268"
+        }
+    ],
+    "tradedPicks": [
+        {
+            "round": 2,
+            "roster_id": 2,
+            "owner_id": 6,
+            "previous_owner_id": 9
+        },
+        {
+            "round": 2,
+            "roster_id": 3,
+            "owner_id": 9,
+            "previous_owner_id": 3
+        },
+        {
+            "round": 4,
+            "roster_id": 3,
+            "owner_id": 9,
+            "previous_owner_id": 3
+        },
+        {
+            "round": 2,
+            "roster_id": 4,
+            "owner_id": 6,
+            "previous_owner_id": 4
+        },
+        {
+            "round": 4,
+            "roster_id": 4,
+            "owner_id": 12,
+            "previous_owner_id": 4
+        },
+        {
+            "round": 3,
+            "roster_id": 5,
+            "owner_id": 7,
+            "previous_owner_id": 5
+        },
+        {
+            "round": 1,
+            "roster_id": 6,
+            "owner_id": 4,
+            "previous_owner_id": 6
+        },
+        {
+            "round": 2,
+            "roster_id": 6,
+            "owner_id": 9,
+            "previous_owner_id": 6
+        },
+        {
+            "round": 1,
+            "roster_id": 7,
+            "owner_id": 1,
+            "previous_owner_id": 7
+        },
+        {
+            "round": 2,
+            "roster_id": 7,
+            "owner_id": 1,
+            "previous_owner_id": 7
+        },
+        {
+            "round": 3,
+            "roster_id": 7,
+            "owner_id": 4,
+            "previous_owner_id": 7
+        },
+        {
+            "round": 1,
+            "roster_id": 9,
+            "owner_id": 6,
+            "previous_owner_id": 9
+        },
+        {
+            "round": 4,
+            "roster_id": 9,
+            "owner_id": 5,
+            "previous_owner_id": 7
+        },
+        {
+            "round": 1,
+            "roster_id": 10,
+            "owner_id": 7,
+            "previous_owner_id": 10
+        },
+        {
+            "round": 2,
+            "roster_id": 10,
+            "owner_id": 2,
+            "previous_owner_id": 10
+        },
+        {
+            "round": 1,
+            "roster_id": 11,
+            "owner_id": 4,
+            "previous_owner_id": 1
+        },
+        {
+            "round": 2,
+            "roster_id": 11,
+            "owner_id": 7,
+            "previous_owner_id": 11
+        },
+        {
+            "round": 3,
+            "roster_id": 11,
+            "owner_id": 5,
+            "previous_owner_id": 7
+        },
+        {
+            "round": 1,
+            "roster_id": 12,
+            "owner_id": 5,
+            "previous_owner_id": 12
+        },
+        {
+            "round": 2,
+            "roster_id": 12,
+            "owner_id": 6,
+            "previous_owner_id": 12
+        },
+        {
+            "round": 3,
+            "roster_id": 12,
+            "owner_id": 5,
+            "previous_owner_id": 12
+        }
+    ],
+    "rosterData": [
+        {
+            "roster_id": 1,
+            "owner_id": "521035584588267520",
+            "players": [
+                "11435",
+                "11569",
+                "11631",
+                "11646",
+                "12474",
+                "12490",
+                "12492",
+                "12509",
+                "12526",
+                "13274",
+                "13279",
+                "13288",
+                "13346",
+                "13405",
+                "13421",
+                "1373",
+                "4018",
+                "4039",
+                "4137",
+                "4950",
+                "4984",
+                "5001",
+                "5012",
+                "7553",
+                "7591",
+                "8117",
+                "8134",
+                "8148",
+                "8408",
+                "9480"
+            ],
+            "manager_display_name": "ryangh",
+            "avatar": "b5cdc0dfb49f018bd6a38bc33bc61c99"
+        },
+        {
+            "roster_id": 2,
+            "owner_id": "521424042611961856",
+            "players": [
+                "11565",
+                "11626",
+                "12495",
+                "12499",
+                "12512",
+                "12524",
+                "13272",
+                "13294",
+                "13317",
+                "13319",
+                "13434",
+                "2078",
+                "2216",
+                "3163",
+                "3198",
+                "4993",
+                "5844",
+                "5870",
+                "5947",
+                "5967",
+                "6783",
+                "6826",
+                "8126",
+                "8188",
+                "8225",
+                "9225",
+                "9504"
+            ],
+            "manager_display_name": "aphilliny21",
+            "avatar": "3dd5a49b6e8b46b474e36af0acaf7914"
+        },
+        {
+            "roster_id": 3,
+            "owner_id": "467132282604351488",
+            "players": [
+                "10219",
+                "10232",
+                "11370",
+                "11557",
+                "11564",
+                "11575",
+                "11589",
+                "11592",
+                "11655",
+                "1166",
+                "12048",
+                "12489",
+                "12521",
+                "12543",
+                "13345",
+                "13380",
+                "3257",
+                "4881",
+                "5849",
+                "6149",
+                "6794",
+                "7021",
+                "7564",
+                "7588",
+                "7610",
+                "8112",
+                "8130",
+                "8150",
+                "8698",
+                "9488"
+            ],
+            "manager_display_name": "OptimalPooper",
+            "avatar": "2c8a8167cf05381ebcc6f971aa8653cd"
+        },
+        {
+            "roster_id": 4,
+            "owner_id": "521485413219885056",
+            "players": [
+                "11299",
+                "11563",
+                "11576",
+                "11628",
+                "11637",
+                "11834",
+                "12457",
+                "12504",
+                "12507",
+                "12511",
+                "12514",
+                "12889",
+                "13275",
+                "13286",
+                "13298",
+                "13302",
+                "13420",
+                "2374",
+                "4098",
+                "4199",
+                "5906",
+                "6804",
+                "6865",
+                "7002",
+                "8122",
+                "8135",
+                "8144",
+                "9482",
+                "9756"
+            ],
+            "manager_display_name": "CHood20",
+            "avatar": "0b99d6cc26aa7519e37cdfb269184da3"
+        },
+        {
+            "roster_id": 5,
+            "owner_id": "989213899293569024",
+            "players": [
+                "11571",
+                "11581",
+                "11596",
+                "11610",
+                "11635",
+                "11643",
+                "12467",
+                "12469",
+                "12483",
+                "12493",
+                "12502",
+                "12503",
+                "12508",
+                "12527",
+                "12536",
+                "12547",
+                "13276",
+                "13287",
+                "13289",
+                "13296",
+                "13306",
+                "13335",
+                "13347",
+                "13349",
+                "13411",
+                "7523",
+                "7571",
+                "9230",
+                "9506",
+                "9753"
+            ],
+            "manager_display_name": "HEFFinAround305",
+            "avatar": "e7af4deab0289b4f5505646424895246"
+        },
+        {
+            "roster_id": 6,
+            "owner_id": "665051007910236160",
+            "players": [
+                "10222",
+                "11566",
+                "11600",
+                "11625",
+                "11632",
+                "12484",
+                "12497",
+                "12498",
+                "12517",
+                "12534",
+                "12535",
+                "12545",
+                "13278",
+                "13281",
+                "13301",
+                "13320",
+                "13333",
+                "13417",
+                "421",
+                "4981",
+                "5022",
+                "5846",
+                "6770",
+                "8138",
+                "8142",
+                "8155",
+                "8167",
+                "9221",
+                "9226",
+                "9754"
+            ],
+            "manager_display_name": "Bloomberg4",
+            "avatar": "b319fdf8b7b5b0359d3c78622ba4d70c"
+        },
+        {
+            "roster_id": 7,
+            "owner_id": "464153930528452608",
+            "players": [
+                "10235",
+                "11783",
+                "12485",
+                "12500",
+                "12540",
+                "13285",
+                "13330",
+                "13402",
+                "13403",
+                "4037",
+                "4217",
+                "4866",
+                "4892",
+                "5995",
+                "6813",
+                "6819",
+                "7049",
+                "7527",
+                "7543",
+                "7569",
+                "8111",
+                "8132",
+                "8146",
+                "8160",
+                "8172",
+                "8180",
+                "9228",
+                "9484",
+                "9486",
+                "9501"
+            ],
+            "manager_display_name": "crbiehl",
+            "avatar": "4f4090e5e9c3941414db40a871e3e909"
+        },
+        {
+            "roster_id": 8,
+            "owner_id": "999040645685649408",
+            "players": [
+                "10859",
+                "11577",
+                "11597",
+                "11618",
+                "11624",
+                "12481",
+                "12505",
+                "12522",
+                "12531",
+                "13269",
+                "13305",
+                "13311",
+                "13404",
+                "1426",
+                "2133",
+                "3214",
+                "4943",
+                "5892",
+                "6790",
+                "7525",
+                "7526",
+                "8125",
+                "8136",
+                "8151",
+                "9481",
+                "9511",
+                "96",
+                "9999"
+            ],
+            "manager_display_name": "cmurtagh86",
+            "avatar": "f0edbf4278f53f9425db175073df6584"
+        },
+        {
+            "roster_id": 9,
+            "owner_id": "467766220007927808",
+            "players": [
+                "10213",
+                "11586",
+                "11603",
+                "11604",
+                "11638",
+                "12470",
+                "12476",
+                "12501",
+                "12518",
+                "12529",
+                "13268",
+                "13293",
+                "13303",
+                "13337",
+                "13342",
+                "13353",
+                "4983",
+                "6803",
+                "7585",
+                "7600",
+                "8137",
+                "8183",
+                "8210",
+                "8228",
+                "9224",
+                "9487",
+                "9502",
+                "9758"
+            ],
+            "manager_display_name": "gdavidson",
+            "avatar": "4d46b7d568cc71d4819293c612731196"
+        },
+        {
+            "roster_id": 10,
+            "owner_id": "325380343328686080",
+            "players": [
+                "11256",
+                "11560",
+                "11583",
+                "11584",
+                "11627",
+                "11647",
+                "11651",
+                "12471",
+                "12487",
+                "12510",
+                "12519",
+                "12530",
+                "12544",
+                "13392",
+                "13414",
+                "13423",
+                "1466",
+                "2449",
+                "4017",
+                "4034",
+                "4046",
+                "5045",
+                "5859",
+                "6011",
+                "7594",
+                "8110",
+                "8154",
+                "8800",
+                "9494",
+                "9997"
+            ],
+            "manager_display_name": "spight",
+            "avatar": "db7b742f6549b03367eb48ed1e328e5e"
+        },
+        {
+            "roster_id": 11,
+            "owner_id": "325371992242946048",
+            "players": [
+                "10216",
+                "10226",
+                "10236",
+                "11559",
+                "12472",
+                "13324",
+                "13338",
+                "13413",
+                "13424",
+                "19",
+                "3294",
+                "3321",
+                "4035",
+                "4179",
+                "6271",
+                "6768",
+                "6786",
+                "6806",
+                "7547",
+                "7670",
+                "827",
+                "829",
+                "8917",
+                "9229",
+                "9479",
+                "9493",
+                "9500",
+                "9508",
+                "9509"
+            ],
+            "manager_display_name": "kpresley",
+            "avatar": "00b11790b9017eaade80f30127ec9986"
+        },
+        {
+            "roster_id": 12,
+            "owner_id": "560984104439771136",
+            "players": [
+                "10229",
+                "11199",
+                "11620",
+                "12506",
+                "12533",
+                "12641",
+                "12670",
+                "13079",
+                "13150",
+                "13329",
+                "13348",
+                "13400",
+                "13418",
+                "2307",
+                "4066",
+                "5850",
+                "5872",
+                "5927",
+                "6797",
+                "6801",
+                "6904",
+                "7090",
+                "7567",
+                "7611",
+                "8119",
+                "8121",
+                "8131",
+                "8161",
+                "8205",
+                "8676"
+            ],
+            "manager_display_name": "MaddensWok",
+            "avatar": "f2c37a242ed4c9a774bb10a881f1a024"
+        }
+    ],
+    "playerInfo": {
+        "4984": {
+            "player_id": "4984",
+            "first_name": "Josh",
+            "last_name": "Allen",
+            "full_name": "Josh Allen",
+            "team": "BUF",
+            "position": "QB",
+            "fantasy_positions": [
+                "QB"
+            ],
+            "search_rank": 1,
+            "years_exp": 8,
+            "is_taken": true,
+            "rostered_by": "ryangh",
+            "in_lineup": false
+        },
+        "6813": {
+            "player_id": "6813",
+            "first_name": "Jonathan",
+            "last_name": "Taylor",
+            "full_name": "Jonathan Taylor",
+            "team": "IND",
+            "position": "RB",
+            "fantasy_positions": [
+                "RB"
+            ],
+            "search_rank": 4,
+            "years_exp": 6,
+            "is_taken": true,
+            "rostered_by": "crbiehl",
+            "in_lineup": false
+        },
+        "7564": {
+            "player_id": "7564",
+            "first_name": "Ja'Marr",
+            "last_name": "Chase",
+            "full_name": "Ja'Marr Chase",
+            "team": "CIN",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 3,
+            "years_exp": 5,
+            "is_taken": true,
+            "rostered_by": "OptimalPooper",
+            "in_lineup": false
+        },
+        "9221": {
+            "player_id": "9221",
+            "first_name": "Jahmyr",
+            "last_name": "Gibbs",
+            "full_name": "Jahmyr Gibbs",
+            "team": "DET",
+            "position": "RB",
+            "fantasy_positions": [
+                "RB"
+            ],
+            "search_rank": 2,
+            "years_exp": 3,
+            "is_taken": true,
+            "rostered_by": "Bloomberg4",
+            "in_lineup": false
+        },
+        "9509": {
+            "player_id": "9509",
+            "first_name": "Bijan",
+            "last_name": "Robinson",
+            "full_name": "Bijan Robinson",
+            "team": "ATL",
+            "position": "RB",
+            "fantasy_positions": [
+                "RB"
+            ],
+            "search_rank": 1,
+            "years_exp": 3,
+            "is_taken": true,
+            "rostered_by": "kpresley",
+            "in_lineup": false
+        },
+        "11564": {
+            "player_id": "11564",
+            "first_name": "Drake",
+            "last_name": "Maye",
+            "full_name": "Drake Maye",
+            "team": "NE",
+            "position": "QB",
+            "fantasy_positions": [
+                "QB"
+            ],
+            "search_rank": 3,
+            "years_exp": 2,
+            "is_taken": true,
+            "rostered_by": "OptimalPooper",
+            "in_lineup": false
+        },
+        "13268": {
+            "player_id": "13268",
+            "first_name": "Elijah",
+            "last_name": "Sarratt",
+            "full_name": "Elijah Sarratt",
+            "team": "BAL",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 201,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "gdavidson",
+            "in_lineup": false
+        },
+        "13269": {
+            "player_id": "13269",
+            "first_name": "Fernando",
+            "last_name": "Mendoza",
+            "full_name": "Fernando Mendoza",
+            "team": "LV",
+            "position": "QB",
+            "fantasy_positions": [
+                "QB"
+            ],
+            "search_rank": 39,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "cmurtagh86",
+            "in_lineup": false
+        },
+        "13272": {
+            "player_id": "13272",
+            "first_name": "Carson",
+            "last_name": "Beck",
+            "full_name": "Carson Beck",
+            "team": "ARI",
+            "position": "QB",
+            "fantasy_positions": [
+                "QB"
+            ],
+            "search_rank": 416,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "aphilliny21",
+            "in_lineup": false
+        },
+        "13274": {
+            "player_id": "13274",
+            "first_name": "Germie",
+            "last_name": "Bernard",
+            "full_name": "Germie Bernard",
+            "team": "PIT",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 194,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "ryangh",
+            "in_lineup": false
+        },
+        "13275": {
+            "player_id": "13275",
+            "first_name": "Ty",
+            "last_name": "Simpson",
+            "full_name": "Ty Simpson",
+            "team": "LAR",
+            "position": "QB",
+            "fantasy_positions": [
+                "QB"
+            ],
+            "search_rank": 141,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "CHood20",
+            "in_lineup": false
+        },
+        "13276": {
+            "player_id": "13276",
+            "first_name": "Omar",
+            "last_name": "Cooper",
+            "full_name": "Omar Cooper",
+            "team": "NYJ",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 146,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "HEFFinAround305",
+            "in_lineup": false
+        },
+        "13278": {
+            "player_id": "13278",
+            "first_name": "Max",
+            "last_name": "Klare",
+            "full_name": "Max Klare",
+            "team": "LAR",
+            "position": "TE",
+            "fantasy_positions": [
+                "TE"
+            ],
+            "search_rank": 212,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "Bloomberg4",
+            "in_lineup": false
+        },
+        "13279": {
+            "player_id": "13279",
+            "first_name": "Carnell",
+            "last_name": "Tate",
+            "full_name": "Carnell Tate",
+            "team": "TEN",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 61,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "ryangh",
+            "in_lineup": false
+        },
+        "13281": {
+            "player_id": "13281",
+            "first_name": "Jordyn",
+            "last_name": "Tyson",
+            "full_name": "Jordyn Tyson",
+            "team": "NO",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 69,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "Bloomberg4",
+            "in_lineup": false
+        },
+        "13285": {
+            "player_id": "13285",
+            "first_name": "Malachi",
+            "last_name": "Fields",
+            "full_name": "Malachi Fields",
+            "team": "NYG",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 210,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "crbiehl",
+            "in_lineup": false
+        },
+        "13286": {
+            "player_id": "13286",
+            "first_name": "Jadarian",
+            "last_name": "Price",
+            "full_name": "Jadarian Price",
+            "team": "SEA",
+            "position": "RB",
+            "fantasy_positions": [
+                "RB"
+            ],
+            "search_rank": 63,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "CHood20",
+            "in_lineup": false
+        },
+        "13287": {
+            "player_id": "13287",
+            "first_name": "Jeremiyah",
+            "last_name": "Love",
+            "full_name": "Jeremiyah Love",
+            "team": "ARI",
+            "position": "RB",
+            "fantasy_positions": [
+                "RB"
+            ],
+            "search_rank": 15,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "HEFFinAround305",
+            "in_lineup": false
+        },
+        "13288": {
+            "player_id": "13288",
+            "first_name": "Nicholas",
+            "last_name": "Singleton",
+            "full_name": "Nicholas Singleton",
+            "team": "TEN",
+            "position": "RB",
+            "fantasy_positions": [
+                "RB"
+            ],
+            "search_rank": 167,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "ryangh",
+            "in_lineup": false
+        },
+        "13289": {
+            "player_id": "13289",
+            "first_name": "Drew",
+            "last_name": "Allar",
+            "full_name": "Drew Allar",
+            "team": "PIT",
+            "position": "QB",
+            "fantasy_positions": [
+                "QB"
+            ],
+            "search_rank": 999,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "HEFFinAround305",
+            "in_lineup": false
+        },
+        "13293": {
+            "player_id": "13293",
+            "first_name": "Ja'Kobi",
+            "last_name": "Lane",
+            "full_name": "Ja'Kobi Lane",
+            "team": "BAL",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 182,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "gdavidson",
+            "in_lineup": false
+        },
+        "13294": {
+            "player_id": "13294",
+            "first_name": "Makai",
+            "last_name": "Lemon",
+            "full_name": "Makai Lemon",
+            "team": "PHI",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 77,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "aphilliny21",
+            "in_lineup": false
+        },
+        "13296": {
+            "player_id": "13296",
+            "first_name": "Caleb",
+            "last_name": "Douglas",
+            "full_name": "Caleb Douglas",
+            "team": "MIA",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 999,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "HEFFinAround305",
+            "in_lineup": false
+        },
+        "13298": {
+            "player_id": "13298",
+            "first_name": "KC",
+            "last_name": "Concepcion",
+            "full_name": "KC Concepcion",
+            "team": "CLE",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 116,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "CHood20",
+            "in_lineup": false
+        },
+        "13301": {
+            "player_id": "13301",
+            "first_name": "Antonio",
+            "last_name": "Williams",
+            "full_name": "Antonio Williams",
+            "team": "WAS",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 156,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "Bloomberg4",
+            "in_lineup": false
+        },
+        "13302": {
+            "player_id": "13302",
+            "first_name": "Adam",
+            "last_name": "Randall",
+            "full_name": "Adam Randall",
+            "team": "BAL",
+            "position": "RB",
+            "fantasy_positions": [
+                "RB"
+            ],
+            "search_rank": 999,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "CHood20",
+            "in_lineup": false
+        },
+        "13303": {
+            "player_id": "13303",
+            "first_name": "Cade",
+            "last_name": "Klubnik",
+            "full_name": "Cade Klubnik",
+            "team": "NYJ",
+            "position": "QB",
+            "fantasy_positions": [
+                "QB"
+            ],
+            "search_rank": 398,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "gdavidson",
+            "in_lineup": false
+        },
+        "13305": {
+            "player_id": "13305",
+            "first_name": "Mike",
+            "last_name": "Washington",
+            "full_name": "Mike Washington",
+            "team": "LV",
+            "position": "RB",
+            "fantasy_positions": [
+                "RB"
+            ],
+            "search_rank": 139,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "cmurtagh86",
+            "in_lineup": false
+        },
+        "13306": {
+            "player_id": "13306",
+            "first_name": "Taylen",
+            "last_name": "Green",
+            "full_name": "Taylen Green",
+            "team": "CLE",
+            "position": "QB",
+            "fantasy_positions": [
+                "QB"
+            ],
+            "search_rank": 999,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "HEFFinAround305",
+            "in_lineup": false
+        },
+        "13311": {
+            "player_id": "13311",
+            "first_name": "Chris",
+            "last_name": "Bell",
+            "full_name": "Chris Bell",
+            "team": "MIA",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 203,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "cmurtagh86",
+            "in_lineup": false
+        },
+        "13317": {
+            "player_id": "13317",
+            "first_name": "Ted",
+            "last_name": "Hurst",
+            "full_name": "Ted Hurst",
+            "team": "TB",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 196,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "aphilliny21",
+            "in_lineup": false
+        },
+        "13319": {
+            "player_id": "13319",
+            "first_name": "Oscar",
+            "last_name": "Delp",
+            "full_name": "Oscar Delp",
+            "team": "NO",
+            "position": "TE",
+            "fantasy_positions": [
+                "TE"
+            ],
+            "search_rank": 999,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "aphilliny21",
+            "in_lineup": false
+        },
+        "13320": {
+            "player_id": "13320",
+            "first_name": "Zachariah",
+            "last_name": "Branch",
+            "full_name": "Zachariah Branch",
+            "team": "ATL",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 180,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "Bloomberg4",
+            "in_lineup": false
+        },
+        "13330": {
+            "player_id": "13330",
+            "first_name": "Kenyon",
+            "last_name": "Sadiq",
+            "full_name": "Kenyon Sadiq",
+            "team": "NYJ",
+            "position": "TE",
+            "fantasy_positions": [
+                "TE"
+            ],
+            "search_rank": 109,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "crbiehl",
+            "in_lineup": false
+        },
+        "13333": {
+            "player_id": "13333",
+            "first_name": "Deion",
+            "last_name": "Burks",
+            "full_name": "Deion Burks",
+            "team": "IND",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 999,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "Bloomberg4",
+            "in_lineup": false
+        },
+        "13337": {
+            "player_id": "13337",
+            "first_name": "Emmett",
+            "last_name": "Johnson",
+            "full_name": "Emmett Johnson",
+            "team": "KC",
+            "position": "RB",
+            "fantasy_positions": [
+                "RB"
+            ],
+            "search_rank": 113,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "gdavidson",
+            "in_lineup": false
+        },
+        "13338": {
+            "player_id": "13338",
+            "first_name": "Kevin",
+            "last_name": "Coleman",
+            "full_name": "Kevin Coleman",
+            "team": "MIA",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 999,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "kpresley",
+            "in_lineup": false
+        },
+        "13345": {
+            "player_id": "13345",
+            "first_name": "Jonah",
+            "last_name": "Coleman",
+            "full_name": "Jonah Coleman",
+            "team": "DEN",
+            "position": "RB",
+            "fantasy_positions": [
+                "RB"
+            ],
+            "search_rank": 118,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "OptimalPooper",
+            "in_lineup": false
+        },
+        "13346": {
+            "player_id": "13346",
+            "first_name": "Denzel",
+            "last_name": "Boston",
+            "full_name": "Denzel Boston",
+            "team": "CLE",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 144,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "ryangh",
+            "in_lineup": false
+        },
+        "13347": {
+            "player_id": "13347",
+            "first_name": "Demond",
+            "last_name": "Claiborne",
+            "full_name": "Demond Claiborne",
+            "team": "MIN",
+            "position": "RB",
+            "fantasy_positions": [
+                "RB"
+            ],
+            "search_rank": 176,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "HEFFinAround305",
+            "in_lineup": false
+        },
+        "13348": {
+            "player_id": "13348",
+            "first_name": "J'Mari",
+            "last_name": "Taylor",
+            "full_name": "J'Mari Taylor",
+            "team": "JAX",
+            "position": "RB",
+            "fantasy_positions": [
+                "RB"
+            ],
+            "search_rank": 999,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "MaddensWok",
+            "in_lineup": false
+        },
+        "13349": {
+            "player_id": "13349",
+            "first_name": "Eli",
+            "last_name": "Stowers",
+            "full_name": "Eli Stowers",
+            "team": "PHI",
+            "position": "TE",
+            "fantasy_positions": [
+                "TE"
+            ],
+            "search_rank": 140,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "HEFFinAround305",
+            "in_lineup": false
+        },
+        "13353": {
+            "player_id": "13353",
+            "first_name": "Chris",
+            "last_name": "Brazzell",
+            "full_name": "Chris Brazzell",
+            "team": "CAR",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 202,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "gdavidson",
+            "in_lineup": false
+        },
+        "13380": {
+            "player_id": "13380",
+            "first_name": "Brenen",
+            "last_name": "Thompson",
+            "full_name": "Brenen Thompson",
+            "team": "LAC",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 999,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "OptimalPooper",
+            "in_lineup": false
+        },
+        "13400": {
+            "player_id": "13400",
+            "first_name": "Justin",
+            "last_name": "Joly",
+            "full_name": "Justin Joly",
+            "team": "DEN",
+            "position": "TE",
+            "fantasy_positions": [
+                "TE"
+            ],
+            "search_rank": 999,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "MaddensWok",
+            "in_lineup": false
+        },
+        "13402": {
+            "player_id": "13402",
+            "first_name": "Skyler",
+            "last_name": "Bell",
+            "full_name": "Skyler Bell",
+            "team": "BUF",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 999,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "crbiehl",
+            "in_lineup": false
+        },
+        "13403": {
+            "player_id": "13403",
+            "first_name": "Jam",
+            "last_name": "Miller",
+            "full_name": "Jam Miller",
+            "team": "NE",
+            "position": "RB",
+            "fantasy_positions": [
+                "RB"
+            ],
+            "search_rank": 999,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "crbiehl",
+            "in_lineup": false
+        },
+        "13404": {
+            "player_id": "13404",
+            "first_name": "Garrett",
+            "last_name": "Nussmeier",
+            "full_name": "Garrett Nussmeier",
+            "team": "KC",
+            "position": "QB",
+            "fantasy_positions": [
+                "QB"
+            ],
+            "search_rank": 329,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "cmurtagh86",
+            "in_lineup": false
+        },
+        "13405": {
+            "player_id": "13405",
+            "first_name": "Kaytron",
+            "last_name": "Allen",
+            "full_name": "Kaytron Allen",
+            "team": "WAS",
+            "position": "RB",
+            "fantasy_positions": [
+                "RB"
+            ],
+            "search_rank": 157,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "ryangh",
+            "in_lineup": false
+        },
+        "13414": {
+            "player_id": "13414",
+            "first_name": "Kaelon",
+            "last_name": "Black",
+            "full_name": "Kaelon Black",
+            "team": "SF",
+            "position": "RB",
+            "fantasy_positions": [
+                "RB"
+            ],
+            "search_rank": 999,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "spight",
+            "in_lineup": false
+        },
+        "13417": {
+            "player_id": "13417",
+            "first_name": "De'Zhaun",
+            "last_name": "Stribling",
+            "full_name": "De'Zhaun Stribling",
+            "team": "SF",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 202,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "Bloomberg4",
+            "in_lineup": false
+        },
+        "13420": {
+            "player_id": "13420",
+            "first_name": "Bryce",
+            "last_name": "Lance",
+            "full_name": "Bryce Lance",
+            "team": "NO",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 999,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "CHood20",
+            "in_lineup": false
+        },
+        "13421": {
+            "player_id": "13421",
+            "first_name": "Eli",
+            "last_name": "Raridon",
+            "full_name": "Eli Raridon",
+            "team": "NE",
+            "position": "TE",
+            "fantasy_positions": [
+                "TE"
+            ],
+            "search_rank": 999,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "ryangh",
+            "in_lineup": false
+        },
+        "13423": {
+            "player_id": "13423",
+            "first_name": "Eli",
+            "last_name": "Heidenreich",
+            "full_name": "Eli Heidenreich",
+            "team": "PIT",
+            "position": "RB",
+            "fantasy_positions": [
+                "RB"
+            ],
+            "search_rank": 999,
+            "years_exp": 0,
+            "is_taken": true,
+            "rostered_by": "spight",
+            "in_lineup": false
+        }
+    },
+    "playerInfoPreDraft": {
+        "4984": {
+            "player_id": "4984",
+            "first_name": "Josh",
+            "last_name": "Allen",
+            "full_name": "Josh Allen",
+            "team": "BUF",
+            "position": "QB",
+            "fantasy_positions": [
+                "QB"
+            ],
+            "search_rank": 1,
+            "years_exp": 8,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "6813": {
+            "player_id": "6813",
+            "first_name": "Jonathan",
+            "last_name": "Taylor",
+            "full_name": "Jonathan Taylor",
+            "team": "IND",
+            "position": "RB",
+            "fantasy_positions": [
+                "RB"
+            ],
+            "search_rank": 4,
+            "years_exp": 6,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "7564": {
+            "player_id": "7564",
+            "first_name": "Ja'Marr",
+            "last_name": "Chase",
+            "full_name": "Ja'Marr Chase",
+            "team": "CIN",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 3,
+            "years_exp": 5,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "9221": {
+            "player_id": "9221",
+            "first_name": "Jahmyr",
+            "last_name": "Gibbs",
+            "full_name": "Jahmyr Gibbs",
+            "team": "DET",
+            "position": "RB",
+            "fantasy_positions": [
+                "RB"
+            ],
+            "search_rank": 2,
+            "years_exp": 3,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "9509": {
+            "player_id": "9509",
+            "first_name": "Bijan",
+            "last_name": "Robinson",
+            "full_name": "Bijan Robinson",
+            "team": "ATL",
+            "position": "RB",
+            "fantasy_positions": [
+                "RB"
+            ],
+            "search_rank": 1,
+            "years_exp": 3,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "11564": {
+            "player_id": "11564",
+            "first_name": "Drake",
+            "last_name": "Maye",
+            "full_name": "Drake Maye",
+            "team": "NE",
+            "position": "QB",
+            "fantasy_positions": [
+                "QB"
+            ],
+            "search_rank": 3,
+            "years_exp": 2,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13268": {
+            "player_id": "13268",
+            "first_name": "Elijah",
+            "last_name": "Sarratt",
+            "full_name": "Elijah Sarratt",
+            "team": "BAL",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 201,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13269": {
+            "player_id": "13269",
+            "first_name": "Fernando",
+            "last_name": "Mendoza",
+            "full_name": "Fernando Mendoza",
+            "team": "LV",
+            "position": "QB",
+            "fantasy_positions": [
+                "QB"
+            ],
+            "search_rank": 39,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13272": {
+            "player_id": "13272",
+            "first_name": "Carson",
+            "last_name": "Beck",
+            "full_name": "Carson Beck",
+            "team": "ARI",
+            "position": "QB",
+            "fantasy_positions": [
+                "QB"
+            ],
+            "search_rank": 416,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13274": {
+            "player_id": "13274",
+            "first_name": "Germie",
+            "last_name": "Bernard",
+            "full_name": "Germie Bernard",
+            "team": "PIT",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 194,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13275": {
+            "player_id": "13275",
+            "first_name": "Ty",
+            "last_name": "Simpson",
+            "full_name": "Ty Simpson",
+            "team": "LAR",
+            "position": "QB",
+            "fantasy_positions": [
+                "QB"
+            ],
+            "search_rank": 141,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13276": {
+            "player_id": "13276",
+            "first_name": "Omar",
+            "last_name": "Cooper",
+            "full_name": "Omar Cooper",
+            "team": "NYJ",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 146,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13278": {
+            "player_id": "13278",
+            "first_name": "Max",
+            "last_name": "Klare",
+            "full_name": "Max Klare",
+            "team": "LAR",
+            "position": "TE",
+            "fantasy_positions": [
+                "TE"
+            ],
+            "search_rank": 212,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13279": {
+            "player_id": "13279",
+            "first_name": "Carnell",
+            "last_name": "Tate",
+            "full_name": "Carnell Tate",
+            "team": "TEN",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 61,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13281": {
+            "player_id": "13281",
+            "first_name": "Jordyn",
+            "last_name": "Tyson",
+            "full_name": "Jordyn Tyson",
+            "team": "NO",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 69,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13285": {
+            "player_id": "13285",
+            "first_name": "Malachi",
+            "last_name": "Fields",
+            "full_name": "Malachi Fields",
+            "team": "NYG",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 210,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13286": {
+            "player_id": "13286",
+            "first_name": "Jadarian",
+            "last_name": "Price",
+            "full_name": "Jadarian Price",
+            "team": "SEA",
+            "position": "RB",
+            "fantasy_positions": [
+                "RB"
+            ],
+            "search_rank": 63,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13287": {
+            "player_id": "13287",
+            "first_name": "Jeremiyah",
+            "last_name": "Love",
+            "full_name": "Jeremiyah Love",
+            "team": "ARI",
+            "position": "RB",
+            "fantasy_positions": [
+                "RB"
+            ],
+            "search_rank": 15,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13288": {
+            "player_id": "13288",
+            "first_name": "Nicholas",
+            "last_name": "Singleton",
+            "full_name": "Nicholas Singleton",
+            "team": "TEN",
+            "position": "RB",
+            "fantasy_positions": [
+                "RB"
+            ],
+            "search_rank": 167,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13289": {
+            "player_id": "13289",
+            "first_name": "Drew",
+            "last_name": "Allar",
+            "full_name": "Drew Allar",
+            "team": "PIT",
+            "position": "QB",
+            "fantasy_positions": [
+                "QB"
+            ],
+            "search_rank": 999,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13293": {
+            "player_id": "13293",
+            "first_name": "Ja'Kobi",
+            "last_name": "Lane",
+            "full_name": "Ja'Kobi Lane",
+            "team": "BAL",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 182,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13294": {
+            "player_id": "13294",
+            "first_name": "Makai",
+            "last_name": "Lemon",
+            "full_name": "Makai Lemon",
+            "team": "PHI",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 77,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13296": {
+            "player_id": "13296",
+            "first_name": "Caleb",
+            "last_name": "Douglas",
+            "full_name": "Caleb Douglas",
+            "team": "MIA",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 999,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13298": {
+            "player_id": "13298",
+            "first_name": "KC",
+            "last_name": "Concepcion",
+            "full_name": "KC Concepcion",
+            "team": "CLE",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 116,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13301": {
+            "player_id": "13301",
+            "first_name": "Antonio",
+            "last_name": "Williams",
+            "full_name": "Antonio Williams",
+            "team": "WAS",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 156,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13302": {
+            "player_id": "13302",
+            "first_name": "Adam",
+            "last_name": "Randall",
+            "full_name": "Adam Randall",
+            "team": "BAL",
+            "position": "RB",
+            "fantasy_positions": [
+                "RB"
+            ],
+            "search_rank": 999,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13303": {
+            "player_id": "13303",
+            "first_name": "Cade",
+            "last_name": "Klubnik",
+            "full_name": "Cade Klubnik",
+            "team": "NYJ",
+            "position": "QB",
+            "fantasy_positions": [
+                "QB"
+            ],
+            "search_rank": 398,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13305": {
+            "player_id": "13305",
+            "first_name": "Mike",
+            "last_name": "Washington",
+            "full_name": "Mike Washington",
+            "team": "LV",
+            "position": "RB",
+            "fantasy_positions": [
+                "RB"
+            ],
+            "search_rank": 139,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13306": {
+            "player_id": "13306",
+            "first_name": "Taylen",
+            "last_name": "Green",
+            "full_name": "Taylen Green",
+            "team": "CLE",
+            "position": "QB",
+            "fantasy_positions": [
+                "QB"
+            ],
+            "search_rank": 999,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13311": {
+            "player_id": "13311",
+            "first_name": "Chris",
+            "last_name": "Bell",
+            "full_name": "Chris Bell",
+            "team": "MIA",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 203,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13317": {
+            "player_id": "13317",
+            "first_name": "Ted",
+            "last_name": "Hurst",
+            "full_name": "Ted Hurst",
+            "team": "TB",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 196,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13319": {
+            "player_id": "13319",
+            "first_name": "Oscar",
+            "last_name": "Delp",
+            "full_name": "Oscar Delp",
+            "team": "NO",
+            "position": "TE",
+            "fantasy_positions": [
+                "TE"
+            ],
+            "search_rank": 999,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13320": {
+            "player_id": "13320",
+            "first_name": "Zachariah",
+            "last_name": "Branch",
+            "full_name": "Zachariah Branch",
+            "team": "ATL",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 180,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13330": {
+            "player_id": "13330",
+            "first_name": "Kenyon",
+            "last_name": "Sadiq",
+            "full_name": "Kenyon Sadiq",
+            "team": "NYJ",
+            "position": "TE",
+            "fantasy_positions": [
+                "TE"
+            ],
+            "search_rank": 109,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13333": {
+            "player_id": "13333",
+            "first_name": "Deion",
+            "last_name": "Burks",
+            "full_name": "Deion Burks",
+            "team": "IND",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 999,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13337": {
+            "player_id": "13337",
+            "first_name": "Emmett",
+            "last_name": "Johnson",
+            "full_name": "Emmett Johnson",
+            "team": "KC",
+            "position": "RB",
+            "fantasy_positions": [
+                "RB"
+            ],
+            "search_rank": 113,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13338": {
+            "player_id": "13338",
+            "first_name": "Kevin",
+            "last_name": "Coleman",
+            "full_name": "Kevin Coleman",
+            "team": "MIA",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 999,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13345": {
+            "player_id": "13345",
+            "first_name": "Jonah",
+            "last_name": "Coleman",
+            "full_name": "Jonah Coleman",
+            "team": "DEN",
+            "position": "RB",
+            "fantasy_positions": [
+                "RB"
+            ],
+            "search_rank": 118,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13346": {
+            "player_id": "13346",
+            "first_name": "Denzel",
+            "last_name": "Boston",
+            "full_name": "Denzel Boston",
+            "team": "CLE",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 144,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13347": {
+            "player_id": "13347",
+            "first_name": "Demond",
+            "last_name": "Claiborne",
+            "full_name": "Demond Claiborne",
+            "team": "MIN",
+            "position": "RB",
+            "fantasy_positions": [
+                "RB"
+            ],
+            "search_rank": 176,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13348": {
+            "player_id": "13348",
+            "first_name": "J'Mari",
+            "last_name": "Taylor",
+            "full_name": "J'Mari Taylor",
+            "team": "JAX",
+            "position": "RB",
+            "fantasy_positions": [
+                "RB"
+            ],
+            "search_rank": 999,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13349": {
+            "player_id": "13349",
+            "first_name": "Eli",
+            "last_name": "Stowers",
+            "full_name": "Eli Stowers",
+            "team": "PHI",
+            "position": "TE",
+            "fantasy_positions": [
+                "TE"
+            ],
+            "search_rank": 140,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13353": {
+            "player_id": "13353",
+            "first_name": "Chris",
+            "last_name": "Brazzell",
+            "full_name": "Chris Brazzell",
+            "team": "CAR",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 202,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13380": {
+            "player_id": "13380",
+            "first_name": "Brenen",
+            "last_name": "Thompson",
+            "full_name": "Brenen Thompson",
+            "team": "LAC",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 999,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13400": {
+            "player_id": "13400",
+            "first_name": "Justin",
+            "last_name": "Joly",
+            "full_name": "Justin Joly",
+            "team": "DEN",
+            "position": "TE",
+            "fantasy_positions": [
+                "TE"
+            ],
+            "search_rank": 999,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13402": {
+            "player_id": "13402",
+            "first_name": "Skyler",
+            "last_name": "Bell",
+            "full_name": "Skyler Bell",
+            "team": "BUF",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 999,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13403": {
+            "player_id": "13403",
+            "first_name": "Jam",
+            "last_name": "Miller",
+            "full_name": "Jam Miller",
+            "team": "NE",
+            "position": "RB",
+            "fantasy_positions": [
+                "RB"
+            ],
+            "search_rank": 999,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13404": {
+            "player_id": "13404",
+            "first_name": "Garrett",
+            "last_name": "Nussmeier",
+            "full_name": "Garrett Nussmeier",
+            "team": "KC",
+            "position": "QB",
+            "fantasy_positions": [
+                "QB"
+            ],
+            "search_rank": 329,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13405": {
+            "player_id": "13405",
+            "first_name": "Kaytron",
+            "last_name": "Allen",
+            "full_name": "Kaytron Allen",
+            "team": "WAS",
+            "position": "RB",
+            "fantasy_positions": [
+                "RB"
+            ],
+            "search_rank": 157,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13414": {
+            "player_id": "13414",
+            "first_name": "Kaelon",
+            "last_name": "Black",
+            "full_name": "Kaelon Black",
+            "team": "SF",
+            "position": "RB",
+            "fantasy_positions": [
+                "RB"
+            ],
+            "search_rank": 999,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13417": {
+            "player_id": "13417",
+            "first_name": "De'Zhaun",
+            "last_name": "Stribling",
+            "full_name": "De'Zhaun Stribling",
+            "team": "SF",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 202,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13420": {
+            "player_id": "13420",
+            "first_name": "Bryce",
+            "last_name": "Lance",
+            "full_name": "Bryce Lance",
+            "team": "NO",
+            "position": "WR",
+            "fantasy_positions": [
+                "WR"
+            ],
+            "search_rank": 999,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13421": {
+            "player_id": "13421",
+            "first_name": "Eli",
+            "last_name": "Raridon",
+            "full_name": "Eli Raridon",
+            "team": "NE",
+            "position": "TE",
+            "fantasy_positions": [
+                "TE"
+            ],
+            "search_rank": 999,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        },
+        "13423": {
+            "player_id": "13423",
+            "first_name": "Eli",
+            "last_name": "Heidenreich",
+            "full_name": "Eli Heidenreich",
+            "team": "PIT",
+            "position": "RB",
+            "fantasy_positions": [
+                "RB"
+            ],
+            "search_rank": 999,
+            "years_exp": 0,
+            "is_taken": false,
+            "rostered_by": null,
+            "in_lineup": false
+        }
+    },
+    "rankingPlayersIdsList": [
+        {
+            "ranking": 1,
+            "match_results": [
+                [
+                    "4984",
+                    1
+                ]
+            ]
+        },
+        {
+            "ranking": 2,
+            "match_results": [
+                [
+                    "9509",
+                    1
+                ]
+            ]
+        },
+        {
+            "ranking": 3,
+            "match_results": [
+                [
+                    "9221",
+                    1
+                ]
+            ]
+        },
+        {
+            "ranking": 4,
+            "match_results": [
+                [
+                    "7564",
+                    1
+                ]
+            ]
+        },
+        {
+            "ranking": 5,
+            "match_results": [
+                [
+                    "11564",
+                    1
+                ]
+            ]
+        },
+        {
+            "ranking": 6,
+            "match_results": [
+                [
+                    "6813",
+                    1
+                ]
+            ]
+        },
+        {
+            "ranking": 7,
+            "match_results": [
+                [
+                    "13287",
+                    1
+                ]
+            ]
+        },
+        {
+            "ranking": 8,
+            "match_results": [
+                [
+                    "13269",
+                    1
+                ]
+            ]
+        },
+        {
+            "ranking": 9,
+            "match_results": [
+                [
+                    "13279",
+                    1
+                ]
+            ]
+        }
+    ]
+}

--- a/src/lib/liveDraft.js
+++ b/src/lib/liveDraft.js
@@ -1,0 +1,147 @@
+/**
+ * Applies live pick data onto a draft board. For each entry in `livePicks`,
+ * finds the matching pick by round/board_spot and fills in its `player_id`
+ * and `picked` flag, and marks the drafted player `is_taken` with the
+ * `rostered_by` manager who owns that pick. Never mutates any of its inputs.
+ */
+export function applyLivePicks({ builtDraft, livePicks, playerInfo, rosterData }) {
+    const newBuiltDraft = builtDraft.map((round) => ({ ...round, picks: [...round.picks] }));
+    let newPlayerInfo = playerInfo;
+
+    livePicks.forEach((livePick) => {
+        const { draft_slot: draftSlot, round: pickRound, player_id: playerId } = livePick;
+        const roundEntry = newBuiltDraft[pickRound - 1];
+        const pickIndex = roundEntry.picks.findIndex((pick) => pick.board_spot === draftSlot);
+        const pick = roundEntry.picks[pickIndex];
+        const newPick = { ...pick, player_id: playerId, picked: true };
+        roundEntry.picks[pickIndex] = newPick;
+
+        const roster = rosterData.find((r) => r.roster_id === newPick.owner_id);
+        newPlayerInfo = {
+            ...newPlayerInfo,
+            [playerId]: {
+                ...newPlayerInfo[playerId],
+                is_taken: true,
+                rostered_by: roster.manager_display_name,
+            },
+        };
+    });
+
+    return { builtDraft: newBuiltDraft, playerInfo: newPlayerInfo };
+}
+
+/**
+ * Applies traded-pick records onto a draft board, updating `owner_id` and
+ * `is_traded` on the matching picks. Follows the precedent set in
+ * `buildDraftRounds`: a traded pick whose round or roster doesn't exist on
+ * this board is skipped with a `console.warn` rather than throwing. Never
+ * mutates its inputs.
+ */
+export function applyTradedPicks({ builtDraft, tradedPicks }) {
+    const newBuiltDraft = builtDraft.map((round) => ({ ...round, picks: [...round.picks] }));
+
+    tradedPicks.forEach((tradedPick) => {
+        const roundEntry = newBuiltDraft[tradedPick.round - 1];
+        if (!roundEntry) {
+            console.warn(`Ignoring traded pick for round ${tradedPick.round}: draft has no such round`);
+            return;
+        }
+        const pickIndex = roundEntry.picks.findIndex((pick) => pick.roster_id === tradedPick.roster_id);
+        if (pickIndex === -1) {
+            console.warn(
+                `Ignoring traded pick in round ${tradedPick.round}: roster ${tradedPick.roster_id} has no pick in this draft`,
+            );
+            return;
+        }
+        roundEntry.picks[pickIndex] = {
+            ...roundEntry.picks[pickIndex],
+            owner_id: tradedPick.owner_id,
+            is_traded: true,
+        };
+    });
+
+    return newBuiltDraft;
+}
+
+/**
+ * Renumbers each even (reversed-order) snake round so its picks are ordered
+ * by ascending `pick_number`. The original mutating implementation guarded
+ * this with `if (round.picks[0].board_spot === 1) round.picks.reverse()`
+ * before sorting - that guard only mattered because the same array was being
+ * reversed in place on every poll tick. Sorting by `pick_number` is
+ * order-independent, so a pure implementation doesn't need the reverse at
+ * all; it produces the same result whether or not the picks were already
+ * reversed. Never mutates its input.
+ */
+export function sortSnakeRounds(builtDraft) {
+    return builtDraft.map((round) => {
+        if (round.round % 2 !== 0) {
+            return round;
+        }
+        return { ...round, picks: [...round.picks].sort((a, b) => a.pick_number - b.pick_number) };
+    });
+}
+
+/**
+ * Pure version of `DraftPanel.getLiveDraft`. Composes `applyLivePicks`,
+ * `applyTradedPicks`, and (for snake drafts) `sortSnakeRounds`, in the same
+ * order the original mutating sync did. Returns a brand new
+ * `{ liveDraft, playerInfo }`; never mutates any of its inputs.
+ */
+export function syncLiveDraft({ liveDraft, livePicks, tradedPicks, playerInfo, rosterData, draftType }) {
+    const { builtDraft: builtDraftWithLivePicks, playerInfo: newPlayerInfo } = applyLivePicks({
+        builtDraft: liveDraft.built_draft,
+        livePicks,
+        playerInfo,
+        rosterData,
+    });
+
+    let newBuiltDraft = applyTradedPicks({ builtDraft: builtDraftWithLivePicks, tradedPicks });
+
+    if (draftType === 'snake') {
+        newBuiltDraft = sortSnakeRounds(newBuiltDraft);
+    }
+
+    return {
+        liveDraft: { ...liveDraft, built_draft: newBuiltDraft },
+        playerInfo: newPlayerInfo,
+    };
+}
+
+/**
+ * Pure version of `DraftRound.updatePickSelection`. Assigns (or clears, when
+ * `playerID` is falsy) the player on the pick matching
+ * `currentManualPick.pick_number` within `round`, and updates the affected
+ * player's `is_taken`/`rostered_by` flags to match. Never mutates any of its
+ * inputs.
+ */
+export function applyManualPick({ round, playerInfo, rosterData, currentManualPick, playerID }) {
+    const pickIndex = round.picks.findIndex((pick) => pick.pick_number === currentManualPick.pick_number);
+    const newPicks = [...round.picks];
+    newPicks[pickIndex] = { ...newPicks[pickIndex], player_id: playerID };
+    const newRound = { ...round, picks: newPicks };
+
+    let newPlayerInfo;
+    if (playerID) {
+        const roster = rosterData.find((r) => r.roster_id === currentManualPick.owner_id);
+        newPlayerInfo = {
+            ...playerInfo,
+            [playerID]: {
+                ...playerInfo[playerID],
+                is_taken: true,
+                rostered_by: roster.manager_display_name,
+            },
+        };
+    } else {
+        newPlayerInfo = {
+            ...playerInfo,
+            [currentManualPick.player_id]: {
+                ...playerInfo[currentManualPick.player_id],
+                is_taken: false,
+                rostered_by: null,
+            },
+        };
+    }
+
+    return { round: newRound, playerInfo: newPlayerInfo };
+}

--- a/src/lib/liveDraft.test.js
+++ b/src/lib/liveDraft.test.js
@@ -1,0 +1,396 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { applyLivePicks, applyTradedPicks, sortSnakeRounds, syncLiveDraft, applyManualPick } from './liveDraft.js';
+import fixtureInputs from './__fixtures__/live-draft-sync-2026.json';
+import golden from './__fixtures__/golden-live-draft-sync.json';
+
+// Every test gets its own structuredClone of the fixture, taken fresh in
+// beforeEach. Sharing the raw JSON import across tests would let a mutation
+// bug in one test silently poison the "before" snapshot of a later
+// "does not mutate its inputs" test, masking the very regression it exists
+// to catch.
+let liveDraft;
+let livePicks;
+let livePicksPartial;
+let tradedPicks;
+let rosterData;
+let playerInfo;
+let playerInfoPreDraft;
+
+beforeEach(() => {
+    ({ liveDraft, livePicks, livePicksPartial, tradedPicks, rosterData, playerInfo, playerInfoPreDraft } =
+        structuredClone(fixtureInputs));
+});
+
+describe('syncLiveDraft', () => {
+    it('matches the golden fixture for the real (linear) draft', () => {
+        const result = syncLiveDraft({
+            liveDraft,
+            livePicks,
+            tradedPicks,
+            playerInfo,
+            rosterData,
+            draftType: 'linear',
+        });
+        expect(result).toEqual(golden.linear);
+    });
+
+    it('matches the golden fixture byte-for-byte (catches key-order regressions)', () => {
+        const result = syncLiveDraft({
+            liveDraft,
+            livePicks,
+            tradedPicks,
+            playerInfo,
+            rosterData,
+            draftType: 'linear',
+        });
+        expect(JSON.stringify(result)).toEqual(JSON.stringify(golden.linear));
+    });
+
+    it('matches the golden fixture for two consecutive sync passes (what the 3s poll does)', () => {
+        const first = syncLiveDraft({ liveDraft, livePicks, tradedPicks, playerInfo, rosterData, draftType: 'linear' });
+        const second = syncLiveDraft({
+            liveDraft: first.liveDraft,
+            livePicks,
+            tradedPicks,
+            playerInfo: first.playerInfo,
+            rosterData,
+            draftType: 'linear',
+        });
+        expect(second).toEqual(golden.linearTwice);
+    });
+
+    it('matches the golden fixture for the forced-snake variant', () => {
+        const result = syncLiveDraft({ liveDraft, livePicks, tradedPicks, playerInfo, rosterData, draftType: 'snake' });
+        expect(result).toEqual(golden.snake);
+    });
+
+    it('matches the golden fixture for two consecutive snake sync passes', () => {
+        const first = syncLiveDraft({ liveDraft, livePicks, tradedPicks, playerInfo, rosterData, draftType: 'snake' });
+        const second = syncLiveDraft({
+            liveDraft: first.liveDraft,
+            livePicks,
+            tradedPicks,
+            playerInfo: first.playerInfo,
+            rosterData,
+            draftType: 'snake',
+        });
+        expect(second).toEqual(golden.snakeTwice);
+    });
+
+    it('matches the golden fixture for a partial (in-progress) draft synced from a clean board', () => {
+        const result = syncLiveDraft({
+            liveDraft,
+            livePicks: livePicksPartial,
+            tradedPicks,
+            playerInfo: playerInfoPreDraft,
+            rosterData,
+            draftType: 'linear',
+        });
+        expect(result).toEqual(golden.partialFromClean);
+    });
+
+    it('matches the golden fixture for a full draft synced from a clean board', () => {
+        const result = syncLiveDraft({
+            liveDraft,
+            livePicks,
+            tradedPicks,
+            playerInfo: playerInfoPreDraft,
+            rosterData,
+            draftType: 'linear',
+        });
+        expect(result).toEqual(golden.linearFromClean);
+    });
+
+    it('matches the clean-board golden byte-for-byte', () => {
+        // golden.linear's playerInfo is unchanged from its input (the league's draft
+        // is complete, so markTakenPlayers had already written the same flags), which
+        // makes the byte-comparison above blind to the flag-writing path. This one
+        // starts from playerInfoPreDraft, where every flag the sync writes is new.
+        const result = syncLiveDraft({
+            liveDraft,
+            livePicks,
+            tradedPicks,
+            playerInfo: playerInfoPreDraft,
+            rosterData,
+            draftType: 'linear',
+        });
+        expect(JSON.stringify(result)).toEqual(JSON.stringify(golden.linearFromClean));
+    });
+
+    it('does not mutate its inputs', () => {
+        const clonedLiveDraft = structuredClone(liveDraft);
+        const clonedLivePicks = structuredClone(livePicks);
+        const clonedTradedPicks = structuredClone(tradedPicks);
+        const clonedPlayerInfo = structuredClone(playerInfo);
+        const clonedRosterData = structuredClone(rosterData);
+
+        syncLiveDraft({ liveDraft, livePicks, tradedPicks, playerInfo, rosterData, draftType: 'linear' });
+
+        expect(liveDraft).toEqual(clonedLiveDraft);
+        expect(livePicks).toEqual(clonedLivePicks);
+        expect(tradedPicks).toEqual(clonedTradedPicks);
+        expect(playerInfo).toEqual(clonedPlayerInfo);
+        expect(rosterData).toEqual(clonedRosterData);
+    });
+
+    it('does not mutate its inputs for the snake variant either', () => {
+        const clonedLiveDraft = structuredClone(liveDraft);
+        syncLiveDraft({ liveDraft, livePicks, tradedPicks, playerInfo, rosterData, draftType: 'snake' });
+        expect(liveDraft).toEqual(clonedLiveDraft);
+    });
+
+    it('applies the snake reordering as part of the sync, and only for snake drafts', () => {
+        // buildDraftRounds always emits picks in ascending pick_number order, so on
+        // real data the snake branch changes nothing and golden.snake is byte-identical
+        // to golden.linear. Without this test, deleting the sortSnakeRounds call from
+        // syncLiveDraft entirely would leave the whole suite green.
+        const outOfOrder = {
+            ...liveDraft,
+            built_draft: liveDraft.built_draft.map((round) => ({ ...round, picks: [...round.picks].reverse() })),
+        };
+        const pickNumbers = (result, isEven) =>
+            result.liveDraft.built_draft
+                .find((round) => (round.round % 2 === 0) === isEven)
+                .picks.map((pick) => pick.pick_number);
+
+        const asSnake = syncLiveDraft({
+            liveDraft: outOfOrder,
+            livePicks: [],
+            tradedPicks: [],
+            playerInfo,
+            rosterData,
+            draftType: 'snake',
+        });
+        const asLinear = syncLiveDraft({
+            liveDraft: outOfOrder,
+            livePicks: [],
+            tradedPicks: [],
+            playerInfo,
+            rosterData,
+            draftType: 'linear',
+        });
+
+        const ascending = (nums) => [...nums].sort((a, b) => a - b);
+        // Snake: even rounds get reordered, odd rounds are left descending.
+        expect(pickNumbers(asSnake, true)).toEqual(ascending(pickNumbers(asSnake, true)));
+        expect(pickNumbers(asSnake, false)).not.toEqual(ascending(pickNumbers(asSnake, false)));
+        // Linear: nothing is reordered at all.
+        expect(pickNumbers(asLinear, true)).not.toEqual(ascending(pickNumbers(asLinear, true)));
+    });
+
+    it('applies traded picks as part of the sync, not just picks the input board already had baked in', () => {
+        // The real fixture's traded picks are already reflected in its built_draft
+        // (buildDraftRounds bakes them in), so a syncLiveDraft that silently skipped
+        // applyTradedPicks would still match the golden fixture for every scenario
+        // above. This synthetic board starts a pick out untraded so the composition
+        // is actually exercised.
+        const untradedLiveDraft = {
+            ...liveDraft,
+            built_draft: [
+                {
+                    round: 1,
+                    picks: [
+                        {
+                            user_id: 'u1',
+                            roster_id: 1,
+                            is_traded: false,
+                            owner_id: 1,
+                            pick_round: 1,
+                            pick_number: 1,
+                            board_spot: 1,
+                            player_id: null,
+                        },
+                    ],
+                },
+            ],
+        };
+        const customTradedPicks = [{ round: 1, roster_id: 1, owner_id: 99 }];
+
+        const result = syncLiveDraft({
+            liveDraft: untradedLiveDraft,
+            livePicks: [],
+            tradedPicks: customTradedPicks,
+            playerInfo,
+            rosterData,
+            draftType: 'linear',
+        });
+
+        const pick = result.liveDraft.built_draft[0].picks[0];
+        expect(pick.owner_id).toBe(99);
+        expect(pick.is_traded).toBe(true);
+    });
+});
+
+describe('applyLivePicks', () => {
+    it('sets player_id and picked on the matching pick, and is_taken/rostered_by on the player', () => {
+        const { builtDraft, playerInfo: newPlayerInfo } = applyLivePicks({
+            builtDraft: liveDraft.built_draft,
+            livePicks,
+            playerInfo,
+            rosterData,
+        });
+        const pick = builtDraft[0].picks.find((p) => p.board_spot === 1);
+        expect(pick.player_id).toEqual('13287');
+        expect(pick.picked).toBe(true);
+        expect(newPlayerInfo['13287'].is_taken).toBe(true);
+        expect(newPlayerInfo['13287'].rostered_by).toEqual(
+            rosterData.find((roster) => roster.roster_id === pick.owner_id).manager_display_name,
+        );
+    });
+
+    it('does not mutate its inputs', () => {
+        const clonedBuiltDraft = structuredClone(liveDraft.built_draft);
+        const clonedLivePicks = structuredClone(livePicks);
+        const clonedPlayerInfo = structuredClone(playerInfo);
+        const clonedRosterData = structuredClone(rosterData);
+
+        applyLivePicks({ builtDraft: liveDraft.built_draft, livePicks, playerInfo, rosterData });
+
+        expect(liveDraft.built_draft).toEqual(clonedBuiltDraft);
+        expect(livePicks).toEqual(clonedLivePicks);
+        expect(playerInfo).toEqual(clonedPlayerInfo);
+        expect(rosterData).toEqual(clonedRosterData);
+    });
+});
+
+describe('applyTradedPicks', () => {
+    it('applies a traded pick to the correct round and roster', () => {
+        const builtDraft = applyTradedPicks({ builtDraft: liveDraft.built_draft, tradedPicks });
+        const round1Pick = builtDraft[0].picks.find((pick) => pick.roster_id === 6);
+        expect(round1Pick.is_traded).toBe(true);
+        expect(round1Pick.owner_id).toBe(4);
+    });
+
+    it('skips (with a warning) a traded pick whose round does not exist', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const badTradedPicks = [...tradedPicks, { round: 999, roster_id: 1, owner_id: 2 }];
+        const builtDraft = applyTradedPicks({ builtDraft: liveDraft.built_draft, tradedPicks: badTradedPicks });
+        expect(builtDraft).toEqual(applyTradedPicks({ builtDraft: liveDraft.built_draft, tradedPicks }));
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('draft has no such round'));
+        warnSpy.mockRestore();
+    });
+
+    it('skips (with a warning) a traded pick whose roster has no pick in the round', () => {
+        const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const badTradedPicks = [...tradedPicks, { round: 1, roster_id: 999, owner_id: 2 }];
+        const builtDraft = applyTradedPicks({ builtDraft: liveDraft.built_draft, tradedPicks: badTradedPicks });
+        expect(builtDraft).toEqual(applyTradedPicks({ builtDraft: liveDraft.built_draft, tradedPicks }));
+        expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('has no pick in this draft'));
+        warnSpy.mockRestore();
+    });
+
+    it('does not mutate its inputs', () => {
+        const clonedBuiltDraft = structuredClone(liveDraft.built_draft);
+        const clonedTradedPicks = structuredClone(tradedPicks);
+
+        applyTradedPicks({ builtDraft: liveDraft.built_draft, tradedPicks });
+
+        expect(liveDraft.built_draft).toEqual(clonedBuiltDraft);
+        expect(tradedPicks).toEqual(clonedTradedPicks);
+    });
+});
+
+describe('sortSnakeRounds', () => {
+    // On real data this function is a no-op: buildDraftRounds already emits every
+    // round's picks in ascending pick_number order, so golden.snake is byte-identical
+    // to golden.linear and the golden-fixture tests above pass whether or not the
+    // reordering runs at all. These two tests feed it a deliberately out-of-order
+    // board so the behaviour is actually pinned rather than vacuously satisfied.
+    const shuffleRoundPicks = (builtDraft) =>
+        builtDraft.map((round) => ({ ...round, picks: [...round.picks].reverse() }));
+
+    it('reorders an even round whose picks arrive out of pick_number order', () => {
+        const shuffled = shuffleRoundPicks(liveDraft.built_draft);
+        const evenBefore = shuffled.find((round) => round.round % 2 === 0);
+        expect(evenBefore.picks.map((pick) => pick.pick_number)).not.toEqual(
+            [...evenBefore.picks.map((pick) => pick.pick_number)].sort((a, b) => a - b),
+        );
+
+        const result = sortSnakeRounds(shuffled);
+        const evenAfter = result.find((round) => round.round % 2 === 0);
+        const pickNumbers = evenAfter.picks.map((pick) => pick.pick_number);
+        expect(pickNumbers).toEqual([...pickNumbers].sort((a, b) => a - b));
+    });
+
+    it('leaves an out-of-order odd round exactly as it found it', () => {
+        const shuffled = shuffleRoundPicks(liveDraft.built_draft);
+        const result = sortSnakeRounds(shuffled);
+        const oddBefore = shuffled.find((round) => round.round % 2 !== 0);
+        const oddAfter = result.find((round) => round.round % 2 !== 0);
+        expect(oddAfter).toEqual(oddBefore);
+    });
+
+    it('sorts even rounds by ascending pick_number and leaves odd rounds untouched', () => {
+        const result = sortSnakeRounds(liveDraft.built_draft);
+        const evenRound = result.find((round) => round.round % 2 === 0);
+        const pickNumbers = evenRound.picks.map((pick) => pick.pick_number);
+        expect(pickNumbers).toEqual([...pickNumbers].sort((a, b) => a - b));
+
+        const oddRound = result.find((round) => round.round % 2 !== 0);
+        expect(oddRound).toEqual(liveDraft.built_draft.find((round) => round.round % 2 !== 0));
+    });
+
+    it('does not mutate its input', () => {
+        const clonedBuiltDraft = structuredClone(liveDraft.built_draft);
+        sortSnakeRounds(liveDraft.built_draft);
+        expect(liveDraft.built_draft).toEqual(clonedBuiltDraft);
+    });
+});
+
+describe('applyManualPick', () => {
+    it('matches the golden fixture for assigning an undrafted pick', () => {
+        const round = liveDraft.built_draft[0];
+        const currentManualPick = round.picks[2];
+        const result = applyManualPick({
+            round,
+            playerInfo: playerInfoPreDraft,
+            rosterData,
+            currentManualPick,
+            playerID: '4984',
+        });
+        expect(result).toEqual({ round: golden.manualAssign.round, playerInfo: golden.manualAssign.playerInfo });
+    });
+
+    it('matches the golden fixture for removing an already-picked pick', () => {
+        const { liveDraft: syncedLiveDraft, playerInfo: syncedPlayerInfo } = syncLiveDraft({
+            liveDraft,
+            livePicks,
+            tradedPicks,
+            playerInfo: playerInfoPreDraft,
+            rosterData,
+            draftType: 'linear',
+        });
+        const round = syncedLiveDraft.built_draft[0];
+        const currentManualPick = round.picks[2];
+        const result = applyManualPick({
+            round,
+            playerInfo: syncedPlayerInfo,
+            rosterData,
+            currentManualPick,
+            playerID: null,
+        });
+        expect(result).toEqual({ round: golden.manualRemove.round, playerInfo: golden.manualRemove.playerInfo });
+    });
+
+    it('does not mutate its inputs', () => {
+        const round = liveDraft.built_draft[0];
+        const currentManualPick = round.picks[2];
+        const clonedRound = structuredClone(round);
+        const clonedPlayerInfo = structuredClone(playerInfoPreDraft);
+        const clonedRosterData = structuredClone(rosterData);
+        const clonedCurrentManualPick = structuredClone(currentManualPick);
+
+        applyManualPick({
+            round,
+            playerInfo: playerInfoPreDraft,
+            rosterData,
+            currentManualPick,
+            playerID: '4984',
+        });
+
+        expect(round).toEqual(clonedRound);
+        expect(playerInfoPreDraft).toEqual(clonedPlayerInfo);
+        expect(rosterData).toEqual(clonedRosterData);
+        expect(currentManualPick).toEqual(clonedCurrentManualPick);
+    });
+});


### PR DESCRIPTION
The last mutation cluster, deferred from #92 because it is entangled with the 3-second live-sync poll. `DraftPanel.getLiveDraft` aliased `playerInfo` and `liveDraft` and wrote through the aliases; `DraftRound.updatePickSelection` mutated its own `round` prop — a slice of the parent's state.

**24 tests → 61.**

### Safety net first
`src/lib/__fixtures__/live-draft-sync-2026.json` holds real production inputs (48 picks, 21 traded picks, 12 rosters), and `golden-live-draft-sync.json` the exact output the pre-refactor code produced for them. Both were captured **before any code moved** and verified against the running app by SHA-256:

| | SHA-256 |
|---|---|
| Pre-sync board | `ed52e0a0…` — matches the production hash recorded in #92 |
| Post-sync board | `984afacc…` — refactored build reproduces it exactly |

The completed draft makes `playerInfo` identical before and after a sync, so the fixture also carries `playerInfoPreDraft` (mid-draft state, no flags set) and `livePicksPartial` (20 of 48 picks). Those are the scenarios where the flag writes are actually observable.

### Changes
- **`src/lib/liveDraft.js`** — `applyLivePicks`, `applyTradedPicks`, `sortSnakeRounds`, `syncLiveDraft`, `applyManualPick`. All pure, key order preserved.
- **`DraftPanel.jsx`** — `getLiveDraft` fetches and delegates; `getTradedDraftPicks` and its stray `console.log` are gone. New `handlePickChange` swaps a round into `built_draft` immutably. Polling `useEffect` untouched.
- **`DraftRound.jsx`** — reports pick changes up via `onPickChange` instead of writing into the prop.

### Sabotage results
Each old behavior was reintroduced one at a time to confirm the suite catches it:

| Sabotage | Tests failed |
|---|---|
| Board mutated in place | 3 |
| `rostered_by` from the wrong roster | 8 |
| `picked: true` dropped | 9 |
| Snake reordering removed from `syncLiveDraft` | 1 |
| Snake reordering sorts descending | 5 |
| Snake reordering applied to linear drafts too | 1 |
| Traded picks not applied | 1 |

Two of these initially failed **zero** tests and needed new coverage: the traded picks are already baked into the board by `buildDraftRounds`, and — see below — the snake branch never changes anything. Both now have composition tests with synthetic boards.

### The snake reordering is dead code
`buildDraftRounds` always emits picks in ascending `pick_number`, so `golden.snake` is byte-identical to `golden.linear` and the old `if (picks[0].board_spot === 1) picks.reverse()` guard never fired on a real board. The behavior is preserved as-is rather than deleted, but it is worth removing once the `playerInfo` flags redesign lands.

### Verification
All five gates pass, plus `npm ci`. Verified at runtime: board hashes match production pre- and post-sync, manual pick removal clears `is_taken`/`rostered_by` correctly, and sync starts and stops cleanly (0 polls in 10s after stop) with no console errors.

### Left alone deliberately
`updateParentState`'s nonexistent `'filterPlayers'` callback, the `is_taken`/`rostered_by`/`in_lineup` flag design, and the `RanksPanel` `exhaustive-deps` warning — all separately tracked.