### PR TITLE
Upgrade to React 19 and lift Testing Library off v11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,17 +11,18 @@
                 "classnames": "^2.3.1",
                 "firebase": "^12.16.0",
                 "fuse.js": "^6.4.6",
-                "react": "^18.2.0",
-                "react-dom": "^18.2.0"
+                "react": "^19.2.8",
+                "react-dom": "^19.2.8"
             },
             "devDependencies": {
                 "@eslint/js": "^9.39.5",
-                "@testing-library/jest-dom": "^5.11.9",
-                "@testing-library/react": "^11.2.7",
-                "@testing-library/user-event": "^12.7.0",
+                "@testing-library/dom": "^10.4.1",
+                "@testing-library/jest-dom": "^7.0.0",
+                "@testing-library/react": "^16.3.2",
+                "@testing-library/user-event": "^14.6.1",
                 "@types/node": "^24.10.1",
-                "@types/react": "^18.3.31",
-                "@types/react-dom": "^18.3.7",
+                "@types/react": "^19.2.17",
+                "@types/react-dom": "^19.2.3",
                 "@vitejs/plugin-react": "^4.7.0",
                 "@vitest/coverage-v8": "^4.1.10",
                 "eslint": "^9.39.5",
@@ -335,19 +336,6 @@
             "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
             "dev": true,
             "license": "MIT",
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/runtime-corejs3": {
-            "version": "7.29.7",
-            "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.7.tgz",
-            "integrity": "sha512-ppj9ouYku+RX0ljtgZd+KMO5mkM2bCqg8H2PYAFWnLsHEIKIdRojqbJ2i3eVHrisuxy7nOFCmngTDdWtUCdXUQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "core-js-pure": "^3.48.0"
-            },
             "engines": {
                 "node": ">=6.9.0"
             }
@@ -1889,102 +1877,6 @@
                 "url": "https://github.com/sponsors/nzakas"
             }
         },
-        "node_modules/@jest/diff-sequences": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
-            "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/expect-utils": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-30.4.1.tgz",
-            "integrity": "sha512-ZBn5CglH8fBsQsvs4VWNzD4aWfUYks+IdOOQU3MEK71ol/BcVm+P+rtb1KpiFBpSWSCE27uOahyyf1vfqOVbcQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/get-type": "30.1.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/get-type": {
-            "version": "30.1.0",
-            "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
-            "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/pattern": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/@jest/pattern/-/pattern-30.4.0.tgz",
-            "integrity": "sha512-RAWn3+f9u8BsHijKJ71uHcFp6vmyEt6VvoWXkl6hKF3qVIuWNmudVjg12DlBPGup/frIl5UcUlH5HfEuvHpEXg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/node": "*",
-                "jest-regex-util": "30.4.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/schemas": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
-            "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@sinclair/typebox": "^0.34.0"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/types": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-30.4.1.tgz",
-            "integrity": "sha512-f1x/vJXIfjOlEmejYpbkbgw1gOqpPECwMvMEtBqe47j7H2Hg8h8w3o3ikhSXq3MI15kg+oQ0exWO0uCtTNJLoQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/pattern": "30.4.0",
-                "@jest/schemas": "30.4.1",
-                "@types/istanbul-lib-coverage": "^2.0.6",
-                "@types/istanbul-reports": "^3.0.4",
-                "@types/node": "*",
-                "@types/yargs": "^17.0.33",
-                "chalk": "^4.1.2"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/@jest/types/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
         "node_modules/@jridgewell/gen-mapping": {
             "version": "0.3.13",
             "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -2488,13 +2380,6 @@
                 "win32"
             ]
         },
-        "node_modules/@sinclair/typebox": {
-            "version": "0.34.52",
-            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
-            "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@standard-schema/spec": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -2508,7 +2393,6 @@
             "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.10.4",
                 "@babel/runtime": "^7.12.5",
@@ -2524,158 +2408,71 @@
             }
         },
         "node_modules/@testing-library/jest-dom": {
-            "version": "5.17.0",
-            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-5.17.0.tgz",
-            "integrity": "sha512-ynmNeT7asXyH3aSVv4vvX4Rb+0qjOhdNHnO/3vuZNqPmhDpV/+rCSGwQ7bLcmU2cJ4dvoheIO85LQj0IbJHEtg==",
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-7.0.0.tgz",
+            "integrity": "sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@adobe/css-tools": "^4.0.1",
-                "@babel/runtime": "^7.9.2",
-                "@types/testing-library__jest-dom": "^5.9.1",
+                "@adobe/css-tools": "^4.4.0",
                 "aria-query": "^5.0.0",
-                "chalk": "^3.0.0",
                 "css.escape": "^1.5.1",
-                "dom-accessibility-api": "^0.5.6",
-                "lodash": "^4.17.15",
+                "dom-accessibility-api": "^0.6.3",
+                "picocolors": "^1.1.1",
                 "redent": "^3.0.0"
             },
             "engines": {
-                "node": ">=8",
+                "node": ">=22",
                 "npm": ">=6",
                 "yarn": ">=1"
-            }
-        },
-        "node_modules/@testing-library/react": {
-            "version": "11.2.7",
-            "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-11.2.7.tgz",
-            "integrity": "sha512-tzRNp7pzd5QmbtXNG/mhdcl7Awfu/Iz1RaVHY75zTdOkmHCuzMhRL83gWHSgOAcjS3CCbyfwUHMZgRJb4kAfpA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/runtime": "^7.12.5",
-                "@testing-library/dom": "^7.28.1"
-            },
-            "engines": {
-                "node": ">=10"
             },
             "peerDependencies": {
-                "react": "*",
-                "react-dom": "*"
+                "@testing-library/dom": ">=10 <11"
             }
         },
-        "node_modules/@testing-library/react/node_modules/@jest/types": {
-            "version": "26.6.2",
-            "resolved": "https://registry.npmjs.org/@jest/types/-/types-26.6.2.tgz",
-            "integrity": "sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/istanbul-lib-coverage": "^2.0.0",
-                "@types/istanbul-reports": "^3.0.0",
-                "@types/node": "*",
-                "@types/yargs": "^15.0.0",
-                "chalk": "^4.0.0"
-            },
-            "engines": {
-                "node": ">= 10.14.2"
-            }
-        },
-        "node_modules/@testing-library/react/node_modules/@testing-library/dom": {
-            "version": "7.31.2",
-            "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-7.31.2.tgz",
-            "integrity": "sha512-3UqjCpey6HiTZT92vODYLPxTBWlM8ZOOjr3LX5F37/VRipW2M1kX6I/Cm4VXzteZqfGfagg8yXywpcOgQBlNsQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.10.4",
-                "@babel/runtime": "^7.12.5",
-                "@types/aria-query": "^4.2.0",
-                "aria-query": "^4.2.2",
-                "chalk": "^4.1.0",
-                "dom-accessibility-api": "^0.5.6",
-                "lz-string": "^1.4.4",
-                "pretty-format": "^26.6.2"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/@testing-library/react/node_modules/@types/aria-query": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-4.2.2.tgz",
-            "integrity": "sha512-HnYpAE1Y6kRyKM/XkEuiRQhTHvkzMBurTHnpFLYLBGPIylZNPs9jJcuOOYWxPLJCSEtmZT0Y8rHDokKN7rRTig==",
+        "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+            "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@testing-library/react/node_modules/@types/yargs": {
-            "version": "15.0.20",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.20.tgz",
-            "integrity": "sha512-KIkX+/GgfFitlASYCGoSF+T4XRXhOubJLhkLVtSfsRTe9jWMmuM2g28zQ41BtPTG7TRBb2xHW+LCNVE9QR/vsg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/yargs-parser": "*"
-            }
-        },
-        "node_modules/@testing-library/react/node_modules/aria-query": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-4.2.2.tgz",
-            "integrity": "sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@babel/runtime": "^7.10.2",
-                "@babel/runtime-corejs3": "^7.10.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            }
-        },
-        "node_modules/@testing-library/react/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/@testing-library/react/node_modules/pretty-format": {
-            "version": "26.6.2",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
-            "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "^26.6.2",
-                "ansi-regex": "^5.0.0",
-                "ansi-styles": "^4.0.0",
-                "react-is": "^17.0.1"
-            },
-            "engines": {
-                "node": ">= 10"
-            }
-        },
-        "node_modules/@testing-library/user-event": {
-            "version": "12.8.3",
-            "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.8.3.tgz",
-            "integrity": "sha512-IR0iWbFkgd56Bu5ZI/ej8yQwrkCv8Qydx6RzwbKz9faXazR/+5tvYKsZQgyXJiwgpcva127YO6JcWy7YlCfofQ==",
+        "node_modules/@testing-library/react": {
+            "version": "16.3.2",
+            "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+            "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.12.5"
             },
             "engines": {
-                "node": ">=10",
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@testing-library/dom": "^10.0.0",
+                "@types/react": "^18.0.0 || ^19.0.0",
+                "@types/react-dom": "^18.0.0 || ^19.0.0",
+                "react": "^18.0.0 || ^19.0.0",
+                "react-dom": "^18.0.0 || ^19.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/react": {
+                    "optional": true
+                },
+                "@types/react-dom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@testing-library/user-event": {
+            "version": "14.6.1",
+            "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+            "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12",
                 "npm": ">=6"
             },
             "peerDependencies": {
@@ -2687,8 +2484,7 @@
             "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
             "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@types/babel__core": {
             "version": "7.20.5",
@@ -2760,73 +2556,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@types/istanbul-lib-coverage": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
-            "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@types/istanbul-lib-report": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.3.tgz",
-            "integrity": "sha512-NQn7AHQnk/RSLOxrBbGyJM/aVQ+pjj5HCgasFxc0K/KhoATfQ/47AyUl15I2yBUpihjmas+a+VJBOqecrFH+uA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/istanbul-lib-coverage": "*"
-            }
-        },
-        "node_modules/@types/istanbul-reports": {
-            "version": "3.0.4",
-            "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.4.tgz",
-            "integrity": "sha512-pk2B1NWalF9toCRu6gjBzR69syFjP4Od8WRAX+0mmf9lAjCRicLOWc+ZrxZHx/0XRjotgkF9t6iaMJ+aXcOdZQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/istanbul-lib-report": "*"
-            }
-        },
-        "node_modules/@types/jest": {
-            "version": "30.0.0",
-            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-30.0.0.tgz",
-            "integrity": "sha512-XTYugzhuwqWjws0CVz8QpM36+T+Dz5mTEBKhNs/esGLnCIlGdRy+Dq78NRjd7ls7r8BC8ZRMOrKlkO1hU0JOwA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "expect": "^30.0.0",
-                "pretty-format": "^30.0.0"
-            }
-        },
-        "node_modules/@types/jest/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/@types/jest/node_modules/pretty-format": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-            "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/schemas": "30.4.1",
-                "ansi-styles": "^5.2.0",
-                "react-is-18": "npm:react-is@^18.3.1",
-                "react-is-19": "npm:react-is@^19.2.5"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
         "node_modules/@types/json-schema": {
             "version": "7.0.15",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -2843,67 +2572,25 @@
                 "undici-types": "~7.18.0"
             }
         },
-        "node_modules/@types/prop-types": {
-            "version": "15.7.15",
-            "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
-            "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/@types/react": {
-            "version": "18.3.31",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
-            "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+            "version": "19.2.17",
+            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+            "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@types/prop-types": "*",
                 "csstype": "^3.2.2"
             }
         },
         "node_modules/@types/react-dom": {
-            "version": "18.3.7",
-            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-            "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+            "version": "19.2.3",
+            "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+            "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
             "dev": true,
             "license": "MIT",
             "peerDependencies": {
-                "@types/react": "^18.0.0"
+                "@types/react": "^19.2.0"
             }
-        },
-        "node_modules/@types/stack-utils": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
-            "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/@types/testing-library__jest-dom": {
-            "version": "5.14.9",
-            "resolved": "https://registry.npmjs.org/@types/testing-library__jest-dom/-/testing-library__jest-dom-5.14.9.tgz",
-            "integrity": "sha512-FSYhIjFlfOpGSRyVoMBMuS3ws5ehFQODymf3vlI7U1K8c7PHwWwFY7VREfmsuzHSOnoKs/9/Y983ayOs7eRzqw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/jest": "*"
-            }
-        },
-        "node_modules/@types/yargs": {
-            "version": "17.0.35",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
-            "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@types/yargs-parser": "*"
-            }
-        },
-        "node_modules/@types/yargs-parser": {
-            "version": "21.0.3",
-            "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.3.tgz",
-            "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
-            "dev": true,
-            "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
             "version": "8.65.0",
@@ -3805,36 +3492,6 @@
                 "node": ">=18"
             }
         },
-        "node_modules/chalk": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-            "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/ci-info": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
-            "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
-            "dev": true,
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/sibiraj-s"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/classnames": {
             "version": "2.5.1",
             "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
@@ -3886,18 +3543,6 @@
             "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/core-js-pure": {
-            "version": "3.49.0",
-            "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
-            "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
-            "dev": true,
-            "hasInstallScript": true,
-            "license": "MIT",
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/core-js"
-            }
         },
         "node_modules/cross-spawn": {
             "version": "7.0.6",
@@ -4669,24 +4314,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/expect": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/expect/-/expect-30.4.1.tgz",
-            "integrity": "sha512-PMARsyh/JtqC20HoGqlFcIlQAyqUtW4PlI1rup1uhYJtKuwAjbvWi3GQMAn+STdHum/dk8xrKfUM1+5SAwpolA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/expect-utils": "30.4.1",
-                "@jest/get-type": "30.1.0",
-                "jest-matcher-utils": "30.4.1",
-                "jest-message-util": "30.4.1",
-                "jest-mock": "30.4.1",
-                "jest-util": "30.4.1"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
         "node_modules/expect-type": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
@@ -5084,13 +4711,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/graceful-fs": {
-            "version": "4.2.11",
-            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-            "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-            "dev": true,
-            "license": "ISC"
         },
         "node_modules/has-bigints": {
             "version": "1.1.0",
@@ -5782,262 +5402,11 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/jest-diff": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
-            "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/diff-sequences": "30.4.0",
-                "@jest/get-type": "30.1.0",
-                "chalk": "^4.1.2",
-                "pretty-format": "30.4.1"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-diff/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/jest-diff/node_modules/pretty-format": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-            "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/schemas": "30.4.1",
-                "ansi-styles": "^5.2.0",
-                "react-is-18": "npm:react-is@^18.3.1",
-                "react-is-19": "npm:react-is@^19.2.5"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-diff/node_modules/pretty-format/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/jest-matcher-utils": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
-            "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/get-type": "30.1.0",
-                "chalk": "^4.1.2",
-                "jest-diff": "30.4.1",
-                "pretty-format": "30.4.1"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-matcher-utils/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/jest-matcher-utils/node_modules/pretty-format": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-            "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/schemas": "30.4.1",
-                "ansi-styles": "^5.2.0",
-                "react-is-18": "npm:react-is@^18.3.1",
-                "react-is-19": "npm:react-is@^19.2.5"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-matcher-utils/node_modules/pretty-format/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/jest-message-util": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.4.1.tgz",
-            "integrity": "sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/code-frame": "^7.27.1",
-                "@jest/types": "30.4.1",
-                "@types/stack-utils": "^2.0.3",
-                "chalk": "^4.1.2",
-                "graceful-fs": "^4.2.11",
-                "jest-util": "30.4.1",
-                "picomatch": "^4.0.3",
-                "pretty-format": "30.4.1",
-                "slash": "^3.0.0",
-                "stack-utils": "^2.0.6"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-message-util/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
-        "node_modules/jest-message-util/node_modules/pretty-format": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
-            "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/schemas": "30.4.1",
-                "ansi-styles": "^5.2.0",
-                "react-is-18": "npm:react-is@^18.3.1",
-                "react-is-19": "npm:react-is@^19.2.5"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-message-util/node_modules/pretty-format/node_modules/ansi-styles": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-            }
-        },
-        "node_modules/jest-mock": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.4.1.tgz",
-            "integrity": "sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "30.4.1",
-                "@types/node": "*",
-                "jest-util": "30.4.1"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-regex-util": {
-            "version": "30.4.0",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.4.0.tgz",
-            "integrity": "sha512-mWlvLviKIgIQ8VCuM1xRdD0TWp3zlzionlmDBjuXVBs+VkmXq6FgW9T4Emr7oGz/Rk6feDCGyiugolcQEyp3mg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-util": {
-            "version": "30.4.1",
-            "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.4.1.tgz",
-            "integrity": "sha512-vjQb1sACEiv13DKJMDToJpzVW0joCsIQrmbg0fi7CyOOt+g9jTuQl2A216pWRBYhOVt53XbL/2LbMKg1BECWOw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@jest/types": "30.4.1",
-                "@types/node": "*",
-                "chalk": "^4.1.2",
-                "ci-info": "^4.2.0",
-                "graceful-fs": "^4.2.11",
-                "picomatch": "^4.0.3"
-            },
-            "engines": {
-                "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
-            }
-        },
-        "node_modules/jest-util/node_modules/chalk": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/chalk/chalk?sponsor=1"
-            }
-        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/js-yaml": {
@@ -6217,13 +5586,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/lodash": {
-            "version": "4.18.1",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-            "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-            "dev": true,
-            "license": "MIT"
-        },
         "node_modules/lodash.camelcase": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
@@ -6247,6 +5609,7 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
             "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "js-tokens": "^3.0.0 || ^4.0.0"
@@ -6770,7 +6133,6 @@
             "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-regex": "^5.0.1",
                 "ansi-styles": "^5.0.0",
@@ -6786,7 +6148,6 @@
             "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -6853,50 +6214,30 @@
             "license": "MIT"
         },
         "node_modules/react": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-            "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+            "version": "19.2.8",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+            "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
             "license": "MIT",
-            "dependencies": {
-                "loose-envify": "^1.1.0"
-            },
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/react-dom": {
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-            "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+            "version": "19.2.8",
+            "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+            "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
             "license": "MIT",
             "dependencies": {
-                "loose-envify": "^1.1.0",
-                "scheduler": "^0.23.2"
+                "scheduler": "^0.27.0"
             },
             "peerDependencies": {
-                "react": "^18.3.1"
+                "react": "^19.2.8"
             }
         },
         "node_modules/react-is": {
             "version": "17.0.2",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
             "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/react-is-18": {
-            "name": "react-is",
-            "version": "18.3.1",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
-            "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/react-is-19": {
-            "name": "react-is",
-            "version": "19.2.8",
-            "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
-            "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
             "dev": true,
             "license": "MIT"
         },
@@ -7155,13 +6496,10 @@
             }
         },
         "node_modules/scheduler": {
-            "version": "0.23.2",
-            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-            "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-            "license": "MIT",
-            "dependencies": {
-                "loose-envify": "^1.1.0"
-            }
+            "version": "0.27.0",
+            "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+            "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+            "license": "MIT"
         },
         "node_modules/semver": {
             "version": "6.3.1",
@@ -7328,16 +6666,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/slash": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/source-map-js": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -7346,29 +6674,6 @@
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/stack-utils": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
-            "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "escape-string-regexp": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/stack-utils/node_modules/escape-string-regexp": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-            "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/stackback": {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
         "classnames": "^2.3.1",
         "firebase": "^12.16.0",
         "fuse.js": "^6.4.6",
-        "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react": "^19.2.8",
+        "react-dom": "^19.2.8"
     },
     "scripts": {
         "dev": "vite",
@@ -27,12 +27,13 @@
     },
     "devDependencies": {
         "@eslint/js": "^9.39.5",
-        "@testing-library/jest-dom": "^5.11.9",
-        "@testing-library/react": "^11.2.7",
-        "@testing-library/user-event": "^12.7.0",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/jest-dom": "^7.0.0",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@types/node": "^24.10.1",
-        "@types/react": "^18.3.31",
-        "@types/react-dom": "^18.3.7",
+        "@types/react": "^19.2.17",
+        "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^4.7.0",
         "@vitest/coverage-v8": "^4.1.10",
         "eslint": "^9.39.5",

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,10 +1,112 @@
-import { describe, expect, it } from 'vitest';
-import createRankings from './helpers';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import App from './App';
+import rosterFlagsFixture from './lib/__fixtures__/roster-flags-2026.json';
+import realDraftFixture from './lib/__fixtures__/real-draft-2026.json';
 
-describe('createRankings', () => {
-    it('returns empty result arrays for empty input', () => {
-        const [searchResultsArray, notFoundPlayers] = createRankings('', {});
-        expect(searchResultsArray).toEqual([]);
-        expect(notFoundPlayers).toEqual([]);
+// This test exists to close a specific coverage gap: the whole suite stayed
+// green when the `decorateRosters` call was deliberately deleted from
+// `App.getLeagueData`. Nothing exercised a real render of `App`, so nothing
+// could notice that `roster.manager_display_name` had gone missing. Asserting
+// that a manager name resolved from the fixture's `managerData` reaches the
+// rendered draft board is what makes that deletion fail this test.
+
+vi.mock('./firebase.js', () => ({
+    auth: {
+        currentUser: {
+            isAnonymous: true,
+            email: null,
+            uid: 'test-uid',
+            getIdToken: vi.fn().mockResolvedValue('test-id-token'),
+        },
+    },
+    googleProvider: {},
+}));
+
+vi.mock('firebase/auth', () => ({
+    onAuthStateChanged: vi.fn((auth, callback) => {
+        // Simplest path: report an already-signed-in (anonymous) user
+        // immediately, so App skips the signInAnonymously branch entirely.
+        callback({ uid: 'test-uid', isAnonymous: true });
+        return () => {};
+    }),
+    signInAnonymously: vi.fn().mockResolvedValue({ user: { uid: 'test-uid', isAnonymous: true } }),
+    signInWithPopup: vi.fn().mockResolvedValue({}),
+    signOut: vi.fn().mockResolvedValue({}),
+}));
+
+const { rosterDataRaw, managerData, playerInfo } = rosterFlagsFixture;
+const { currentDraft: draftSettings, tradedDraftPicks } = realDraftFixture;
+
+const LEAGUE_ID = '1312088290526003200';
+const DRAFT_ID = 'draft123';
+
+const jsonResponse = (data) => Promise.resolve({ ok: true, statusText: 'OK', json: () => Promise.resolve(data) });
+
+function mockFetch(url) {
+    if (url.includes('latest_update_attempt')) {
+        return jsonResponse('2026-01-01T00:00:00.000Z');
+    }
+    if (url.includes('legacy/players')) {
+        return jsonResponse(playerInfo);
+    }
+    if (url.includes('dlf_adp')) {
+        // RanksPanel fetches this on mount regardless of the App-level flow
+        // under test; give it a harmless response so it doesn't produce an
+        // unhandled rejection.
+        return jsonResponse({});
+    }
+    if (url.includes('state/nfl')) {
+        return jsonResponse({ league_season: '2026' });
+    }
+    if (url.includes(`league/${LEAGUE_ID}/rosters/`)) {
+        return jsonResponse(structuredClone(rosterDataRaw));
+    }
+    if (url.includes(`league/${LEAGUE_ID}/users/`)) {
+        return jsonResponse(structuredClone(managerData));
+    }
+    if (url.includes(`league/${LEAGUE_ID}/drafts/`)) {
+        return jsonResponse([{ draft_id: DRAFT_ID }]);
+    }
+    if (url.includes('leagues/nfl/')) {
+        return jsonResponse([{ league_id: LEAGUE_ID, name: 'Test League' }]);
+    }
+    if (url.includes(`league/${LEAGUE_ID}/`)) {
+        return jsonResponse({
+            league_id: LEAGUE_ID,
+            name: 'Test League',
+            roster_positions: ['QB', 'RB', 'RB', 'WR', 'WR', 'TE', 'FLEX', 'BN', 'BN'],
+        });
+    }
+    if (url.includes(`draft/${DRAFT_ID}/traded_picks/`)) {
+        return jsonResponse(structuredClone(tradedDraftPicks));
+    }
+    if (url.includes(`draft/${DRAFT_ID}`)) {
+        return jsonResponse({
+            ...structuredClone(draftSettings),
+            draft_id: DRAFT_ID,
+            season: '2026',
+            status: 'drafting',
+            draft_order: {},
+        });
+    }
+    return Promise.reject(new Error(`Unhandled fetch url in App.test.jsx: ${url}`));
+}
+
+describe('App', () => {
+    it('renders a manager display name resolved from managerData on the draft board', async () => {
+        global.fetch = vi.fn(mockFetch);
+
+        render(<App />);
+
+        // Roster 1 is owned by managerData's `ryangh`, and slot_to_roster_id in
+        // the real-draft fixture assigns board spot 3 to roster 1 in every
+        // round (the draft is linear, not snake) - so once the board is built,
+        // "ryangh" should show up as a pick owner at least once. This element
+        // only exists if `decorateRosters` ran: without it,
+        // `roster.manager_display_name` is `undefined` and DraftRound renders
+        // "Pick owner missing" or `undefined` instead.
+        const ryanghMentions = await screen.findAllByText('ryangh', {}, { timeout: 5000 });
+        expect(ryanghMentions.length).toBeGreaterThan(0);
     });
 });

--- a/src/Components/Button/Button.tsx
+++ b/src/Components/Button/Button.tsx
@@ -9,7 +9,7 @@ interface Props {
     isDisabled: boolean;
 }
 
-export const Button = ({ text, onClick, btnStyle = 'primary', isDisabled = false }: Props): JSX.Element => {
+export const Button = ({ text, onClick, btnStyle = 'primary', isDisabled = false }: Props): React.JSX.Element => {
     const btnClass = classNames(btnStyle, {
         disabled: isDisabled,
     });

--- a/src/helpers.test.js
+++ b/src/helpers.test.js
@@ -1,0 +1,10 @@
+import { describe, expect, it } from 'vitest';
+import createRankings from './helpers';
+
+describe('createRankings', () => {
+    it('returns empty result arrays for empty input', () => {
+        const [searchResultsArray, notFoundPlayers] = createRankings('', {});
+        expect(searchResultsArray).toEqual([]);
+        expect(notFoundPlayers).toEqual([]);
+    });
+});

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -2,4 +2,4 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom/extend-expect';
+import '@testing-library/jest-dom/vitest';


### PR DESCRIPTION
Unblocks the component-test work the last two PRs kept deferring.

| | Before | After |
|---|---|---|
| react / react-dom | 18.2 | 19.2.8 |
| @types/react / -dom | 18.3 | 19.2 |
| @testing-library/react | 11.2 | 16.3 |
| @testing-library/jest-dom | 5.11 | 7.0 |
| @testing-library/user-event | 12.7 | 14.6 |
| @testing-library/dom | (transitive) | explicit devDependency |

That last row matters: Testing Library 16 declares `@testing-library/dom` as a peer instead of bundling it. Without it `npm install` succeeds and `npm ci` — which CI runs — does not. ESLint stays capped at 9.x; no lint dependency was touched.

## Code changes the upgrades force

- `setupTests.js` imported `@testing-library/jest-dom/extend-expect`, an entry point removed in jest-dom 6. Now `@testing-library/jest-dom/vitest`.
- `Button.tsx` typed its return as `JSX.Element`. React 19 removes the global `JSX` namespace, so it becomes `React.JSX.Element`.
- `App.test.jsx` only tested `createRankings` from `helpers.js`, so **nothing in the suite rendered a component** and Testing Library was entirely unexercised — upgrading it from v11 to v16 would have proved nothing. That test moves to `helpers.test.js`, and `App.test.jsx` becomes a real `App` render test.

## The App render test closes #95's known gap

#95 shipped with one disclosed hole: deleting the `decorateRosters` call from `App.getLeagueData` left all 74 tests green. It now fails — the manager name resolved from `managerData` stops reaching the rendered board. Verified by re-running that exact sabotage.

## Bundle: 91.41 → 106.07 kB gzip

This is React 19 itself, not a regression. Minified and gzipped the same way Vite does it, between 18.2 and 19.2.8 `react-dom` grows 13,591 bytes and `react` 339 — 13,930 of the observed 14,660-byte increase, the remainder being interop overhead.

## Runtime verification under React 19 StrictMode

Both production board hashes still reproduce (`ed52e0a0…` pre-sync, `984afacc…` post-sync); the derived flag map still hashes to the `050812a4…` baseline from #95; `playerInfo` carries no flag fields across all 9,363 players; the manual-pick modal still opens. No console errors and no deprecation warnings.

The StrictMode concern was double-invoked effects restarting the 3s poll twice. Measured rather than assumed: gaps are a uniform ~4000ms (3s timer plus ~1s for the two sequential fetches), `picks` and `traded_picks` counts stay equal, and there is no short/long alternation — a single loop, stopping cleanly. The poll effect is keyed on `isSyncing`, which is `false` at mount, so both StrictMode invocations hit the early return.

## Found on the way, fixed separately

The new test infrastructure immediately surfaced a real pre-existing bug: `getTradedDraftPicks` calls `setState` then synchronously calls `getSpecificDraft()` → `buildDraft()`, which reads `this.state.tradedDraftPicks` before React has flushed it. With the fixture's 21 traded picks, **0** render as traded. In production the extra `await fetch` inside `getSpecificDraft` happens to give React time, so it works by timing luck — a fast or cached draft response would drop traded-pick ownership from the board. React 18 already batched this way, and Testing Library 11 could not render React 18 roots, which is why no test could ever have caught it. Filed separately and kept out of this PR so the upgrade stays bisectable.