### PR TITLE
Pass traded picks down the chain instead of through state

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,7 +19,6 @@ class App extends React.Component {
     state = {
         playerInfo: {},
         leagueData: [],
-        tradedDraftPicks: [],
         isLoading: true,
         loadingMessage: 'Initial load...',
         rankingPlayersIdsList: [],
@@ -194,13 +193,16 @@ class App extends React.Component {
             .catch((error) => {
                 console.error('Error:', error);
             });
-        this.setState({
-            tradedDraftPicks: tradedPicks,
-        });
-        this.getSpecificDraft();
+        // Handed straight down the chain rather than round-tripped through state:
+        // setState batches inside an async context, so buildDraft could read the
+        // previous value and render every pick under its original roster with no
+        // "via <manager>" attribution. Production only got away with it because
+        // getSpecificDraft awaits another fetch first, which happened to give React
+        // time to flush.
+        this.getSpecificDraft(tradedPicks);
     };
 
-    getSpecificDraft = async () => {
+    getSpecificDraft = async (tradedDraftPicks) => {
         const { leagueData } = this.state;
         const draftId = leagueData.currentLeagueDrafts[0].draft_id;
         const DRAFT_PATH = DRAFT + draftId;
@@ -215,7 +217,7 @@ class App extends React.Component {
             leagueData,
         });
         if (draftData.draft_order) {
-            this.buildDraft();
+            this.buildDraft(tradedDraftPicks);
         } else {
             this.setState({
                 loadingMessage: '',
@@ -304,8 +306,8 @@ class App extends React.Component {
         });
     };
 
-    buildDraft = () => {
-        const { leagueData, tradedDraftPicks } = this.state;
+    buildDraft = (tradedDraftPicks) => {
+        const { leagueData } = this.state;
         const { currentDraft, rosterData } = leagueData;
         const { built_draft, player_pool } = buildDraftRounds({ currentDraft, rosterData, tradedDraftPicks });
         const newLeagueData = {

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -109,4 +109,27 @@ describe('App', () => {
         const ryanghMentions = await screen.findAllByText('ryangh', {}, { timeout: 5000 });
         expect(ryanghMentions.length).toBeGreaterThan(0);
     });
+
+    it('applies every traded pick to the board', async () => {
+        global.fetch = vi.fn(mockFetch);
+
+        render(<App />);
+        await screen.findAllByText('ryangh', {}, { timeout: 5000 });
+
+        // These mocked fetches resolve immediately, which is the whole point: it
+        // leaves React no window to flush a setState between getTradedDraftPicks
+        // and buildDraft. When the traded picks were round-tripped through state,
+        // buildDraft read the previous value and none of them landed.
+        //
+        // A traded pick also reads two different rosters - the current owner via
+        // pick.owner_id and the original holder via pick.roster_id - so the
+        // "<owner> via <originator>" text covers a lookup the assertion above
+        // never touches.
+        const owners = [...document.querySelectorAll('p.draft-pick')];
+        const traded = owners.filter((pick) => pick.textContent.includes(' via '));
+        expect(traded).toHaveLength(tradedDraftPicks.length);
+        for (const pick of traded) {
+            expect(pick.textContent).toMatch(/^\S+ via \S+$/);
+        }
+    });
 });


### PR DESCRIPTION
Closes #98. Found by the render test that #97 made possible, and kept out of that PR so the React 19 upgrade stayed bisectable.

`getTradedDraftPicks` called `setState({ tradedDraftPicks })` then synchronously called `getSpecificDraft()` → `buildDraft()`, which read the value straight back out of state. React batches `setState` inside an async context, so `buildDraft` could read the previous value — every pick then rendered under its original roster with no `via <manager>` attribution.

Production only got away with it because `getSpecificDraft` awaits another fetch before calling `buildDraft`, which happened to give React time to flush. That's timing, not correctness — a fast or cached draft response drops traded-pick ownership from the board.

## The fix

The chain is strictly single-caller (`getTradedDraftPicks` → `getSpecificDraft` → `buildDraft`) and `state.tradedDraftPicks` was read in exactly one place, so it existed only to ferry a value three calls down. It's now passed as an argument and gone from state — eliminating the failure mode rather than working around it.

## Evidence

Against the 21 traded picks in `real-draft-2026.json`, with fetches resolving immediately:

| | traded picks applied |
|---|---|
| before | 0 of 21 |
| after | 21 of 21 |

The new test asserts the count and the `"<owner> via <originator>"` shape, which also covers the `pick.roster_id` lookup the existing `App` test never touched. Sabotaged two ways — restoring the round-trip, and passing the argument but ignoring it — both fail with `expected [] to have a length of 21`, a crisp assertion rather than a timeout.

Runtime behaviour is unchanged: the board still hashes to the production pre-sync anchor `ed52e0a0…`, all 21 traded picks render (`Bloomberg4 via gdavidson`, `CHood20 via kpresley`, …), and the derived flag map still matches its `050812a4…` baseline.

Tests 75 → 76.

Still open and unrelated: #96, the same class of defect in `DraftPanel.getLiveDraft`.