### PR TITLE
Compose the draft board sync against current state

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -324,13 +324,18 @@ class App extends React.Component {
         });
     };
 
-    updateDraftBoard = (built_draft) => {
+    // Takes a reducer rather than a finished board on purpose. Callers compute
+    // the next board from an awaited fetch, so passing a value means computing
+    // it from whatever the caller's closure captured - and a manual pick made
+    // during those awaits is then silently overwritten. Composing against
+    // prevState instead is what makes the sync and a manual pick coexist.
+    updateDraftBoard = (buildNextDraftBoard) => {
         this.setState((prevState) => ({
             leagueData: {
                 ...prevState.leagueData,
                 currentDraft: {
                     ...prevState.leagueData.currentDraft,
-                    built_draft,
+                    built_draft: buildNextDraftBoard(prevState.leagueData.currentDraft.built_draft),
                 },
             },
         }));

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import App from './App';
 import rosterFlagsFixture from './lib/__fixtures__/roster-flags-2026.json';
 import realDraftFixture from './lib/__fixtures__/real-draft-2026.json';
@@ -35,7 +36,7 @@ vi.mock('firebase/auth', () => ({
     signOut: vi.fn().mockResolvedValue({}),
 }));
 
-const { rosterDataRaw, managerData, playerInfo } = rosterFlagsFixture;
+const { rosterDataRaw, managerData, playerInfo, livePicksPartial } = rosterFlagsFixture;
 const { currentDraft: draftSettings, tradedDraftPicks } = realDraftFixture;
 
 const LEAGUE_ID = '1312088290526003200';
@@ -131,5 +132,55 @@ describe('App', () => {
         for (const pick of traded) {
             expect(pick.textContent).toMatch(/^\S+ via \S+$/);
         }
+    });
+
+    it('keeps a manual pick made while a sync tick is in flight', async () => {
+        // Reproduces #96. `getLiveDraft` awaits two fetches and then builds the
+        // new board from the `currentDraft` its closure captured, so anything
+        // written to the board during those awaits is overwritten.
+        //
+        // Only the live-picks fetch is gated, and only so the manual pick can be
+        // placed inside the window - every other fetch still resolves instantly.
+        // This is control over the interleaving, not added latency: real latency
+        // is what hid #98, and against the live app this window measured ~50ms,
+        // which is precisely why the bug is easy to hit and hard to notice.
+        let releaseLivePicks;
+        const livePicksGate = new Promise((resolve) => {
+            releaseLivePicks = resolve;
+        });
+        global.fetch = vi.fn((url) => {
+            if (url.includes(`draft/${DRAFT_ID}/picks/`)) {
+                return livePicksGate.then(() => jsonResponse(structuredClone(livePicksPartial)));
+            }
+            return mockFetch(url);
+        });
+
+        const user = userEvent.setup();
+        render(<App />);
+        await screen.findAllByText('ryangh', {}, { timeout: 5000 });
+
+        // livePicksPartial covers rounds 1 and 2.1-2.8, so 3.1 is a slot the
+        // server has no pick for - the mid-draft case where a manager pencils in
+        // a pick the sync can't legitimately overwrite.
+        const manualPickBox = screen.getByText('3.1').closest('.draft-pick');
+
+        await user.click(screen.getByRole('button', { name: 'Update' }));
+
+        await user.click(manualPickBox);
+        await user.type(screen.getByPlaceholderText('Start typing player name to search'), 'Brady');
+        await user.click(await screen.findByText(/Tom Brady/));
+
+        // The pick is on the board before the sync resolves; that is what makes
+        // the assertion after the release meaningful rather than vacuous.
+        const round3 = manualPickBox.closest('.draft-picks-box');
+        expect(within(round3).getByText('Tom Brady')).toBeTruthy();
+
+        releaseLivePicks();
+
+        // The sync landing is the event under test, so wait on its own result
+        // rather than on a timer: Jeremiyah Love is live pick 1.1.
+        await waitFor(() => expect(screen.getAllByText('Jeremiyah Love').length).toBeGreaterThan(0));
+
+        expect(within(round3).queryByText('Tom Brady')).toBeTruthy();
     });
 });

--- a/src/Panels/DraftPanel.jsx
+++ b/src/Panels/DraftPanel.jsx
@@ -18,8 +18,8 @@ const DraftPanel = ({ leagueData, playerInfo, rosterInfo, rankingPlayersIdsList,
     };
 
     const handlePickChange = (updatedRound) => {
-        updateDraftBoard(
-            currentDraft.built_draft.map((round) => (round.round === updatedRound.round ? updatedRound : round)),
+        updateDraftBoard((builtDraft) =>
+            builtDraft.map((round) => (round.round === updatedRound.round ? updatedRound : round)),
         );
     };
 
@@ -37,13 +37,13 @@ const DraftPanel = ({ leagueData, playerInfo, rosterInfo, rankingPlayersIdsList,
                 console.error('Error:', error);
             });
 
-        const newLiveDraft = syncLiveDraft({
-            liveDraft: { built_draft: currentDraft.built_draft },
-            livePicks,
-            tradedPicks,
-        });
-
-        updateDraftBoard(newLiveDraft.built_draft);
+        // Applied against the board as it stands when the update runs, not the
+        // one this closure captured before the two awaits above: a manual pick
+        // assigned while they were in flight would otherwise be discarded.
+        updateDraftBoard(
+            (builtDraft) =>
+                syncLiveDraft({ liveDraft: { built_draft: builtDraft }, livePicks, tradedPicks }).built_draft,
+        );
     };
 
     const getLiveDraftRef = useRef(getLiveDraft);


### PR DESCRIPTION
Closes #96. Last known bug of the "reads a value that hasn't settled" class, and the same shape as #98.

`getLiveDraft` awaited two fetches and then built the new board from the `currentDraft` its closure captured. A manual pick assigned during those awaits was written to state, then overwritten by a board derived from pre-pick props.

## The fix

`updateDraftBoard` takes a reducer instead of a finished board, so both call sites compose against `prevState` rather than a snapshot. `handlePickChange` moves to the same form; it runs synchronously inside a click handler so its closure was never stale, but the API is now uniform and there is no value-shaped call site left to regress to.

## Evidence

Reproduced in the running app before the fix — pick 1.12 penciled in during an in-flight tick, against a draft truncated to the first 5 picks to simulate mid-draft:

| | pick 1.12 | pick 1.1 (server's) |
|---|---|---|
| before | **discarded** | Jeremiyah Love |
| after | Puka Nacua | Jeremiyah Love |

The measured race window against the live API is ~50ms, not the ~1s a previous estimate assumed — the two sync fetches returned in 26ms and 48ms.

The new test gates only the live-picks fetch, so the manual pick can be placed inside the window; every other fetch still resolves instantly. Sabotaged five ways: reverting `getLiveDraft` to the closure form, passing the reducer but ignoring its argument, and having `updateDraftBoard` drop the reducer all fail it; removing the `applyLivePicks` step also fails it, which is what shows the "sync landed" half isn't vacuous. Reverting `handlePickChange` alone does **not** fail anything — that half is consistency, not covered behaviour.

Board derivation is unchanged: pre-sync `ed52e0a0…` and post-sync `984afacc…` both still reproduce.

Tests 76 → 77.