### PR TITLE
Check the ADP response before reading its body

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -53,8 +53,8 @@ function mockFetch(url) {
     }
     if (url.includes('dlf_adp')) {
         // RanksPanel fetches this on mount regardless of the App-level flow
-        // under test; give it a harmless response so it doesn't produce an
-        // unhandled rejection.
+        // under test; give it a successful response so it stays out of the way.
+        // The failing case is exercised deliberately in its own test below.
         return jsonResponse({});
     }
     if (url.includes('state/nfl')) {
@@ -182,5 +182,37 @@ describe('App', () => {
         await waitFor(() => expect(screen.getAllByText('Jeremiyah Love').length).toBeGreaterThan(0));
 
         expect(within(round3).queryByText('Tom Brady')).toBeTruthy();
+    });
+
+    it('survives an ADP request that fails', async () => {
+        // `RanksPanel.getADP` called `updateResponse.json()` before checking the
+        // response, and `App.fetchRequest` returns undefined whenever its own
+        // catch swallows an error - which includes any non-ok response, since
+        // checkErrors throws on those. So a failing ADP request threw a
+        // TypeError out of an async effect: ADP silently never loaded, and the
+        // rejection went unhandled.
+        const rejections = [];
+        const recordRejection = (reason) => rejections.push(reason);
+        process.on('unhandledRejection', recordRejection);
+
+        try {
+            global.fetch = vi.fn((url) => {
+                if (url.includes('dlf_adp')) {
+                    return Promise.reject(new Error('ADP service unavailable'));
+                }
+                return mockFetch(url);
+            });
+
+            render(<App />);
+
+            // The rest of the app must still come up: a failed ADP lookup costs
+            // the ADP column, nothing else.
+            await screen.findAllByText('ryangh', {}, { timeout: 5000 });
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            expect(rejections).toEqual([]);
+        } finally {
+            process.off('unhandledRejection', recordRejection);
+        }
     });
 });

--- a/src/Panels/RanksPanel.jsx
+++ b/src/Panels/RanksPanel.jsx
@@ -182,13 +182,17 @@ const RanksPanel = ({
     useEffect(() => {
         const getADP = async () => {
             const updateResponse = await fetchRequest(DLF_ADP + (await auth.currentUser.getIdToken(true)), 'GET');
-            const lastResponse = await updateResponse.json().then((data) => data);
-            if (updateResponse && updateResponse.ok) {
-                setADP(lastResponse);
-                console.log(updateResponse.status);
-            } else {
-                console.log(updateResponse.status);
+            // The guard has to come before the body is read: fetchRequest
+            // resolves to undefined whenever its own catch swallows an error,
+            // and checkErrors throws on any non-ok response, so every failure
+            // arrives here as undefined. Reading .json() first threw a
+            // TypeError out of this effect instead.
+            if (!updateResponse || !updateResponse.ok) {
+                console.error('Error: could not load ADP data, continuing without it');
+                return;
             }
+            setADP(await updateResponse.json());
+            console.log(updateResponse.status);
         };
         getADP();
     }, []);


### PR DESCRIPTION
`RanksPanel.getADP` called `updateResponse.json()` before its `if (updateResponse && updateResponse.ok)` guard. `App.fetchRequest` resolves to `undefined` whenever its own catch swallows an error — and since `checkErrors` throws on any non-ok response, *every* failure arrives as `undefined`. So a failing ADP request threw `TypeError: Cannot read properties of undefined (reading 'json')` out of an async effect: ADP silently never loaded and the rejection went unhandled. The `else` branch would have crashed on `updateResponse.status` for the same reason.

The guard now runs before the body is read, and a failure logs and returns, leaving ADP as its empty default.

## Evidence

`App.test.jsx` had been mocking the `dlf_adp` URL specifically to dodge this. The new test points that URL at a rejecting fetch and asserts no unhandled rejection escapes; against the old code it fails with the TypeError above.

Sabotaged four ways. Dropping the guard, dropping its `!updateResponse` half, and moving it back after the `.json()` call all fail the test.

The fourth found a **pre-existing gap, not closed here**: deleting `setADP` entirely still leaves the suite green. Nothing asserts ADP data reaches the UI, because the rank list is empty in the App test — covering it means constructing a `rankingPlayersIdsList`, which is a bigger job than this fix.

Tests 77 → 78.