### PR TITLE
Unsubscribe from auth state changes on unmount

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -37,7 +37,7 @@ class App extends React.Component {
     selectRosterInfo = memoizeRosterInfo();
 
     componentDidMount() {
-        onAuthStateChanged(auth, (user) => {
+        this.unsubscribeAuth = onAuthStateChanged(auth, (user) => {
             if (user) {
                 const { playerInfo } = this.state;
                 const { currentUser } = auth;
@@ -55,6 +55,11 @@ class App extends React.Component {
             }
         });
     }
+
+    componentWillUnmount() {
+        this.unsubscribeAuth();
+    }
+
     // TODO clean up and pull out helper functions and search function into separate file(s)
     checkErrors = (response) => {
         if (!response.ok) {

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -24,12 +24,15 @@ vi.mock('./firebase.js', () => ({
     googleProvider: {},
 }));
 
+const authMockState = vi.hoisted(() => ({ unsubscribe: null }));
+
 vi.mock('firebase/auth', () => ({
     onAuthStateChanged: vi.fn((auth, callback) => {
         // Simplest path: report an already-signed-in (anonymous) user
         // immediately, so App skips the signInAnonymously branch entirely.
         callback({ uid: 'test-uid', isAnonymous: true });
-        return () => {};
+        authMockState.unsubscribe = vi.fn();
+        return authMockState.unsubscribe;
     }),
     signInAnonymously: vi.fn().mockResolvedValue({ user: { uid: 'test-uid', isAnonymous: true } }),
     signInWithPopup: vi.fn().mockResolvedValue({}),
@@ -214,5 +217,19 @@ describe('App', () => {
         } finally {
             process.off('unhandledRejection', recordRejection);
         }
+    });
+
+    it('unsubscribes from auth state changes on unmount', async () => {
+        global.fetch = vi.fn(mockFetch);
+
+        const { unmount } = render(<App />);
+        await screen.findAllByText('ryangh', {}, { timeout: 5000 });
+
+        expect(authMockState.unsubscribe).toEqual(expect.any(Function));
+        expect(authMockState.unsubscribe).not.toHaveBeenCalled();
+
+        unmount();
+
+        expect(authMockState.unsubscribe).toHaveBeenCalledTimes(1);
     });
 });


### PR DESCRIPTION
`componentDidMount` called `onAuthStateChanged(auth, callback)` but discarded the returned unsubscribe function, and the class had no `componentWillUnmount`. The Firebase auth listener stayed attached for the life of the page, past any unmount.

Fix: store the returned unsubscribe on the instance and call it from a new `componentWillUnmount`.

Added a test in `App.test.jsx` reusing the existing render-and-mock recipe: `onAuthStateChanged`'s mock now returns a fresh `vi.fn()` per call instead of a no-op, so the test can assert it fires exactly once after `unmount()`.

**Sabotage check:** removed `componentWillUnmount` and reran the suite — the new test failed (`expected "vi.fn()" to be called 1 times, but got 0 times`), 78/79 passing. Restored the fix; full suite is green at 79/79.

Gates: `npm ci`, `npm run lint` (1 pre-existing warning, 0 errors), `npm run format:check`, `npm run typecheck`, `npm run test:run` (79/79), `npm run build` — all pass.