### PR TITLE
Guard against a failed draft-details fetch

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -217,11 +217,15 @@ class App extends React.Component {
             .catch((error) => {
                 console.error('Error:', error);
             });
-        leagueData.currentDraft = draftData;
+        // The fetch's own catch resolves to undefined on failure, and
+        // DraftPanel reads currentDraft.draft_id unconditionally - so
+        // currentDraft has to stay a real object even when the fetch fails,
+        // or the next render crashes. Same shape as the ADP bug (#101).
+        leagueData.currentDraft = draftData || { draft_id: draftId };
         this.setState({
             leagueData,
         });
-        if (draftData.draft_order) {
+        if (draftData && draftData.draft_order) {
             this.buildDraft(tradedDraftPicks);
         } else {
             this.setState({

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -219,6 +219,38 @@ describe('App', () => {
         }
     });
 
+    it('survives a draft request that fails', async () => {
+        // getSpecificDraft's own catch resolves draftData to undefined on a
+        // failed fetch, and DraftPanel reads currentDraft.draft_id
+        // unconditionally to render its "Draft ID" input - so this only
+        // passes if currentDraft fell back to a real object instead of
+        // crashing the render.
+        const rejections = [];
+        const recordRejection = (reason) => rejections.push(reason);
+        process.on('unhandledRejection', recordRejection);
+
+        try {
+            global.fetch = vi.fn((url) => {
+                if (url.includes(`draft/${DRAFT_ID}/traded_picks/`)) {
+                    return mockFetch(url);
+                }
+                if (url.includes(`draft/${DRAFT_ID}`)) {
+                    return Promise.reject(new Error('Draft service unavailable'));
+                }
+                return mockFetch(url);
+            });
+
+            render(<App />);
+
+            expect(await screen.findByDisplayValue(DRAFT_ID, {}, { timeout: 5000 })).toBeTruthy();
+            await new Promise((resolve) => setTimeout(resolve, 0));
+
+            expect(rejections).toEqual([]);
+        } finally {
+            process.off('unhandledRejection', recordRejection);
+        }
+    });
+
     it('unsubscribes from auth state changes on unmount', async () => {
         global.fetch = vi.fn(mockFetch);
 


### PR DESCRIPTION
`getSpecificDraft`'s own `.catch` resolves `draftData` to `undefined` on a failed fetch (network error or a non-JSON error body). `DraftPanel` reads `currentDraft.draft_id` unconditionally to build its "Draft ID" input, so once `currentDraft` was set to `undefined` and the loading spinner cleared, the next render threw `TypeError: Cannot read properties of undefined (reading 'draft_id')` and crashed. Same shape as the ADP bug fixed in #101 — a swallowed fetch failure read before being checked.

Fix: fall back to `{ draft_id: draftId }` (already known from the league's draft list) so `currentDraft` stays a real object even when the details fetch fails. `buildDraft` is correctly skipped in that case (no `draft_order` to build from).

Added a test reusing the existing fetch-mock recipe: fails only the draft-details fetch, leaves everything else mocked normally, and asserts the "Draft ID" input still renders with no unhandled rejection.

**Sabotage check:** reverted the fallback and reran — the test failed exactly as expected, with the predicted crash surfacing as an uncaught exception (`TypeError: Cannot read properties of undefined (reading 'draft_id')` in `DraftPanel.jsx:10`) and the test timing out. Restored the fix; full suite is green at 80/80.

Gates: `npm ci`, `npm run lint` (1 pre-existing warning, 0 errors), `npm run format:check`, `npm run typecheck`, `npm run test:run` (80/80), `npm run build` — all pass.