### PR TITLE
Replace updateParentState's string dispatch with named callbacks

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -246,14 +246,18 @@ class App extends React.Component {
         });
     };
 
-    updateParentState = (state, value, callback, loadingMessage) => {
+    updateLeagueID = (leagueID) => {
         this.setState(
             {
-                [state]: value,
-                loadingMessage,
+                leagueID,
+                loadingMessage: 'Loading league panel...',
             },
-            this[callback],
+            this.getLeagueData,
         );
+    };
+
+    updateRankingPlayersIdsList = (rankingPlayersIdsList) => {
+        this.setState({ rankingPlayersIdsList });
     };
 
     startLoad = (loadMessage, searchText) => {
@@ -419,7 +423,7 @@ class App extends React.Component {
                             signedIn={signedIn}
                             playerInfo={playerInfo}
                             rosterInfo={rosterInfo}
-                            updateFilter={this.updateParentState}
+                            updateRankingPlayersIdsList={this.updateRankingPlayersIdsList}
                             startLoad={this.startLoad}
                             fetchRequest={this.fetchRequest}
                             checkErrors={this.checkErrors}
@@ -433,7 +437,7 @@ class App extends React.Component {
                         <LeaguePanel
                             leagueData={leagueData}
                             leagueID={leagueID}
-                            updateParentState={this.updateParentState}
+                            updateLeagueID={this.updateLeagueID}
                             rankingPlayersIdsList={rankingPlayersIdsList}
                             rosterPositions={rosterPositions}
                             playerInfo={playerInfo}

--- a/src/Panels/LeaguePanel.jsx
+++ b/src/Panels/LeaguePanel.jsx
@@ -6,7 +6,7 @@ const LeaguePanel = ({
     leagueData,
     playerInfo,
     rosterInfo,
-    updateParentState,
+    updateLeagueID,
     rosterPositions,
     leagueID,
     loadingMessage,
@@ -15,9 +15,6 @@ const LeaguePanel = ({
     updateDraftBoard,
 }) => {
     const [leaguePanel, setLeaguePanel] = useState('draft');
-    const updateLeagueID = (value) => {
-        updateParentState('leagueID', value, 'getLeagueData', 'Loading league panel...');
-    };
 
     return (
         <div className="panel league-panel">

--- a/src/Panels/RanksPanel.jsx
+++ b/src/Panels/RanksPanel.jsx
@@ -15,7 +15,7 @@ const RanksPanel = ({
     playerInfo,
     rosterInfo,
     lineupSet,
-    updateFilter,
+    updateRankingPlayersIdsList,
     startLoad,
     fetchRequest,
     checkErrors,
@@ -53,7 +53,7 @@ const RanksPanel = ({
     });
 
     const startSearch = () => {
-        updateFilter('rankingPlayersIdsList', []);
+        updateRankingPlayersIdsList([]);
         setCurrentListVal(defaultSelector);
         setIsNewRankList(true);
         startLoad('Loading search panel...', searchText);
@@ -133,9 +133,9 @@ const RanksPanel = ({
         setIsNewRankList(false);
         setCurrentListVal(newListName);
         if (newListName !== defaultSelector) {
-            updateFilter('rankingPlayersIdsList', allRankLists[newListName].rank_list);
+            updateRankingPlayersIdsList(allRankLists[newListName].rank_list);
         } else {
-            updateFilter('rankingPlayersIdsList', []);
+            updateRankingPlayersIdsList([]);
         }
     };
 


### PR DESCRIPTION
\`updateParentState(state, value, callback, loadingMessage)\` set an arbitrary state key by string and looked up the follow-up method as \`this[callback]\` — a typo in either string fails silently with no error, since a bad key just adds an unused state field and a bad callback name resolves to \`undefined\` (setState treats that as no callback).

It had exactly two calling shapes in practice:
- \`LeaguePanel\`: switch the league (\`leagueID\`), show the loading message, then call \`getLeagueData\`.
- \`RanksPanel\`: replace or clear \`rankingPlayersIdsList\`, no callback.

Replaced with two explicit methods, \`updateLeagueID\` and \`updateRankingPlayersIdsList\`, each doing exactly what its name says. Also dropped \`LeaguePanel\`'s local \`updateLeagueID\` wrapper, since the prop now already has the exact shape \`Dropdown\`'s \`updateCurrentValue\` expects.

Behavior-preserving refactor — traced both call chains (\`Dropdown.onChange\` → \`updateCurrentValue\` → \`updateLeagueID\`, and \`RanksPanel\`'s two call sites) to confirm the argument shapes match exactly. No prior test coverage existed for either path, so none was removed; didn't add new coverage since there's no behavior change to protect against regressing.

Gates: \`npm ci\`, \`npm run lint\` (1 pre-existing warning, 0 errors), \`npm run format:check\`, \`npm run typecheck\`, \`npm run test:run\` (79/79), \`npm run build\` — all pass.