### PR TITLE
Cover the derived-flags path through the panels

### DIFF
--- a/src/Components/PlayerInfoItem.test.jsx
+++ b/src/Components/PlayerInfoItem.test.jsx
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import PlayerInfoItem from './PlayerInfoItem';
+import { buildLineupSet, buildRosterInfo, decorateRosters } from '../lib/rosterInfo.js';
+import rosterFlagsFixture from '../lib/__fixtures__/roster-flags-2026.json';
+
+// PlayerInfoItem is the leaf that consumes all three derived-flag helpers -
+// isTaken, rosteredBy and isInLineup - and until now nothing tested that path.
+// App.test.jsx renders App for real but with an empty rank list, so no
+// PlayerInfoItem is ever constructed there and nothing flag-dependent is
+// observable. These tests build rosterInfo through the real derivation
+// (decorateRosters -> buildRosterInfo) rather than hand-rolling a Map, so a
+// change to how the flags are derived shows up here too.
+
+const { rosterDataRaw, managerData, playerInfo } = rosterFlagsFixture;
+
+const rosterData = decorateRosters({ rosterData: rosterDataRaw, managerData });
+const rosterInfo = buildRosterInfo({ rosterData, builtDraft: null });
+
+const MY_DISPLAY_NAME = 'ryangh';
+
+// Chosen against the fixture, not invented. 13307 is on nobody's roster - the
+// free-agent requirement from the flag-staleness work, where a player who is
+// taken for an unrelated reason silently masks the assertion. 13294 is on
+// roster 2 (aphilliny21), and 13274 is on roster 1, which is mine.
+const FREE_AGENT_ID = '13307';
+const OTHERS_PLAYER_ID = '13294';
+const MY_PLAYER_ID = '13274';
+
+const searchDataFor = (playerId) => ({
+    match_results: [[playerId, '0.000']],
+    ranking: '12',
+    search_string: 'a pasted rank line',
+});
+
+function renderItem(playerId, { lineupSet = new Set(), ...overrides } = {}) {
+    const props = {
+        player: playerInfo[playerId],
+        playerInfo,
+        rosterInfo,
+        lineupSet,
+        addToRoster: vi.fn(),
+        searchData: searchDataFor(playerId),
+        updatePlayerId: vi.fn(),
+        isNewRankList: false,
+        adpData: null,
+        myDisplayName: MY_DISPLAY_NAME,
+        ...overrides,
+    };
+    const { container } = render(<PlayerInfoItem {...props} />);
+    return { ...props, item: container.querySelector('.single-player-item') };
+}
+
+describe('PlayerInfoItem', () => {
+    it('shows a free agent as available and offers the Add button', () => {
+        const { item } = renderItem(FREE_AGENT_ID);
+
+        // rosteredBy returns null for an id the map doesn't hold, which is what
+        // drives the 'Free Agent' fallback rather than a blank team name.
+        expect(screen.getByText('Free Agent')).toBeTruthy();
+        // The `-available` half of the class list is the only visual signal that
+        // a player is still draftable; it is driven purely by isTaken.
+        expect(item.className).toContain(`${playerInfo[FREE_AGENT_ID].position}-available`);
+        expect(screen.getByRole('button', { name: 'Add' })).toBeEnabled();
+    });
+
+    it("shows another manager's player as taken and hides the Add button entirely", () => {
+        const { item } = renderItem(OTHERS_PLAYER_ID);
+
+        // The display name has to survive the whole derivation: owner_id ->
+        // managerData -> manager_display_name -> rosterInfo -> here.
+        expect(screen.getByText('aphilliny21')).toBeTruthy();
+        expect(screen.queryByText('Free Agent')).toBeNull();
+        expect(item.className).not.toContain('-available');
+        expect(screen.queryByRole('button', { name: 'Add' })).toBeNull();
+    });
+
+    it('still offers Add for a player already on my own roster', () => {
+        // This is the case that makes the `rosteredByName === myDisplayName`
+        // clause test-distinguishable. The player is taken, so the `!taken`
+        // clause is false and only the display-name comparison can keep the
+        // button on screen - dropping that clause would hide Add for every
+        // player I own, which is exactly the set I most want to add to a lineup.
+        const { item } = renderItem(MY_PLAYER_ID);
+
+        expect(screen.getByText(MY_DISPLAY_NAME)).toBeTruthy();
+        expect(item.className).not.toContain('-available');
+        expect(screen.getByRole('button', { name: 'Add' })).toBeEnabled();
+    });
+
+    it('disables the Add button for a player already in the lineup', () => {
+        // The lineup set is built by the real helper rather than a literal Set
+        // so the shape stays honest, but what this protects is the component
+        // half: that lineupSet reaches the item and drives the button's label
+        // and disabled state. buildLineupSet's own numeric filtering is
+        // covered directly in lib/rosterInfo.test.js - sabotaging that filter
+        // does not fail this test, and this comment used to claim it did.
+        const lineupSet = buildLineupSet(['QB', MY_PLAYER_ID, 'FLX', 'BN']);
+        renderItem(MY_PLAYER_ID, { lineupSet });
+
+        const added = screen.getByRole('button', { name: 'Added' });
+        expect(added).toBeDisabled();
+        expect(screen.queryByRole('button', { name: 'Add' })).toBeNull();
+    });
+});

--- a/src/Panels/DraftRound.test.jsx
+++ b/src/Panels/DraftRound.test.jsx
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DraftRound from './DraftRound';
+import { buildRosterInfo, decorateRosters } from '../lib/rosterInfo.js';
+import rosterFlagsFixture from '../lib/__fixtures__/roster-flags-2026.json';
+
+// Two things meet in DraftRound and neither had a direct test: the derived
+// flags decide which ranked players the manual-pick modal is allowed to offer,
+// and the DraftRound -> applyManualPick -> onPickChange contract is what PR
+// #100's reducer-shaped updateDraftBoard composes against. App.test.jsx reaches
+// the second only through the much heavier live-sync test, and the first not at
+// all.
+
+const { rosterDataRaw, managerData, playerInfo, builtDraft } = rosterFlagsFixture;
+
+const rosterData = decorateRosters({ rosterData: rosterDataRaw, managerData });
+const rosterInfo = buildRosterInfo({ rosterData, builtDraft: null });
+
+// 13307 is on nobody's roster. That matters more here than anywhere else: the
+// natural repro for this filter uses a player who is also taken for an
+// unrelated reason, which makes "correctly excluded" and "wrongly excluded"
+// indistinguishable. 13294 and 13274 are genuinely taken (roster 2 and my own
+// roster 1), so their absence is the real assertion.
+const FREE_AGENT = { id: '13307', name: 'Marlin Klein' };
+const OTHERS_PLAYER = { id: '13294', name: 'Makai Lemon' };
+const MY_PLAYER = { id: '13274', name: 'Germie Bernard' };
+
+const rankEntry = (playerId) => ({
+    match_results: [[playerId, '0.000']],
+    ranking: '1',
+    search_string: 'a pasted rank line',
+});
+
+const round = builtDraft[0];
+
+function renderRound(overrides = {}) {
+    const onPickChange = vi.fn();
+    const props = {
+        round,
+        playerInfo,
+        rosterInfo,
+        rosterData,
+        rankingPlayersIdsList: [rankEntry(FREE_AGENT.id), rankEntry(OTHERS_PLAYER.id), rankEntry(MY_PLAYER.id)],
+        onPickChange,
+        ...overrides,
+    };
+    render(<DraftRound {...props} />);
+    return { onPickChange };
+}
+
+// The modal is rendered as a sibling of the round box, so scope queries to it
+// rather than to the board - the board also renders player names.
+const openPickModal = async (user, pickLabel) => {
+    await user.click(screen.getByText(pickLabel).closest('.draft-pick'));
+    return screen.getByText(/^Manually select pick/).closest('div').parentElement;
+};
+
+describe('DraftRound manual pick selection', () => {
+    let user;
+
+    beforeEach(() => {
+        user = userEvent.setup();
+    });
+
+    it('offers only untaken ranked players in the pick modal', async () => {
+        renderRound();
+
+        const modal = await openPickModal(user, '1.1');
+
+        expect(within(modal).getByText(new RegExp(FREE_AGENT.name))).toBeTruthy();
+        expect(within(modal).queryByText(new RegExp(OTHERS_PLAYER.name))).toBeNull();
+        expect(within(modal).queryByText(new RegExp(MY_PLAYER.name))).toBeNull();
+    });
+
+    it('reports the chosen player back through onPickChange as a whole round', async () => {
+        const { onPickChange } = renderRound();
+
+        const modal = await openPickModal(user, '1.1');
+        await user.click(within(modal).getByText(new RegExp(FREE_AGENT.name)));
+
+        expect(onPickChange).toHaveBeenCalledTimes(1);
+        const updatedRound = onPickChange.mock.calls[0][0];
+
+        // DraftPanel swaps the whole round object into the board by matching
+        // `round.round`, so an update that loses the round number - or that
+        // hands back a bare pick - silently drops the pick on the floor.
+        expect(updatedRound.round).toBe(round.round);
+        expect(updatedRound.picks.find((pick) => pick.pick_number === 1).player_id).toBe(FREE_AGENT.id);
+
+        // Every other pick has to survive untouched, and the input round must
+        // not have been mutated in place: DraftPanel's reducer compares against
+        // prevState, which an in-place edit would defeat.
+        expect(updatedRound.picks).toHaveLength(round.picks.length);
+        expect(round.picks[0].player_id).toBeNull();
+    });
+
+    it('lets a filled pick be cleared again', async () => {
+        // The remove path only renders when the pick already holds a player,
+        // and it is the half of the flow that clears rather than sets - the
+        // asymmetric direction, where a flag that is written but never cleared
+        // fails silently.
+        const filledRound = {
+            ...round,
+            picks: round.picks.map((pick) => (pick.pick_number === 1 ? { ...pick, player_id: FREE_AGENT.id } : pick)),
+        };
+        const { onPickChange } = renderRound({ round: filledRound });
+
+        const modal = await openPickModal(user, '1.1');
+        await user.click(within(modal).getByText('Remove pick?'));
+
+        expect(onPickChange.mock.calls[0][0].picks.find((pick) => pick.pick_number === 1).player_id).toBeNull();
+    });
+
+    it('attributes a traded pick to its current owner via the original holder', async () => {
+        // pick.owner_id and pick.roster_id resolve against two different
+        // rosters; the "via" text is the only place both lookups are visible.
+        const tradedRound = {
+            ...round,
+            picks: round.picks.map((pick) =>
+                pick.pick_number === 1 ? { ...pick, is_traded: true, owner_id: 1, roster_id: 2 } : pick,
+            ),
+        };
+        renderRound({ round: tradedRound });
+
+        expect(screen.getByText('ryangh via aphilliny21')).toBeTruthy();
+    });
+});

--- a/src/Panels/RanksPanel.test.jsx
+++ b/src/Panels/RanksPanel.test.jsx
@@ -1,0 +1,130 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import RanksPanel from './RanksPanel';
+import { buildRosterInfo, decorateRosters } from '../lib/rosterInfo.js';
+import rosterFlagsFixture from '../lib/__fixtures__/roster-flags-2026.json';
+
+// RanksPanel.filterPlayers is the only place the derived flags decide what
+// renders at all, and it is a four-branch table over isTaken/rosteredBy rather
+// than a single condition. App.test.jsx cannot reach it: the rank list is empty
+// there, so every branch is vacuous. Each test below pins one branch, because a
+// table that agrees with the real one only in the default state is the likely
+// shape of a regression here.
+
+vi.mock('../firebase.js', () => ({
+    auth: {
+        currentUser: {
+            uid: 'test-uid',
+            getIdToken: vi.fn().mockResolvedValue('test-id-token'),
+        },
+    },
+    googleProvider: {},
+}));
+
+const { rosterDataRaw, managerData, playerInfo } = rosterFlagsFixture;
+
+const rosterData = decorateRosters({ rosterData: rosterDataRaw, managerData });
+const rosterInfo = buildRosterInfo({ rosterData, builtDraft: null });
+
+const MY_DISPLAY_NAME = 'ryangh';
+
+// One player per flag state, all WR/TE so the position filters (which default
+// to QB/RB/WR/TE on) never confound the taken/mine assertions.
+const FREE_AGENT = { id: '13307', name: 'Marlin Klein' }; // on nobody's roster
+const OTHERS_PLAYER = { id: '13294', name: 'Makai Lemon' }; // roster 2, aphilliny21
+const MY_PLAYER = { id: '13274', name: 'Germie Bernard' }; // roster 1, mine
+
+const rankEntry = (playerId, ranking) => ({
+    match_results: [[playerId, '0.000']],
+    ranking: String(ranking),
+    search_string: 'a pasted rank line',
+});
+
+const rankingPlayersIdsList = [rankEntry(FREE_AGENT.id, 1), rankEntry(OTHERS_PLAYER.id, 2), rankEntry(MY_PLAYER.id, 3)];
+
+function renderPanel() {
+    // signedIn stays false so the saved-rank-lists effect takes its else
+    // branch and no global fetch is needed; ADP resolves empty so the panel
+    // renders without an ADP column. Neither touches the filter path.
+    const props = {
+        loadingMessage: '',
+        signedIn: false,
+        playerInfo,
+        rosterInfo,
+        lineupSet: new Set(),
+        updateRankingPlayersIdsList: vi.fn(),
+        startLoad: vi.fn(),
+        fetchRequest: vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) }),
+        checkErrors: vi.fn((response) => response),
+        rankingPlayersIdsList,
+        addToRoster: vi.fn(),
+        updatePlayerId: vi.fn(),
+        notFoundPlayers: [],
+        myDisplayName: MY_DISPLAY_NAME,
+    };
+    render(<RanksPanel {...props} />);
+    return props;
+}
+
+// The filter controls are <label> elements wrapping a checkbox, so the
+// accessible name is what to click rather than the label text node.
+const toggle = (user, name) => user.click(screen.getByRole('checkbox', { name }));
+
+const visiblePlayers = () =>
+    [FREE_AGENT, OTHERS_PLAYER, MY_PLAYER].filter((p) => screen.queryByText(p.name) !== null).map((p) => p.name);
+
+describe('RanksPanel player filters', () => {
+    let user;
+
+    beforeEach(() => {
+        user = userEvent.setup();
+    });
+
+    it('shows free agents and my own players by default, and hides everyone elses', async () => {
+        // Default filters: showTaken false, showMyPlayers true - the branch a
+        // manager actually drafts against.
+        renderPanel();
+
+        expect(visiblePlayers()).toEqual([FREE_AGENT.name, MY_PLAYER.name]);
+    });
+
+    it('shows every player once Taken is on alongside My players', async () => {
+        renderPanel();
+
+        await toggle(user, 'Taken');
+
+        expect(visiblePlayers()).toEqual([FREE_AGENT.name, OTHERS_PLAYER.name, MY_PLAYER.name]);
+    });
+
+    it('shows only free agents when both Taken and My players are off', async () => {
+        renderPanel();
+
+        await toggle(user, 'My players');
+
+        expect(visiblePlayers()).toEqual([FREE_AGENT.name]);
+    });
+
+    it('hides my own players when Taken is on but My players is off', async () => {
+        // The one branch that reads rosteredBy rather than isTaken: it keeps
+        // anything not rostered by me, which is how a manager scouts the rest
+        // of the league without their own roster in the way.
+        renderPanel();
+
+        await toggle(user, 'Taken');
+        await toggle(user, 'My players');
+
+        expect(visiblePlayers()).toEqual([FREE_AGENT.name, OTHERS_PLAYER.name]);
+    });
+
+    it('applies the position filters on top of the flag filters', async () => {
+        // The position filter runs as a second pass over whatever filterPlayers
+        // returned, so turning WR off must not disturb the taken/mine decision
+        // for the TE that remains.
+        renderPanel();
+
+        await toggle(user, 'WR');
+
+        expect(visiblePlayers()).toEqual([FREE_AGENT.name]);
+    });
+});


### PR DESCRIPTION
The `rosterInfo`/`lineupSet` derivation reaching the panels was verified end to end only by a manual browser check in session 4. `App.test.jsx` renders `App` for real, but with an **empty rank list** — so no `PlayerInfoItem` is ever constructed there and every flag-dependent branch is vacuous.

No production code changed. Tests 80 → 93.

## What each file protects

| File | Protects |
|---|---|
| `PlayerInfoItem.test.jsx` (4) | The leaf consuming all three helpers. Free agent / taken by someone else / taken by me / in lineup. |
| `RanksPanel.test.jsx` (5) | `filterPlayers`' four-branch table, one test per branch, plus the position pass layered on top. |
| `DraftRound.test.jsx` (4) | The manual-pick modal's untaken-only filter, and the `applyManualPick → onPickChange` contract. |

Two choices worth calling out:

**The taken-by-me case is load-bearing.** It's the only thing that makes the `(rosteredByName && rosteredByName === myDisplayName) || !taken` clause test-distinguishable — the player *is* taken, so only the display-name comparison can keep the Add button on screen. Dropping that clause hides Add for exactly the set of players I'm most likely to add to a lineup.

**Exclusion assertions use `13307`**, who is on nobody's roster. The natural repro uses a player who is also taken for an unrelated reason, which makes "correctly excluded" and "wrongly excluded" indistinguishable — the same trap the flag-staleness work hit.

## Sabotage verification

Every test was verified by deleting what it protects and confirming the predicted failure, then restoring. Thirteen sabotages, each failing only its intended test(s):

| Sabotage | Result |
|---|---|
| Drop the `=== myDisplayName` clause | 2 failed |
| `rosteredBy` always null | 3 failed |
| `isTaken` always false | 2 failed |
| `isInLineup` always false | 1 failed |
| `filterPlayers` always true | 3 failed |
| Default branch drops the "or mine" clause | 1 failed |
| `showTaken`-only branch drops the `rosteredBy` check | 1 failed |
| Neither-filter branch drops `!isTaken` | 1 failed |
| Position-filter pass removed | 1 failed |
| Modal stops filtering out taken players | 1 failed |
| `applyManualPick` returns the round unchanged | 2 failed |
| `applyManualPick` mutates the input round | 1 failed |
| `via` resolves the originator with `owner_id` | 1 failed |

**One sabotage did not fail, and the test was corrected rather than kept.** An early comment claimed the in-lineup test protected `buildLineupSet`'s numeric filter; breaking that filter left the test green, because the surrounding position labels are never queried as player ids. That filter is already covered directly in `lib/rosterInfo.test.js`, so the comment now says what the test actually pins — the component half — and the behaviour was re-verified by sabotaging `isInLineup` instead.

## Gates

`npm ci`, `npm run lint` (1 pre-existing warning, 0 errors), `npm run format:check`, `npm run typecheck`, `npm run test:run` (93 pass), `npm run build` — all green.

## Not in this PR

`DraftPanel` (sync start/stop, the poll loop's `cancelled` re-check) and `LeaguePanel` (tab switch, weekly lineup) still have no direct tests. The four leaf components are exercised for real by these tests but not tested directly; only `OnFocusButton` has logic that would justify its own file.