### PR TITLE
Cover the draft sync loop and the league panel's tab switch

### DIFF
--- a/src/Panels/DraftPanel.test.jsx
+++ b/src/Panels/DraftPanel.test.jsx
@@ -1,0 +1,224 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import DraftPanel from './DraftPanel';
+import { buildRosterInfo, decorateRosters } from '../lib/rosterInfo.js';
+import rosterFlagsFixture from '../lib/__fixtures__/roster-flags-2026.json';
+
+// The polling loop is the reason this file exists. Its `cancelled` re-check
+// guards a loop that could not be stopped mid-flight - the await can resolve
+// after cleanup has already run, so clearTimeout fires against a timer that
+// does not exist yet and the next tick gets scheduled anyway. Nothing tested it.
+//
+// The other half is that both call sites hand updateDraftBoard a *reducer*
+// rather than a finished board (PR #100). A regression that passes a finished
+// board still renders correctly in isolation, so what needs asserting is the
+// shape of the argument, not what ends up on screen.
+//
+// This file drives the DOM with fireEvent rather than userEvent: userEvent's
+// internal delay schedules real timers, which deadlocks against the fake timers
+// the 3s poll needs. fireEvent is synchronous and does fire React's onChange,
+// so nothing is lost here beyond a less realistic click.
+
+const { rosterDataRaw, managerData, playerInfo, builtDraft, livePicksPartial, tradedPicks } = rosterFlagsFixture;
+
+const rosterData = decorateRosters({ rosterData: rosterDataRaw, managerData });
+const rosterInfo = buildRosterInfo({ rosterData, builtDraft: null });
+
+const DRAFT_ID = 'draft123';
+const FREE_AGENT = { id: '13307', name: 'Marlin Klein' };
+
+const jsonResponse = (data) => Promise.resolve({ ok: true, json: () => Promise.resolve(data) });
+
+const rankEntry = (playerId) => ({
+    match_results: [[playerId, '0.000']],
+    ranking: '1',
+    search_string: 'a pasted rank line',
+});
+
+const instantFetch = (url) => jsonResponse(url.includes('traded_picks') ? tradedPicks : livePicksPartial);
+
+// Gates only the first live-picks request; everything else stays instant. That
+// is control over the interleaving rather than added latency - blanket delays
+// are what hid the bugs these tests exist for.
+function gatedFetch() {
+    let release;
+    const gate = new Promise((resolve) => {
+        release = resolve;
+    });
+    let gated = false;
+    const fetchMock = vi.fn((url) => {
+        if (url.includes('picks/') && !url.includes('traded_picks') && !gated) {
+            gated = true;
+            return gate.then(() => jsonResponse(livePicksPartial));
+        }
+        return instantFetch(url);
+    });
+    return { fetchMock, release: () => release() };
+}
+
+function renderPanel(overrides = {}) {
+    const updateDraftBoard = vi.fn();
+    const props = {
+        leagueData: {
+            currentDraft: {
+                draft_id: DRAFT_ID,
+                season: '2026',
+                player_pool: 'Rookie',
+                status: 'drafting',
+                built_draft: builtDraft,
+            },
+            rosterData,
+        },
+        playerInfo,
+        rosterInfo,
+        rankingPlayersIdsList: [rankEntry(FREE_AGENT.id)],
+        updateDraftBoard,
+        ...overrides,
+    };
+    const result = render(<DraftPanel {...props} />);
+    return { updateDraftBoard, ...result };
+}
+
+const click = async (element) => {
+    await act(async () => {
+        fireEvent.click(element);
+    });
+};
+
+const settle = async (ms) => {
+    await act(async () => {
+        await vi.advanceTimersByTimeAsync(ms);
+    });
+};
+
+const button = (name) => screen.getByRole('button', { name });
+const urlsFetched = () => global.fetch.mock.calls.map((call) => call[0]);
+
+describe('DraftPanel', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        global.fetch = vi.fn(instantFetch);
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('polls repeatedly while syncing and stops when sync is switched off', async () => {
+        renderPanel();
+
+        await click(button('Sync draft'));
+        await settle(7000);
+
+        // Two fetches per tick on a 3s timer: the immediate poll plus two more.
+        const whileSyncing = global.fetch.mock.calls.length;
+        expect(whileSyncing).toBeGreaterThan(2);
+
+        await click(button('Stop sync'));
+        await settle(10000);
+
+        expect(global.fetch.mock.calls.length).toBe(whileSyncing);
+    });
+
+    it('does not schedule another tick when sync is stopped while a request is in flight', async () => {
+        // The exact shape of the bug the `cancelled` re-check guards: cleanup
+        // runs while the awaits are still pending, so clearTimeout has nothing
+        // to clear and the loop reschedules itself forever after.
+        const { fetchMock, release } = gatedFetch();
+        global.fetch = fetchMock;
+
+        renderPanel();
+
+        await click(button('Sync draft'));
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+
+        // Stop while that first request is still pending.
+        await click(button('Stop sync'));
+
+        release();
+        await settle(10000);
+
+        // The in-flight invocation still finishes its own second fetch - that
+        // is unavoidable and not the bug. What must not happen is a further
+        // tick: without the re-check, 10s buys three more polls.
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('stops polling when the panel unmounts mid-request', async () => {
+        const { fetchMock, release } = gatedFetch();
+        global.fetch = fetchMock;
+
+        const { unmount } = renderPanel();
+
+        await click(button('Sync draft'));
+        unmount();
+
+        release();
+        await settle(10000);
+
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('hands updateDraftBoard a reducer rather than a finished board when syncing', async () => {
+        const { updateDraftBoard } = renderPanel();
+
+        await click(button('Update'));
+        await settle(0);
+
+        expect(updateDraftBoard).toHaveBeenCalledTimes(1);
+        const reducer = updateDraftBoard.mock.calls[0][0];
+        expect(typeof reducer).toBe('function');
+
+        // Composing against whatever the caller passes is the whole point of
+        // #100: a sync that captured its own board would discard a manual pick
+        // made during the two awaits inside getLiveDraft.
+        const boardWithManualPick = builtDraft.map((round) =>
+            round.round === 3
+                ? {
+                      ...round,
+                      picks: round.picks.map((pick) =>
+                          pick.pick_number === 1 ? { ...pick, player_id: FREE_AGENT.id } : pick,
+                      ),
+                  }
+                : round,
+        );
+        const next = reducer(boardWithManualPick);
+        const round3Pick1 = next.find((round) => round.round === 3).picks.find((pick) => pick.pick_number === 1);
+
+        // livePicksPartial covers rounds 1 and 2.1-2.8, so the server has no
+        // pick for 3.1 and the manual one has to survive the merge.
+        expect(round3Pick1.player_id).toBe(FREE_AGENT.id);
+    });
+
+    it('hands updateDraftBoard a reducer that swaps in only the changed round on a manual pick', async () => {
+        const { updateDraftBoard } = renderPanel();
+
+        await click(screen.getByText('1.1').closest('.draft-pick'));
+        const modal = screen.getByText(/^Manually select pick/).closest('div').parentElement;
+        await click(within(modal).getByText(new RegExp(FREE_AGENT.name)));
+
+        expect(updateDraftBoard).toHaveBeenCalledTimes(1);
+        const reducer = updateDraftBoard.mock.calls[0][0];
+        expect(typeof reducer).toBe('function');
+
+        const next = reducer(builtDraft);
+        expect(next.find((round) => round.round === 1).picks[0].player_id).toBe(FREE_AGENT.id);
+        // Only the edited round is replaced; the others keep their identity.
+        expect(next.find((round) => round.round === 2)).toBe(builtDraft.find((round) => round.round === 2));
+    });
+
+    it('syncs against the draft id typed into the input rather than the original one', async () => {
+        renderPanel();
+
+        await act(async () => {
+            fireEvent.change(screen.getByDisplayValue(DRAFT_ID), { target: { value: 'other456' } });
+        });
+
+        await click(button('Update'));
+        await settle(0);
+
+        expect(urlsFetched().length).toBeGreaterThan(0);
+        expect(urlsFetched().every((url) => url.includes('other456'))).toBe(true);
+        expect(urlsFetched().some((url) => url.includes(DRAFT_ID))).toBe(false);
+    });
+});

--- a/src/Panels/LeaguePanel.test.jsx
+++ b/src/Panels/LeaguePanel.test.jsx
@@ -1,0 +1,152 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import LeaguePanel from './LeaguePanel';
+import { buildRosterInfo, decorateRosters } from '../lib/rosterInfo.js';
+import rosterFlagsFixture from '../lib/__fixtures__/roster-flags-2026.json';
+
+// LeaguePanel is a router: it owns which of the two sub-panels is showing, and
+// the weekly lineup is the only view rendered nowhere else. App.test.jsx never
+// leaves the draft tab, so the weekly branch and the tab switch itself had no
+// coverage at all.
+
+const { rosterDataRaw, managerData, playerInfo, builtDraft } = rosterFlagsFixture;
+
+const rosterData = decorateRosters({ rosterData: rosterDataRaw, managerData });
+const rosterInfo = buildRosterInfo({ rosterData, builtDraft: null });
+
+const LEAGUE_ID = '1312088290526003200';
+const OTHER_LEAGUE_ID = '9999999999999999999';
+const STARTER = { id: '13274', name: 'Germie Bernard' };
+
+// roster_text is written onto the player by lib/roster.js when a player is
+// added to a lineup; the fixture holds the undecorated player database, so the
+// decoration is applied here rather than in the fixture file.
+const lineupPlayerInfo = {
+    ...playerInfo,
+    [STARTER.id]: { ...playerInfo[STARTER.id], roster_text: 'WR' },
+};
+
+// Index 1 is the only filled slot; the bare labels around it are what
+// distinguishes a real starter from an empty position.
+const ROSTER_POSITIONS = ['QB', STARTER.id, 'FLX'];
+
+function renderPanel(overrides = {}) {
+    const updateLeagueID = vi.fn();
+    const removeFromLineup = vi.fn();
+    const props = {
+        leagueData: {
+            currentLeague: { name: 'Test League' },
+            leagueIds: [
+                { league_id: LEAGUE_ID, name: 'Test League' },
+                { league_id: OTHER_LEAGUE_ID, name: '4 QB Madness' },
+            ],
+            currentDraft: {
+                draft_id: 'draft123',
+                season: '2026',
+                player_pool: 'Rookie',
+                status: 'drafting',
+                built_draft: builtDraft,
+            },
+            rosterData,
+        },
+        playerInfo: lineupPlayerInfo,
+        rosterInfo,
+        updateLeagueID,
+        rosterPositions: ROSTER_POSITIONS,
+        leagueID: LEAGUE_ID,
+        loadingMessage: '',
+        removeFromLineup,
+        rankingPlayersIdsList: [],
+        updateDraftBoard: vi.fn(),
+        ...overrides,
+    };
+    const { container } = render(<LeaguePanel {...props} />);
+    return { updateLeagueID, removeFromLineup, container };
+}
+
+const draftPanelShowing = () => screen.queryByRole('button', { name: 'Sync draft' }) !== null;
+
+describe('LeaguePanel', () => {
+    let user;
+
+    beforeEach(() => {
+        user = userEvent.setup();
+        global.fetch = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve([]) }));
+    });
+
+    it('shows only the loader while the league panel is loading', () => {
+        const { container } = renderPanel({ loadingMessage: 'Loading league panel...' });
+
+        expect(container.querySelector('.panel-loader')).toBeTruthy();
+        expect(screen.queryByText('Test League')).toBeNull();
+        expect(draftPanelShowing()).toBe(false);
+    });
+
+    it('opens on the draft tab', () => {
+        renderPanel();
+
+        expect(draftPanelShowing()).toBe(true);
+        expect(screen.queryByText(STARTER.name)).toBeNull();
+    });
+
+    it('swaps the draft panel for the weekly lineup and back', async () => {
+        renderPanel();
+
+        await user.click(screen.getByText('Weekly'));
+        expect(draftPanelShowing()).toBe(false);
+        expect(screen.getAllByText(STARTER.name).length).toBeGreaterThan(0);
+
+        // Switching back matters as much as switching away: the board used to
+        // live in DraftPanel's own state, so a round trip through Weekly lost
+        // every pick. It is App's state now, but the round trip is the thing
+        // that exposed it.
+        await user.click(screen.getByText('Draft'));
+        expect(draftPanelShowing()).toBe(true);
+        expect(screen.queryByText(STARTER.name)).toBeNull();
+    });
+
+    it('renders filled lineup slots as players and empty ones as bare position labels', async () => {
+        const { container } = renderPanel();
+
+        await user.click(screen.getByText('Weekly'));
+
+        const slots = [...container.querySelectorAll('.lineup-position')];
+        expect(slots).toHaveLength(ROSTER_POSITIONS.length);
+
+        // A filled slot takes its class from the player's position rather than
+        // from the raw entry, which is what colours it on screen.
+        expect(slots[1].className).toContain(lineupPlayerInfo[STARTER.id].position);
+        expect(slots[1].textContent).toContain(STARTER.name);
+        // Doubled because the slot renders a full-text and an abbr-text span,
+        // one of which CSS hides depending on viewport width.
+        expect(slots[0].textContent).toBe('QBQB');
+        expect(slots[2].textContent).toBe('FLXFLX');
+    });
+
+    it('removes a player from the lineup by slot index, and ignores clicks on empty slots', async () => {
+        const { removeFromLineup, container } = renderPanel();
+
+        await user.click(screen.getByText('Weekly'));
+        const slots = [...container.querySelectorAll('.lineup-position')];
+
+        await user.click(slots[0]);
+        expect(removeFromLineup).not.toHaveBeenCalled();
+
+        await user.click(slots[1]);
+        // The index is what lib/roster.js splices the position label back into,
+        // so passing the wrong one restores the slot in the wrong place.
+        expect(removeFromLineup).toHaveBeenCalledTimes(1);
+        expect(removeFromLineup).toHaveBeenCalledWith(STARTER.id, 1);
+    });
+
+    it('reports a league change up by league id', async () => {
+        const { updateLeagueID } = renderPanel();
+
+        await user.selectOptions(screen.getByRole('combobox'), OTHER_LEAGUE_ID);
+
+        // The dropdown shows names but has to report ids: switching leagues by
+        // display name would break the moment two leagues shared one.
+        expect(updateLeagueID).toHaveBeenCalledWith(OTHER_LEAGUE_ID);
+    });
+});


### PR DESCRIPTION
Tier B of the panel coverage work, following #105. No production code changed. Tests **93 → 105**.

## DraftPanel (6 tests)

The polling loop at [DraftPanel.jsx:54](https://github.com/rghart/my-sleeper-app/blob/master/src/Panels/DraftPanel.jsx#L54) had no test at all — including the `cancelled` re-check, which guards a loop that could not be stopped mid-flight. The await can resolve *after* cleanup has run, so `clearTimeout` fires against a timer that doesn't exist yet and the next tick gets scheduled anyway.

Two tests pin that specifically — stopping the sync, and unmounting — each gating **only** the first live-picks request so the stop lands inside the window. Everything else stays instant; that's control over the interleaving, not added latency.

Both `updateDraftBoard` call sites are also asserted to hand over a **reducer** rather than a finished board. This needs asserting on the shape of the argument, because a regression that passes a finished board still renders correctly in isolation — which is precisely why #96 survived as long as it did.

## LeaguePanel (6 tests)

The weekly lineup is rendered nowhere else, and `App.test.jsx` never leaves the draft tab. Covers the loader branch, the default tab, the Weekly↔Draft round trip, filled-vs-empty slot rendering, `removeFromLineup(id, i)` including that empty slots ignore clicks, and that the dropdown reports league **ids** rather than names.

## Sabotage verification

Twelve sabotages, each restored to green afterwards:

| Sabotage | Result |
|---|---|
| Drop the post-await `if (cancelled) return` | **2 failed** — exactly the two tests written for it, and not the plain stop-sync test |
| Effect cleanup removed entirely | 3 failed |
| `handlePickChange` passes a finished board | 1 failed |
| `getLiveDraft` syncs against its captured board (the #96 regression) | 1 failed |
| `updateDraftID` stops updating the fetch path | 1 failed |
| Weekly tab never renders the lineup | 3 failed |
| Draft tab always renders | 1 failed |
| `removeFromLineup` called without the slot index | 1 failed |
| Empty slots become clickable | 1 failed |
| Slot class from the raw entry, not the player position | 1 failed |
| Dropdown reports the league name instead of the id | 1 failed |
| Loader branch removed | 1 failed |

The first row is the one worth reading: re-introducing exactly the mid-flight bug fails only the two tests aimed at it, and leaves the ordinary stop-sync test green. That's the distinction that makes the pair worth having separately.

## A trap worth recording

`DraftPanel.test.jsx` uses `fireEvent`, not `userEvent`. userEvent's internal delay schedules **real** timers, which deadlock against the fake timers the 3s poll requires — every test in the file timed out at 5s until that changed, including ones that never touch the loop. `fireEvent` is synchronous and still fires React's `onChange`, so nothing is lost beyond a less realistic click. `LeaguePanel.test.jsx` needs no fake timers and uses `userEvent` normally.

## Gates

`npm ci`, `npm run lint` (1 pre-existing warning, 0 errors), `npm run format:check`, `npm run typecheck`, `npm run test:run` (105 pass), `npm run build` — all green.

## What's left

No panel is uncovered now. The four leaf components are exercised for real by these tests but have no direct files; only `OnFocusButton` has logic that would justify one.