### PR TITLE
Delete three unused pieces of App state

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,12 +22,10 @@ class App extends React.Component {
         isLoading: true,
         loadingMessage: 'Initial load...',
         rankingPlayersIdsList: [],
-        isTyping: false,
         leagueID: '1312088290526003200',
         rosterPositions: [],
         notFoundPlayers: [],
         lastUpdate: null,
-        liveDraft: [],
         signedIn: false,
         signedInEmail: null,
         season: null,
@@ -282,7 +280,6 @@ class App extends React.Component {
             isLoading: false,
             loadingMessage: '',
             notFoundPlayers: notFoundPlayers,
-            searchText: '',
         });
     };
 


### PR DESCRIPTION
Stage 0 of the App decomposition. Three deletions, no behaviour change.

| Field | Status |
|---|---|
| `isTyping` | Declared in initial state, read nowhere in the repo |
| `liveDraft` | Same. The other `liveDraft` names in the tree are a local in `lib/liveDraft.js` and its tests — unrelated to App's state |
| `searchText` | Written by `updateRankings`, but never declared in initial state and never read. `RanksPanel` owns its own |

## On verification

**Sabotage doesn't apply to a pure deletion** — there's no behaviour to break, so "delete the thing the test protects" has no meaning here. What this needs instead is a reachability proof, so that's what I did:

- Grepped the whole tree (including tests and fixtures) for each name. App's `isTyping` and `liveDraft` appear only on their own declaration lines.
- Ruled out the two ways a grep could be wrong: there is **no computed state access** (`state[...]`) anywhere in `App`, the panels or the components, and `App` never spreads whole state into props or enumerates its keys. State is only ever destructured by name, so a name that doesn't appear textually cannot be read.

Gates: `npm run lint` (1 pre-existing warning, 0 errors), `format:check`, `typecheck`, `test:run` (105 pass), `build` — all green. Bundle 340.53 → 340.50 kB.

I have not browser-checked this one, since a field that is never read cannot change what renders. The later stages that move real logic will get one.

## Next

Stage 1 replaces the stringly-typed `loadingMessage`: three components compare it against magic strings, and `RanksPanel` sends `'Loading search panel...'` up through `startLoad` then compares against that same string coming back down as a prop — the same shape #104 removed.