### PR TITLE
Replace the loadingMessage string with an explicit loading state

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,12 +15,27 @@ import APP_DB_URLS, { SLEEPER_API_URLS, SLEEPER_USER_ID } from './urls.js';
 const { LATEST_UPDATE_ATTEMPT, ACTIVE_PLAYERS } = APP_DB_URLS;
 const { LEAGUE, USER_LEAGUES, NFL_STATE, DRAFT, ROSTERS, SLEEPER_USERS, TRADED_PICKS, DRAFTS } = SLEEPER_API_URLS;
 
+// What, if anything, is currently loading. These states are mutually exclusive
+// - at most one thing loads at a time - which is why this is one field rather
+// than a set of independent booleans that could contradict each other.
+//
+// This replaces a string that three components compared against magic
+// literals, with RanksPanel passing 'Loading search panel...' *up* through
+// startLoad and then comparing against that same literal coming back down as a
+// prop. The panels now receive a plain boolean and no longer share a
+// vocabulary with App at all, so these names stay private to this file.
+const LOADING = {
+    NONE: 'none',
+    INITIAL: 'initial',
+    LEAGUE_PANEL: 'leaguePanel',
+    RANKS_PANEL: 'ranksPanel',
+};
+
 class App extends React.Component {
     state = {
         playerInfo: {},
         leagueData: [],
-        isLoading: true,
-        loadingMessage: 'Initial load...',
+        loading: LOADING.INITIAL,
         rankingPlayersIdsList: [],
         leagueID: '1312088290526003200',
         rosterPositions: [],
@@ -161,8 +176,7 @@ class App extends React.Component {
                 this.setState(
                     {
                         leagueData: leagueData,
-                        isLoading: false,
-                        loadingMessage: 'Loading league panel...',
+                        loading: LOADING.LEAGUE_PANEL,
                         myDisplayName: resolveMyDisplayName(leagueData.managerData, SLEEPER_USER_ID),
                         rosterPositions: leagueData.currentLeague.roster_positions
                             .filter((pos) => pos !== 'BN')
@@ -227,7 +241,7 @@ class App extends React.Component {
             this.buildDraft(tradedDraftPicks);
         } else {
             this.setState({
-                loadingMessage: '',
+                loading: LOADING.NONE,
             });
         }
     };
@@ -252,7 +266,7 @@ class App extends React.Component {
         this.setState(
             {
                 leagueID,
-                loadingMessage: 'Loading league panel...',
+                loading: LOADING.LEAGUE_PANEL,
             },
             this.getLeagueData,
         );
@@ -262,10 +276,13 @@ class App extends React.Component {
         this.setState({ rankingPlayersIdsList });
     };
 
-    startLoad = (loadMessage, searchText) => {
+    // The caller no longer names the loading state it wants: there was only
+    // ever one caller and it always asked for the ranks panel, so the message
+    // it passed just travelled back down to it as a prop.
+    startLoad = (searchText) => {
         this.setState(
             {
-                loadingMessage: loadMessage,
+                loading: LOADING.RANKS_PANEL,
             },
             () => setTimeout(() => this.updateRankings(searchText), 0),
         );
@@ -277,8 +294,7 @@ class App extends React.Component {
 
         this.setState({
             rankingPlayersIdsList: searchResultsArray,
-            isLoading: false,
-            loadingMessage: '',
+            loading: LOADING.NONE,
             notFoundPlayers: notFoundPlayers,
         });
     };
@@ -330,7 +346,7 @@ class App extends React.Component {
         };
         this.setState({
             leagueData: newLeagueData,
-            loadingMessage: '',
+            loading: LOADING.NONE,
         });
     };
 
@@ -373,9 +389,8 @@ class App extends React.Component {
     render() {
         const {
             playerInfo,
-            isLoading,
             lastUpdate,
-            loadingMessage,
+            loading,
             rankingPlayersIdsList,
             rosterPositions,
             leagueData,
@@ -385,7 +400,7 @@ class App extends React.Component {
             signedInEmail,
             myDisplayName,
         } = this.state;
-        if (isLoading && loadingMessage === 'Initial load...') {
+        if (loading === LOADING.INITIAL) {
             return <div className="loader"></div>;
         } else {
             const rosterInfo = this.selectRosterInfo({
@@ -420,7 +435,7 @@ class App extends React.Component {
                     </p>
                     <div className="main-container">
                         <RanksPanel
-                            loadingMessage={loadingMessage}
+                            isLoading={loading === LOADING.RANKS_PANEL}
                             signedIn={signedIn}
                             playerInfo={playerInfo}
                             rosterInfo={rosterInfo}
@@ -443,7 +458,7 @@ class App extends React.Component {
                             rosterPositions={rosterPositions}
                             playerInfo={playerInfo}
                             rosterInfo={rosterInfo}
-                            loadingMessage={loadingMessage}
+                            isLoading={loading === LOADING.LEAGUE_PANEL}
                             removeFromLineup={this.removeFromLineup}
                             updateDraftBoard={this.updateDraftBoard}
                         />

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -43,6 +43,7 @@ const { rosterDataRaw, managerData, playerInfo, livePicksPartial } = rosterFlags
 const { currentDraft: draftSettings, tradedDraftPicks } = realDraftFixture;
 
 const LEAGUE_ID = '1312088290526003200';
+const OTHER_LEAGUE_ID = '9999999999999999999';
 const DRAFT_ID = 'draft123';
 
 const jsonResponse = (data) => Promise.resolve({ ok: true, statusText: 'OK', json: () => Promise.resolve(data) });
@@ -63,22 +64,27 @@ function mockFetch(url) {
     if (url.includes('state/nfl')) {
         return jsonResponse({ league_season: '2026' });
     }
-    if (url.includes(`league/${LEAGUE_ID}/rosters/`)) {
+    // Both leagues are served the same fixture data; only the id differs. The
+    // second one exists so the league dropdown has somewhere to switch to.
+    if (/league\/\d+\/rosters\//.test(url)) {
         return jsonResponse(structuredClone(rosterDataRaw));
     }
-    if (url.includes(`league/${LEAGUE_ID}/users/`)) {
+    if (/league\/\d+\/users\//.test(url)) {
         return jsonResponse(structuredClone(managerData));
     }
-    if (url.includes(`league/${LEAGUE_ID}/drafts/`)) {
+    if (/league\/\d+\/drafts\//.test(url)) {
         return jsonResponse([{ draft_id: DRAFT_ID }]);
     }
     if (url.includes('leagues/nfl/')) {
-        return jsonResponse([{ league_id: LEAGUE_ID, name: 'Test League' }]);
+        return jsonResponse([
+            { league_id: LEAGUE_ID, name: 'Test League' },
+            { league_id: OTHER_LEAGUE_ID, name: 'Other League' },
+        ]);
     }
-    if (url.includes(`league/${LEAGUE_ID}/`)) {
+    if (/league\/\d+\/$/.test(url)) {
         return jsonResponse({
-            league_id: LEAGUE_ID,
-            name: 'Test League',
+            league_id: url.includes(OTHER_LEAGUE_ID) ? OTHER_LEAGUE_ID : LEAGUE_ID,
+            name: url.includes(OTHER_LEAGUE_ID) ? 'Other League' : 'Test League',
             roster_positions: ['QB', 'RB', 'RB', 'WR', 'WR', 'TE', 'FLEX', 'BN', 'BN'],
         });
     }
@@ -249,6 +255,73 @@ describe('App', () => {
         } finally {
             process.off('unhandledRejection', recordRejection);
         }
+    });
+
+    it('shows a full-page loader, and neither panel, until the league data arrives', async () => {
+        // The initial-load branch used to be guarded by `isLoading &&
+        // loadingMessage === 'Initial load...'` and is now a single enum
+        // check. Nothing rendered App before its data settled, so which of
+        // those two conditions was doing the work was never observable.
+        let releaseLeague;
+        const leagueGate = new Promise((resolve) => {
+            releaseLeague = resolve;
+        });
+        global.fetch = vi.fn((url) => {
+            if (url.includes(`league/${LEAGUE_ID}/rosters/`)) {
+                return leagueGate.then(() => mockFetch(url));
+            }
+            return mockFetch(url);
+        });
+
+        const { container } = render(<App />);
+
+        // The whole-page loader is a bare div, distinct from the per-panel
+        // `.panel-loader` the two panels render.
+        await waitFor(() => expect(container.querySelector('.loader')).toBeTruthy());
+        expect(screen.queryByText('Sleeper Team Assistant')).toBeNull();
+
+        releaseLeague();
+
+        await screen.findAllByText('ryangh', {}, { timeout: 5000 });
+        expect(container.querySelector('.loader')).toBeNull();
+    });
+
+    it('shows the league panel loader while a league switch is in flight', async () => {
+        // The only path where the league-panel loading state earns its keep.
+        // On the initial load it is redundant - the full-page loader already
+        // suppresses both panels until the board is built, so never entering
+        // it changes nothing observable. On a switch, App is already past that
+        // branch, and without this state LeaguePanel would render against
+        // half-replaced league data.
+        let releaseSecondLeague;
+        const gate = new Promise((resolve) => {
+            releaseSecondLeague = resolve;
+        });
+        let gated = false;
+        global.fetch = vi.fn((url) => {
+            if (url.includes(`league/${OTHER_LEAGUE_ID}/rosters/`) && !gated) {
+                gated = true;
+                return gate.then(() => mockFetch(url));
+            }
+            return mockFetch(url);
+        });
+
+        const user = userEvent.setup();
+        const { container } = render(<App />);
+        await screen.findAllByText('ryangh', {}, { timeout: 5000 });
+        expect(container.querySelector('.league-panel .panel-loader')).toBeNull();
+
+        await user.selectOptions(screen.getByDisplayValue('Test League'), OTHER_LEAGUE_ID);
+
+        await waitFor(() => expect(container.querySelector('.league-panel .panel-loader')).toBeTruthy());
+        // The full-page loader is a different thing and must not come back:
+        // a league switch replaces one panel, it does not restart the app.
+        expect(container.querySelector(':scope > .loader')).toBeNull();
+
+        releaseSecondLeague();
+
+        await waitFor(() => expect(container.querySelector('.league-panel .panel-loader')).toBeNull());
+        expect(screen.getAllByText('ryangh').length).toBeGreaterThan(0);
     });
 
     it('unsubscribes from auth state changes on unmount', async () => {

--- a/src/Panels/LeaguePanel.jsx
+++ b/src/Panels/LeaguePanel.jsx
@@ -9,7 +9,7 @@ const LeaguePanel = ({
     updateLeagueID,
     rosterPositions,
     leagueID,
-    loadingMessage,
+    isLoading,
     removeFromLineup,
     rankingPlayersIdsList,
     updateDraftBoard,
@@ -18,7 +18,7 @@ const LeaguePanel = ({
 
     return (
         <div className="panel league-panel">
-            {loadingMessage === 'Loading league panel...' ? (
+            {isLoading ? (
                 <div className="panel-loader"></div>
             ) : (
                 <>

--- a/src/Panels/LeaguePanel.test.jsx
+++ b/src/Panels/LeaguePanel.test.jsx
@@ -55,7 +55,7 @@ function renderPanel(overrides = {}) {
         updateLeagueID,
         rosterPositions: ROSTER_POSITIONS,
         leagueID: LEAGUE_ID,
-        loadingMessage: '',
+        isLoading: false,
         removeFromLineup,
         rankingPlayersIdsList: [],
         updateDraftBoard: vi.fn(),
@@ -76,7 +76,7 @@ describe('LeaguePanel', () => {
     });
 
     it('shows only the loader while the league panel is loading', () => {
-        const { container } = renderPanel({ loadingMessage: 'Loading league panel...' });
+        const { container } = renderPanel({ isLoading: true });
 
         expect(container.querySelector('.panel-loader')).toBeTruthy();
         expect(screen.queryByText('Test League')).toBeNull();

--- a/src/Panels/RanksPanel.jsx
+++ b/src/Panels/RanksPanel.jsx
@@ -10,7 +10,7 @@ import { isTaken, rosteredBy } from '../lib/rosterInfo.js';
 const { APP_USERS, TYPE_PARAMS, DLF_ADP } = APP_DB_URLS;
 
 const RanksPanel = ({
-    loadingMessage,
+    isLoading,
     signedIn,
     playerInfo,
     rosterInfo,
@@ -56,7 +56,7 @@ const RanksPanel = ({
         updateRankingPlayersIdsList([]);
         setCurrentListVal(defaultSelector);
         setIsNewRankList(true);
-        startLoad('Loading search panel...', searchText);
+        startLoad(searchText);
         setSearchText('');
     };
 
@@ -243,7 +243,7 @@ const RanksPanel = ({
 
     return (
         <div className="panel search-panel">
-            {loadingMessage === 'Loading search panel...' ? (
+            {isLoading ? (
                 <div className="panel-loader"></div>
             ) : (
                 <>

--- a/src/Panels/RanksPanel.test.jsx
+++ b/src/Panels/RanksPanel.test.jsx
@@ -43,12 +43,12 @@ const rankEntry = (playerId, ranking) => ({
 
 const rankingPlayersIdsList = [rankEntry(FREE_AGENT.id, 1), rankEntry(OTHERS_PLAYER.id, 2), rankEntry(MY_PLAYER.id, 3)];
 
-function renderPanel() {
+function renderPanel(overrides = {}) {
     // signedIn stays false so the saved-rank-lists effect takes its else
     // branch and no global fetch is needed; ADP resolves empty so the panel
     // renders without an ADP column. Neither touches the filter path.
     const props = {
-        loadingMessage: '',
+        isLoading: false,
         signedIn: false,
         playerInfo,
         rosterInfo,
@@ -62,9 +62,10 @@ function renderPanel() {
         updatePlayerId: vi.fn(),
         notFoundPlayers: [],
         myDisplayName: MY_DISPLAY_NAME,
+        ...overrides,
     };
-    render(<RanksPanel {...props} />);
-    return props;
+    const { container } = render(<RanksPanel {...props} />);
+    return { ...props, container };
 }
 
 // The filter controls are <label> elements wrapping a checkbox, so the
@@ -73,6 +74,29 @@ const toggle = (user, name) => user.click(screen.getByRole('checkbox', { name })
 
 const visiblePlayers = () =>
     [FREE_AGENT, OTHERS_PLAYER, MY_PLAYER].filter((p) => screen.queryByText(p.name) !== null).map((p) => p.name);
+
+describe('RanksPanel loading', () => {
+    it('shows only the loader while the ranks panel is loading', () => {
+        const { container } = renderPanel({ isLoading: true });
+
+        expect(container.querySelector('.panel-loader')).toBeTruthy();
+        expect(screen.queryByText(FREE_AGENT.name)).toBeNull();
+    });
+
+    it('asks for a search by text alone, without naming a loading state', async () => {
+        // startLoad used to take the loading message as its first argument, and
+        // RanksPanel passed the literal 'Loading search panel...' - which came
+        // straight back down as the prop it then compared against. The panel no
+        // longer knows that vocabulary exists.
+        const user = userEvent.setup();
+        const { startLoad } = renderPanel();
+
+        await user.type(screen.getByPlaceholderText('Copy + Paste rankings here...'), 'Ja  rr Chase');
+        await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+        expect(startLoad).toHaveBeenCalledWith('Ja  rr Chase');
+    });
+});
 
 describe('RanksPanel player filters', () => {
     let user;


### PR DESCRIPTION
Stage 1 of the App decomposition. Tests **105 → 109**.

Three components compared `loadingMessage` against magic string literals, and `RanksPanel` passed `'Loading search panel...'` **up** through `startLoad` only to compare against that same literal coming back down as a prop. Same shape as the `updateParentState` string dispatch removed in #104.

App now holds a single `loading` enum — the states are mutually exclusive, so one field can't contradict itself the way independent booleans could — and each panel receives a plain `isLoading` boolean. The state names stay private to `App.jsx`; the panels no longer share a vocabulary with it.

Two things went away as a consequence:

- **`isLoading` as a separate field.** Read in exactly one place, in conjunction with `loadingMessage === 'Initial load...'` — and that literal was never re-set after the initial state, so the two always moved together and the conjunction was equivalent to the enum check alone.
- **`startLoad`'s message argument.** One caller, always asking for the ranks panel.

## A gap the sabotage run found

Making App **never enter** `LOADING.LEAGUE_PANEL` left all 108 tests green. That state turns out to be redundant on the initial load — `LOADING.INITIAL` already suppresses both panels until `buildDraft` sets `NONE`, so skipping it changes nothing observable. It only earns its keep on the **league-switch** path, where App is already past that branch and `LeaguePanel` would otherwise render against half-replaced league data.

Nothing tested that path, so I added it (plus one for the initial full-page loader). Re-running the same sabotage now fails 8 tests, and the narrower variant — only the league-switch call site stops setting it — fails exactly the one new test.

## Sabotage verification

| Sabotage | Result |
|---|---|
| `LeaguePanel` ignores `isLoading` | 8 failed |
| `RanksPanel` ignores `isLoading` | 1 failed |
| `RanksPanel` names the loading state again | 1 failed |
| App's initial-load branch never fires | 7 failed |
| App never enters `LOADING.LEAGUE_PANEL` | **passed at first** → 8 failed after the new tests |
| Only the league-switch site stops setting it | 1 failed (the new test) |
| The two panels' loading flags swapped | 7 failed |

## Browser verification

Ran against the live Sleeper API with a `MutationObserver` watching for each loader, since both are transient:

- **League switch** (TBD → 4 QB Madness): league-panel loader appeared, full-page loader did **not** — a switch replaces a panel, it doesn't restart the app. Board swapped 48 → 32 picks (12-team → 8-team).
- **Rank list submit**: search-panel loader appeared, full-page loader did not. The submitted list rendered with correct roster attribution.
- Zero console errors throughout.

## Gates

`npm run lint` (1 pre-existing warning, 0 errors), `format:check`, `typecheck`, `test:run` (109 pass), `build` — all green. Bundle 340.50 → 340.40 kB.

## Next

Stage 2 extracts `checkErrors`/`fetchRequest` into `lib/http.js`. That drops two props from `RanksPanel` and removes the deliberate `exhaustive-deps` warning **at its cause** — the function is unstable precisely because it's a class method passed as a prop; a module import is stable by construction.