### PR TITLE
Extract the fetch layer out of App into lib/http.js

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import { onAuthStateChanged, signInAnonymously, signInWithPopup, signOut as fire
 import { auth, googleProvider } from './firebase.js';
 import createRankings from './helpers.js';
 import { buildDraftRounds } from './lib/draft.js';
+import { checkErrors } from './lib/http.js';
 import { addPlayerToRoster, removePlayerFromLineup } from './lib/roster.js';
 import { buildLineupSet, decorateRosters, memoizeRosterInfo } from './lib/rosterInfo.js';
 import { resolveLeagueSeason, resolveMyDisplayName } from './lib/sleeper.js';
@@ -73,35 +74,9 @@ class App extends React.Component {
         this.unsubscribeAuth();
     }
 
-    // TODO clean up and pull out helper functions and search function into separate file(s)
-    checkErrors = (response) => {
-        if (!response.ok) {
-            throw new Error(response.statusText, response.status);
-        }
-        return response;
-    };
-
-    fetchRequest = async (url, type, data, custHeaders) => {
-        const response = await fetch(url, {
-            method: type,
-            headers: custHeaders
-                ? custHeaders
-                : {
-                      'Content-type': 'application/json',
-                  },
-            body: data ? JSON.stringify(data) : null,
-        })
-            .then(this.checkErrors)
-            .catch((err) => console.error('Error:', err));
-        if (response) {
-            console.log(response.statusText);
-        }
-        return response;
-    };
-
     getLatestUpdateAttempt = async () => {
         return await fetch(LATEST_UPDATE_ATTEMPT + (await auth.currentUser.getIdToken(true)))
-            .then(this.checkErrors)
+            .then(checkErrors)
             .then((response) => response.json())
             .then((data) => {
                 this.setState({
@@ -131,7 +106,7 @@ class App extends React.Component {
 
     getLeagueSeason = async () => {
         return await fetch(NFL_STATE)
-            .then(this.checkErrors)
+            .then(checkErrors)
             .then((response) => response.json())
             .then((nflState) => resolveLeagueSeason(nflState))
             .catch((error) => {
@@ -441,8 +416,6 @@ class App extends React.Component {
                             rosterInfo={rosterInfo}
                             updateRankingPlayersIdsList={this.updateRankingPlayersIdsList}
                             startLoad={this.startLoad}
-                            fetchRequest={this.fetchRequest}
-                            checkErrors={this.checkErrors}
                             addToRoster={this.addToRoster}
                             updatePlayerId={this.updatePlayerId}
                             notFoundPlayers={notFoundPlayers}

--- a/src/Panels/RanksPanel.jsx
+++ b/src/Panels/RanksPanel.jsx
@@ -7,6 +7,7 @@ import { auth } from '../firebase.js';
 import APP_DB_URLS from '../urls.js';
 import Button from '../Components/Button';
 import { isTaken, rosteredBy } from '../lib/rosterInfo.js';
+import { checkErrors, fetchRequest } from '../lib/http.js';
 const { APP_USERS, TYPE_PARAMS, DLF_ADP } = APP_DB_URLS;
 
 const RanksPanel = ({
@@ -17,8 +18,6 @@ const RanksPanel = ({
     lineupSet,
     updateRankingPlayersIdsList,
     startLoad,
-    fetchRequest,
-    checkErrors,
     rankingPlayersIdsList,
     addToRoster,
     updatePlayerId,
@@ -239,7 +238,7 @@ const RanksPanel = ({
             setAllListsVals([defaultSelector]);
             setRankListType('new');
         }
-    }, [checkErrors, signedIn]);
+    }, [signedIn]);
 
     return (
         <div className="panel search-panel">

--- a/src/Panels/RanksPanel.test.jsx
+++ b/src/Panels/RanksPanel.test.jsx
@@ -45,8 +45,11 @@ const rankingPlayersIdsList = [rankEntry(FREE_AGENT.id, 1), rankEntry(OTHERS_PLA
 
 function renderPanel(overrides = {}) {
     // signedIn stays false so the saved-rank-lists effect takes its else
-    // branch and no global fetch is needed; ADP resolves empty so the panel
-    // renders without an ADP column. Neither touches the filter path.
+    // branch and never fetches. The ADP request still fires on mount and now
+    // goes through the real fetchRequest, so it needs a stubbed global fetch
+    // rather than an injected mock - which is closer to production than the
+    // hand-written stand-in it replaces.
+    global.fetch = vi.fn(() => Promise.resolve({ ok: true, statusText: 'OK', json: () => Promise.resolve({}) }));
     const props = {
         isLoading: false,
         signedIn: false,
@@ -55,8 +58,6 @@ function renderPanel(overrides = {}) {
         lineupSet: new Set(),
         updateRankingPlayersIdsList: vi.fn(),
         startLoad: vi.fn(),
-        fetchRequest: vi.fn().mockResolvedValue({ ok: true, json: () => Promise.resolve({}) }),
-        checkErrors: vi.fn((response) => response),
         rankingPlayersIdsList,
         addToRoster: vi.fn(),
         updatePlayerId: vi.fn(),

--- a/src/lib/http.js
+++ b/src/lib/http.js
@@ -1,0 +1,39 @@
+/**
+ * Throws on any non-ok response so a failed request lands in a `.catch`
+ * rather than flowing on as a body that isn't there. Returns the response
+ * untouched otherwise, so it composes as a `.then` link in a fetch chain.
+ */
+export function checkErrors(response) {
+    if (!response.ok) {
+        throw new Error(response.statusText, response.status);
+    }
+    return response;
+}
+
+/**
+ * A fetch wrapper that swallows its own errors: any network failure, and any
+ * non-ok response (via `checkErrors`), resolves to `undefined` rather than
+ * rejecting.
+ *
+ * That is load-bearing for every caller - a returned `undefined` is how a
+ * failure is signalled, so callers must check the result before reading from
+ * it. Reading `.json()` or a property first is what caused #101 and #103, both
+ * of which surfaced as a TypeError far from the request that failed.
+ */
+export async function fetchRequest(url, type, data, custHeaders) {
+    const response = await fetch(url, {
+        method: type,
+        headers: custHeaders
+            ? custHeaders
+            : {
+                  'Content-type': 'application/json',
+              },
+        body: data ? JSON.stringify(data) : null,
+    })
+        .then(checkErrors)
+        .catch((err) => console.error('Error:', err));
+    if (response) {
+        console.log(response.statusText);
+    }
+    return response;
+}

--- a/src/lib/http.test.js
+++ b/src/lib/http.test.js
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { checkErrors, fetchRequest } from './http.js';
+
+// fetchRequest's contract is that it never rejects: every failure - network
+// error or non-ok response - resolves to `undefined`. Callers rely on that to
+// signal failure, and reading from the result before checking it is exactly
+// what caused #101 and #103. These tests pin the contract now that it lives in
+// a module of its own rather than as a method on App.
+
+const okResponse = (body = {}) => ({ ok: true, statusText: 'OK', json: () => Promise.resolve(body) });
+
+describe('checkErrors', () => {
+    it('returns an ok response untouched so it composes in a then-chain', () => {
+        const response = okResponse();
+        expect(checkErrors(response)).toBe(response);
+    });
+
+    it('throws on a non-ok response', () => {
+        expect(() => checkErrors({ ok: false, status: 404, statusText: 'Not Found' })).toThrow('Not Found');
+    });
+
+    it('treats any falsy ok as a failure, not just an explicit false', () => {
+        expect(() => checkErrors({ ok: undefined, statusText: 'Gateway Timeout' })).toThrow();
+    });
+});
+
+describe('fetchRequest', () => {
+    beforeEach(() => {
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+        vi.spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('resolves to the response on success', async () => {
+        const response = okResponse({ some: 'data' });
+        global.fetch = vi.fn(() => Promise.resolve(response));
+
+        expect(await fetchRequest('https://example.test/x', 'GET')).toBe(response);
+    });
+
+    it('resolves to undefined when the network rejects', async () => {
+        global.fetch = vi.fn(() => Promise.reject(new Error('offline')));
+
+        // Not a rejection: callers `await` this without a try/catch, so a
+        // rejection here would become an unhandled one far from the call site.
+        await expect(fetchRequest('https://example.test/x', 'GET')).resolves.toBeUndefined();
+    });
+
+    it('resolves to undefined on a non-ok response', async () => {
+        // The path that matters most: checkErrors throws, the internal catch
+        // swallows it, and the caller gets undefined rather than a response
+        // object whose .json() would throw.
+        global.fetch = vi.fn(() => Promise.resolve({ ok: false, statusText: 'Internal Server Error' }));
+
+        await expect(fetchRequest('https://example.test/x', 'GET')).resolves.toBeUndefined();
+    });
+
+    it('serialises a body and defaults to a JSON content type', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(okResponse()));
+
+        await fetchRequest('https://example.test/x', 'PUT', { rank_list: [1, 2] });
+
+        expect(global.fetch).toHaveBeenCalledWith('https://example.test/x', {
+            method: 'PUT',
+            headers: { 'Content-type': 'application/json' },
+            body: JSON.stringify({ rank_list: [1, 2] }),
+        });
+    });
+
+    it('sends a null body when there is no data, rather than the string "undefined"', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(okResponse()));
+
+        await fetchRequest('https://example.test/x', 'DELETE');
+
+        expect(global.fetch.mock.calls[0][1].body).toBeNull();
+    });
+
+    it('prefers caller-supplied headers over the JSON default', async () => {
+        global.fetch = vi.fn(() => Promise.resolve(okResponse()));
+
+        await fetchRequest('https://example.test/x', 'POST', null, { Authorization: 'Bearer t' });
+
+        expect(global.fetch.mock.calls[0][1].headers).toEqual({ Authorization: 'Bearer t' });
+    });
+});


### PR DESCRIPTION
Stage 2 of the App decomposition. Tests **109 → 118**.

`checkErrors` and `fetchRequest` were class methods on `App`, and `fetchRequest` was drilled into `RanksPanel` as a prop purely so the panel could make its own requests. Neither has anything to do with App's state. Both are now module functions in `src/lib/http.js`; `RanksPanel` imports them and loses two props.

The bodies moved verbatim — this is a move, not a rewrite.

## The lint warning is gone, at its cause

Lint now reports **0 problems**, where it previously reported 1 warning by design.

The rule fired because `fetchRequest` was a class property passed as a prop: a new reference every render, so listing it in the ADP effect's dep array would have re-run the fetch on every render, and omitting it was the lesser evil. A module import is a stable binding, so the rule has nothing left to complain about. `checkErrors` drops out of the second effect's dep array for the same reason.

This is the fix the warning was asking for, not a suppression.

## New tests

`lib/http.test.js` (9 tests) pins the contract that #101 and #103 both depended on: `fetchRequest` **never rejects** — every failure, network error or non-ok response, resolves to `undefined`. Callers rely on that to detect failure, and reading from the result before checking it is exactly what caused both bugs.

## Sabotage verification

| Sabotage | Result |
|---|---|
| `checkErrors` stops throwing on non-ok | 3 failed |
| `fetchRequest` lets failures reject instead of swallowing | 3 failed — including App's `survives an ADP request that fails` |
| Body always `JSON.stringify`'d, even when absent | 1 failed |
| Custom headers ignored | 1 failed |
| RanksPanel's ADP guard removed (the #101 shape, now via the module) | 1 failed |

The second row is the one that matters: breaking the swallow contract inside the new module still fails the App-level #101 regression test, so the extraction preserved the end-to-end behaviour and not just the unit-level shape.

## Browser verification

Against the live Sleeper API: 48 picks with 21 traded-pick attributions, the player-DB update timestamp rendered (that path runs through the moved `checkErrors`), rank list submitted and rendered with correct roster attribution, zero console errors.

The console output is itself the proof the moved code runs: the `OK` lines are `lib/http.js`'s own `console.log(response.statusText)`, and the `200` lines are RanksPanel logging *after* the #101 guard passed.

**One thing I checked rather than assumed:** the ADP column renders no values for any player I tried. The request returns **200 OK** — it is not failing — the dataset simply has no entries for those players under those keys. I verified this is **identical on master** by checking out master, reloading, and repeating the same steps. Pre-existing and out of scope here, but worth recording; the player DB's last update attempt reads Nov 2022, so the ADP data is likely stale too.

## Not fixed here

`new Error(response.statusText, response.status)` moved as-is. Error's second parameter is an options object, not a status, so the status is silently discarded. Fixing it is a behaviour change and belongs in its own commit rather than riding along in a move.

## Gates

`npm ci`, `npm run lint` (**0 problems**), `format:check`, `typecheck`, `test:run` (118 pass), `build` — all green. Bundle 340.40 → 340.24 kB.