### PR TITLE
Make the load chain return values instead of round-tripping through state

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,13 +8,18 @@ import { onAuthStateChanged, signInAnonymously, signInWithPopup, signOut as fire
 import { auth, googleProvider } from './firebase.js';
 import createRankings from './helpers.js';
 import { buildDraftRounds } from './lib/draft.js';
-import { checkErrors } from './lib/http.js';
+import {
+    fetchDraft,
+    fetchLatestUpdateAttempt,
+    fetchLeagueBundle,
+    fetchLeagueSeason,
+    fetchPlayerData,
+    fetchTradedDraftPicks,
+} from './lib/sleeperApi.js';
 import { addPlayerToRoster, removePlayerFromLineup } from './lib/roster.js';
-import { buildLineupSet, decorateRosters, memoizeRosterInfo } from './lib/rosterInfo.js';
-import { resolveLeagueSeason, resolveMyDisplayName } from './lib/sleeper.js';
-import APP_DB_URLS, { SLEEPER_API_URLS, SLEEPER_USER_ID } from './urls.js';
-const { LATEST_UPDATE_ATTEMPT, ACTIVE_PLAYERS } = APP_DB_URLS;
-const { LEAGUE, USER_LEAGUES, NFL_STATE, DRAFT, ROSTERS, SLEEPER_USERS, TRADED_PICKS, DRAFTS } = SLEEPER_API_URLS;
+import { buildLineupSet, memoizeRosterInfo } from './lib/rosterInfo.js';
+import { resolveMyDisplayName } from './lib/sleeper.js';
+import { SLEEPER_USER_ID } from './urls.js';
 
 // What, if anything, is currently loading. These states are mutually exclusive
 // - at most one thing loads at a time - which is why this is one field rather
@@ -25,6 +30,21 @@ const { LEAGUE, USER_LEAGUES, NFL_STATE, DRAFT, ROSTERS, SLEEPER_USERS, TRADED_P
 // startLoad and then comparing against that same literal coming back down as a
 // prop. The panels now receive a plain boolean and no longer share a
 // vocabulary with App at all, so these names stay private to this file.
+// Sleeper's own labels, shortened for display, with bench slots dropped -
+// only startable positions appear in the weekly lineup.
+function toRosterPositions(rosterPositions) {
+    return rosterPositions
+        .filter((pos) => pos !== 'BN')
+        .map((pos) => {
+            if (pos === 'SUPER_FLEX') {
+                return 'SFLX';
+            } else if (pos === 'FLEX') {
+                return 'FLX';
+            }
+            return pos;
+        });
+}
+
 const LOADING = {
     NONE: 'none',
     INITIAL: 'initial',
@@ -60,9 +80,9 @@ class App extends React.Component {
                     signedInEmail: currentUser.email ? currentUser.email : null,
                 });
                 if (playerInfo && Object.keys(playerInfo).length === 0) {
-                    this.getPlayerData();
+                    this.loadEverything();
                 } else {
-                    this.getLeagueData();
+                    this.loadLeague(playerInfo);
                 }
             } else {
                 signInAnonymously(auth).catch((err) => console.error('Error:', err));
@@ -74,158 +94,90 @@ class App extends React.Component {
         this.unsubscribeAuth();
     }
 
-    getLatestUpdateAttempt = async () => {
-        return await fetch(LATEST_UPDATE_ATTEMPT + (await auth.currentUser.getIdToken(true)))
-            .then(checkErrors)
-            .then((response) => response.json())
-            .then((data) => {
-                this.setState({
-                    lastUpdate: data,
-                });
-                return data;
-            })
-            .catch((error) => {
-                console.error('Error:', error);
-            });
-    };
-
-    getPlayerData = async () => {
-        this.getLatestUpdateAttempt();
-        await fetch(ACTIVE_PLAYERS)
-            .then((response) => response.json())
-            .then((data) => {
-                this.setState({
-                    playerInfo: data,
-                });
-            })
-            .catch((error) => {
-                console.error('Error:', error);
-            });
-        this.getLeagueData();
-    };
-
-    getLeagueSeason = async () => {
-        return await fetch(NFL_STATE)
-            .then(checkErrors)
-            .then((response) => response.json())
-            .then((nflState) => resolveLeagueSeason(nflState))
-            .catch((error) => {
-                console.error('Error fetching NFL state, falling back to current calendar year:', error);
-                return String(new Date().getFullYear());
-            });
-    };
-
-    getLeagueData = async () => {
-        const leagueID = this.state.leagueID;
-        const LEAGUE_PATH = LEAGUE + leagueID + '/';
-        const season = this.state.season ? this.state.season : await this.getLeagueSeason();
-        if (!this.state.season) {
-            this.setState({ season });
-        }
-        const urls = [
-            LEAGUE_PATH + ROSTERS,
-            LEAGUE_PATH + SLEEPER_USERS,
-            LEAGUE_PATH,
-            USER_LEAGUES(season),
-            LEAGUE_PATH + DRAFTS,
-        ];
-        const requests = urls.map(async (url) => {
-            const response = await fetch(url);
-            return response.json();
+    // The whole load chain, from player database through to a built draft
+    // board. Each step passes its result to the next as an argument instead of
+    // writing it to state and reading it back: #96 and #98 were both a read of
+    // a value that had not settled, and neither is expressible in this shape.
+    loadEverything = async () => {
+        // Deliberately not awaited, matching the original: this is a display-only
+        // timestamp and the player database is the critical path, so serialising
+        // the two would add a whole round trip to every cold start. The guard
+        // keeps a failed request from replacing the null default with undefined,
+        // which renders as 'Invalid Date' rather than being ignored.
+        fetchLatestUpdateAttempt().then((lastUpdate) => {
+            if (lastUpdate !== undefined) {
+                this.setState({ lastUpdate });
+            }
         });
-        Promise.all(requests)
-            .then((data) => {
-                const leagueData = {};
-                [
-                    leagueData.rosterData,
-                    leagueData.managerData,
-                    leagueData.currentLeague,
-                    leagueData.leagueIds,
-                    leagueData.currentLeagueDrafts,
-                ] = data;
-                leagueData.rosterData = decorateRosters({
-                    rosterData: leagueData.rosterData,
-                    managerData: leagueData.managerData,
-                });
-                this.warnAboutMissingRosterPlayers(leagueData.rosterData);
-                this.setState(
-                    {
-                        leagueData: leagueData,
-                        loading: LOADING.LEAGUE_PANEL,
-                        myDisplayName: resolveMyDisplayName(leagueData.managerData, SLEEPER_USER_ID),
-                        rosterPositions: leagueData.currentLeague.roster_positions
-                            .filter((pos) => pos !== 'BN')
-                            .map((pos) => {
-                                if (pos === 'SUPER_FLEX') {
-                                    return 'SFLX';
-                                } else if (pos === 'FLEX') {
-                                    return 'FLX';
-                                } else {
-                                    return pos;
-                                }
-                            }),
-                    },
-                    this.getTradedDraftPicks,
-                );
-                if (this.state.rankingPlayersIdsList.length > 0) {
-                    this.setState({ rankingPlayersIdsList: [...this.state.rankingPlayersIdsList] });
-                }
-            })
-            .catch((error) => {
-                console.error('Error:', error);
-            });
+
+        const playerInfo = await fetchPlayerData();
+        if (playerInfo) {
+            this.setState({ playerInfo });
+        }
+        await this.loadLeague(playerInfo || this.state.playerInfo);
     };
 
-    getTradedDraftPicks = async () => {
-        const draftId = this.state.leagueData.currentLeagueDrafts[0].draft_id;
-        const DRAFT_PATH = DRAFT + draftId + '/';
-        const tradedPicks = await fetch(DRAFT_PATH + TRADED_PICKS)
-            .then((response) => response.json())
-            .then((data) => data)
-            .catch((error) => {
-                console.error('Error:', error);
-            });
-        // Handed straight down the chain rather than round-tripped through state:
-        // setState batches inside an async context, so buildDraft could read the
-        // previous value and render every pick under its original roster with no
-        // "via <manager>" attribution. Production only got away with it because
-        // getSpecificDraft awaits another fetch first, which happened to give React
-        // time to flush.
-        this.getSpecificDraft(tradedPicks);
-    };
+    // `playerInfo` is a parameter rather than a state read for the same
+    // reason: on the very first load the setState above has not necessarily
+    // flushed, and warnAboutMissingRosterPlayers would compare rosters against
+    // an empty database and warn about every player in the league.
+    loadLeague = async (playerInfo) => {
+        const season = this.state.season || (await fetchLeagueSeason());
+        const leagueData = await fetchLeagueBundle({ leagueID: this.state.leagueID, season });
+        if (!leagueData) {
+            this.setState({ season, loading: LOADING.NONE });
+            return;
+        }
 
-    getSpecificDraft = async (tradedDraftPicks) => {
-        const { leagueData } = this.state;
-        const draftId = leagueData.currentLeagueDrafts[0].draft_id;
-        const DRAFT_PATH = DRAFT + draftId;
-        const draftData = await fetch(DRAFT_PATH)
-            .then((response) => response.json())
-            .then((data) => data)
-            .catch((error) => {
-                console.error('Error:', error);
-            });
-        // The fetch's own catch resolves to undefined on failure, and
-        // DraftPanel reads currentDraft.draft_id unconditionally - so
-        // currentDraft has to stay a real object even when the fetch fails,
-        // or the next render crashes. Same shape as the ADP bug (#101).
-        leagueData.currentDraft = draftData || { draft_id: draftId };
+        this.warnAboutMissingRosterPlayers(leagueData.rosterData, playerInfo);
         this.setState({
+            season,
             leagueData,
+            loading: LOADING.LEAGUE_PANEL,
+            myDisplayName: resolveMyDisplayName(leagueData.managerData, SLEEPER_USER_ID),
+            rosterPositions: toRosterPositions(leagueData.currentLeague.roster_positions),
         });
-        if (draftData && draftData.draft_order) {
-            this.buildDraft(tradedDraftPicks);
-        } else {
-            this.setState({
-                loading: LOADING.NONE,
-            });
-        }
+
+        await this.loadDraft(leagueData);
+    };
+
+    loadDraft = async (leagueData) => {
+        const draftId = leagueData.currentLeagueDrafts[0].draft_id;
+        const tradedDraftPicks = await fetchTradedDraftPicks(draftId);
+        const draftData = await fetchDraft(draftId);
+
+        // fetchDraft resolves to undefined on failure and DraftPanel reads
+        // currentDraft.draft_id unconditionally, so currentDraft has to stay a
+        // real object even when the request fails or the next render crashes
+        // (#103).
+        const currentDraft = draftData || { draft_id: draftId };
+        const built =
+            draftData && draftData.draft_order
+                ? buildDraftRounds({ currentDraft, rosterData: leagueData.rosterData, tradedDraftPicks })
+                : null;
+
+        // Composed against prevState rather than the leagueData this call
+        // captured. Note this is defensive, not load-bearing today: the only
+        // things that could rewrite leagueData during the two awaits above are
+        // a second league switch or a manual pick, and both are impossible
+        // while this runs because LeaguePanel is showing its loader - the
+        // dropdown and DraftPanel are unmounted behind it. No test covers it
+        // for that reason. It stays because it costs nothing and that gating
+        // is incidental: a loader change elsewhere would otherwise reintroduce
+        // #96's shape here, one level up.
+        this.setState((prevState) => ({
+            leagueData: {
+                ...prevState.leagueData,
+                currentDraft: built ? { ...currentDraft, ...built } : currentDraft,
+            },
+            loading: LOADING.NONE,
+        }));
     };
 
     // Diagnostic carried over from the old markTakenPlayers: a roster player id
     // that isn't in the player DB is usually a retired player that was removed
     // from it. Purely informational - it doesn't affect what gets rendered.
-    warnAboutMissingRosterPlayers = (rosterData) => {
-        const { playerInfo } = this.state;
+    warnAboutMissingRosterPlayers = (rosterData, playerInfo) => {
         rosterData.forEach((roster) => {
             (roster.players || []).forEach((player) => {
                 if (!playerInfo[player]) {
@@ -243,7 +195,7 @@ class App extends React.Component {
                 leagueID,
                 loading: LOADING.LEAGUE_PANEL,
             },
-            this.getLeagueData,
+            () => this.loadLeague(this.state.playerInfo),
         );
     };
 
@@ -304,24 +256,6 @@ class App extends React.Component {
         this.setState({
             playerInfo: updated.playerInfo,
             rosterPositions: updated.rosterPositions,
-        });
-    };
-
-    buildDraft = (tradedDraftPicks) => {
-        const { leagueData } = this.state;
-        const { currentDraft, rosterData } = leagueData;
-        const { built_draft, player_pool } = buildDraftRounds({ currentDraft, rosterData, tradedDraftPicks });
-        const newLeagueData = {
-            ...leagueData,
-            currentDraft: {
-                ...currentDraft,
-                built_draft,
-                player_pool,
-            },
-        };
-        this.setState({
-            leagueData: newLeagueData,
-            loading: LOADING.NONE,
         });
     };
 

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -45,6 +45,12 @@ const { currentDraft: draftSettings, tradedDraftPicks } = realDraftFixture;
 const LEAGUE_ID = '1312088290526003200';
 const OTHER_LEAGUE_ID = '9999999999999999999';
 const DRAFT_ID = 'draft123';
+const OTHER_DRAFT_ID = 'draftOther';
+
+// On roster 1 (mine) in the first league, dropped from every roster in the
+// second - so switching leagues must change this player's attribution from
+// 'ryangh' to 'Free Agent'.
+const SWAPPED_PLAYER = { id: '13274', name: 'Germie Bernard' };
 
 const jsonResponse = (data) => Promise.resolve({ ok: true, statusText: 'OK', json: () => Promise.resolve(data) });
 
@@ -64,16 +70,27 @@ function mockFetch(url) {
     if (url.includes('state/nfl')) {
         return jsonResponse({ league_season: '2026' });
     }
-    // Both leagues are served the same fixture data; only the id differs. The
-    // second one exists so the league dropdown has somewhere to switch to.
+    // The second league exists so the dropdown has somewhere to switch to. Its
+    // rosters are the same fixture with SWAPPED_PLAYER dropped from every
+    // roster, so that player's attribution differs between the two leagues -
+    // which is what makes a switch observable in the ranks panel rather than
+    // only on the draft board.
     if (/league\/\d+\/rosters\//.test(url)) {
-        return jsonResponse(structuredClone(rosterDataRaw));
+        const rosters = structuredClone(rosterDataRaw);
+        if (url.includes(OTHER_LEAGUE_ID)) {
+            rosters.forEach((roster) => {
+                if (roster.players) {
+                    roster.players = roster.players.filter((id) => id !== SWAPPED_PLAYER.id);
+                }
+            });
+        }
+        return jsonResponse(rosters);
     }
     if (/league\/\d+\/users\//.test(url)) {
         return jsonResponse(structuredClone(managerData));
     }
     if (/league\/\d+\/drafts\//.test(url)) {
-        return jsonResponse([{ draft_id: DRAFT_ID }]);
+        return jsonResponse([{ draft_id: url.includes(OTHER_LEAGUE_ID) ? OTHER_DRAFT_ID : DRAFT_ID }]);
     }
     if (url.includes('leagues/nfl/')) {
         return jsonResponse([
@@ -88,13 +105,13 @@ function mockFetch(url) {
             roster_positions: ['QB', 'RB', 'RB', 'WR', 'WR', 'TE', 'FLEX', 'BN', 'BN'],
         });
     }
-    if (url.includes(`draft/${DRAFT_ID}/traded_picks/`)) {
+    if (/draft\/[\w]+\/traded_picks\//.test(url)) {
         return jsonResponse(structuredClone(tradedDraftPicks));
     }
-    if (url.includes(`draft/${DRAFT_ID}`)) {
+    if (/draft\/[\w]+$/.test(url)) {
         return jsonResponse({
             ...structuredClone(draftSettings),
-            draft_id: DRAFT_ID,
+            draft_id: url.includes(OTHER_DRAFT_ID) ? OTHER_DRAFT_ID : DRAFT_ID,
             season: '2026',
             status: 'drafting',
             draft_order: {},
@@ -322,6 +339,71 @@ describe('App', () => {
 
         await waitFor(() => expect(container.querySelector('.league-panel .panel-loader')).toBeNull());
         expect(screen.getAllByText('ryangh').length).toBeGreaterThan(0);
+    });
+
+    it('recomputes roster attribution in the ranks panel after a league switch', async () => {
+        // Characterization test, written before touching anything: getLeagueData
+        // ends with a spread of rankingPlayersIdsList into a new array whose
+        // only purpose is to force a re-render. It looks vestigial - the flags
+        // are derived from leagueData.rosterData now, which changes identity on
+        // a switch - but nothing covered this path, so the question could not
+        // be answered by reading. This test answers it either way.
+        global.fetch = vi.fn(mockFetch);
+
+        const user = userEvent.setup();
+        render(<App />);
+        await screen.findAllByText('ryangh', {}, { timeout: 5000 });
+
+        await user.type(screen.getByPlaceholderText('Copy + Paste rankings here...'), `1. ${SWAPPED_PLAYER.name}`);
+        await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+        const attribution = async () => {
+            const item = (await screen.findByText(SWAPPED_PLAYER.name)).closest('.single-player-item');
+            return item.querySelector('.team-name').textContent;
+        };
+
+        expect(await attribution()).toBe('ryangh');
+
+        await user.selectOptions(screen.getByDisplayValue('Test League'), OTHER_LEAGUE_ID);
+
+        // The second league has this player on nobody's roster, so the derived
+        // flags must follow the new league rather than keeping the stale name.
+        await waitFor(async () => expect(await attribution()).toBe('Free Agent'));
+    });
+
+    it('checks rosters against a player database that has actually loaded', async () => {
+        // warnAboutMissingRosterPlayers used to read this.state.playerInfo,
+        // written by the setState immediately before the call. With
+        // instantly-resolving fetches that setState has not flushed, so the
+        // check ran against an empty database and warned about every player in
+        // the league - another instance of the read-before-flush class (#96,
+        // #98). playerInfo is threaded through as an argument now.
+        const warnings = [];
+        vi.spyOn(console, 'warn').mockImplementation((message) => {
+            if (String(message).includes("Can't find player ID")) {
+                warnings.push(message);
+            }
+        });
+
+        try {
+            global.fetch = vi.fn(mockFetch);
+            render(<App />);
+            await screen.findAllByText('ryangh', {}, { timeout: 5000 });
+
+            // Derived from the fixture rather than hardcoded: it is trimmed, so
+            // some roster players are legitimately absent from the player DB.
+            const rosterPlayerIds = rosterDataRaw.flatMap((roster) => roster.players || []);
+            const known = new Set(Object.keys(playerInfo));
+            const legitimatelyMissing = rosterPlayerIds.filter((id) => !known.has(id));
+
+            // The assertion only means something if the fixture actually knows
+            // about some roster players - otherwise both the correct and the
+            // stale read would produce the same count.
+            expect(legitimatelyMissing.length).toBeLessThan(rosterPlayerIds.length);
+            expect(warnings).toHaveLength(legitimatelyMissing.length);
+        } finally {
+            vi.restoreAllMocks();
+        }
     });
 
     it('unsubscribes from auth state changes on unmount', async () => {

--- a/src/lib/sleeperApi.js
+++ b/src/lib/sleeperApi.js
@@ -1,0 +1,117 @@
+import { auth } from '../firebase.js';
+import { checkErrors } from './http.js';
+import { decorateRosters } from './rosterInfo.js';
+import { resolveLeagueSeason } from './sleeper.js';
+import APP_DB_URLS, { SLEEPER_API_URLS } from '../urls.js';
+const { LATEST_UPDATE_ATTEMPT, ACTIVE_PLAYERS } = APP_DB_URLS;
+const { LEAGUE, USER_LEAGUES, NFL_STATE, DRAFT, ROSTERS, SLEEPER_USERS, TRADED_PICKS, DRAFTS } = SLEEPER_API_URLS;
+
+// Every function here returns its data instead of writing it to state. That is
+// the point of the module, not a stylistic preference: the two bugs in #96 and
+// #98 were both "logic reads a value that has not settled yet", and both were
+// only possible because a fetch wrote to state and something downstream read
+// it straight back. A function that returns its result cannot be read early.
+//
+// Failures resolve to `undefined` rather than rejecting, matching fetchRequest
+// in http.js. Callers must check before reading - that is the contract, and
+// ignoring it is what caused #101 and #103.
+
+/**
+ * When the player database was last refreshed. Display-only.
+ */
+export async function fetchLatestUpdateAttempt() {
+    return await fetch(LATEST_UPDATE_ATTEMPT + (await auth.currentUser.getIdToken(true)))
+        .then(checkErrors)
+        .then((response) => response.json())
+        .catch((error) => {
+            console.error('Error:', error);
+        });
+}
+
+/**
+ * The whole player database, keyed by player id.
+ */
+export async function fetchPlayerData() {
+    return await fetch(ACTIVE_PLAYERS)
+        .then((response) => response.json())
+        .catch((error) => {
+            console.error('Error:', error);
+        });
+}
+
+/**
+ * The season to request league data for. Falls back to the current calendar
+ * year when the NFL state endpoint is unreachable, since every league URL
+ * needs some season and a wrong one still renders.
+ */
+export async function fetchLeagueSeason() {
+    return await fetch(NFL_STATE)
+        .then(checkErrors)
+        .then((response) => response.json())
+        .then((nflState) => resolveLeagueSeason(nflState))
+        .catch((error) => {
+            console.error('Error fetching NFL state, falling back to current calendar year:', error);
+            return String(new Date().getFullYear());
+        });
+}
+
+/**
+ * The five league requests that always travel together, resolved in parallel
+ * and returned as one object with rosters already decorated. Resolves to
+ * `undefined` if any of them fails - a partial league is not useful, and
+ * silently rendering one is how a wrong board reaches the screen.
+ */
+export async function fetchLeagueBundle({ leagueID, season }) {
+    const LEAGUE_PATH = LEAGUE + leagueID + '/';
+    const urls = [
+        LEAGUE_PATH + ROSTERS,
+        LEAGUE_PATH + SLEEPER_USERS,
+        LEAGUE_PATH,
+        USER_LEAGUES(season),
+        LEAGUE_PATH + DRAFTS,
+    ];
+
+    return await Promise.all(
+        urls.map(async (url) => {
+            const response = await fetch(url);
+            return response.json();
+        }),
+    )
+        .then(([rosterData, managerData, currentLeague, leagueIds, currentLeagueDrafts]) => ({
+            rosterData: decorateRosters({ rosterData, managerData }),
+            managerData,
+            currentLeague,
+            leagueIds,
+            currentLeagueDrafts,
+        }))
+        .catch((error) => {
+            console.error('Error:', error);
+        });
+}
+
+/**
+ * Picks that have changed hands. Returned rather than stored: threading this
+ * value into the draft build as an argument is the fix from #98, where
+ * round-tripping it through state meant the build read the previous value and
+ * rendered every pick under its original roster.
+ */
+export async function fetchTradedDraftPicks(draftId) {
+    return await fetch(DRAFT + draftId + '/' + TRADED_PICKS)
+        .then((response) => response.json())
+        .catch((error) => {
+            console.error('Error:', error);
+        });
+}
+
+/**
+ * The draft's own settings. Resolves to `undefined` on failure, which callers
+ * must substitute for - `DraftPanel` reads `currentDraft.draft_id`
+ * unconditionally, so a missing object crashes the next render (#103).
+ */
+export async function fetchDraft(draftId) {
+    return await fetch(DRAFT + draftId)
+        .then((response) => response.json())
+        .catch((error) => {
+            console.error('Error:', error);
+        });
+}

--- a/src/lib/sleeperApi.test.js
+++ b/src/lib/sleeperApi.test.js
@@ -1,0 +1,126 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import {
+    fetchDraft,
+    fetchLatestUpdateAttempt,
+    fetchLeagueBundle,
+    fetchLeagueSeason,
+    fetchPlayerData,
+    fetchTradedDraftPicks,
+} from './sleeperApi.js';
+import rosterFlagsFixture from './__fixtures__/roster-flags-2026.json';
+
+vi.mock('../firebase.js', () => ({
+    auth: { currentUser: { uid: 'test-uid', getIdToken: vi.fn().mockResolvedValue('test-id-token') } },
+    googleProvider: {},
+}));
+
+const { rosterDataRaw, managerData } = rosterFlagsFixture;
+
+const jsonResponse = (data) => Promise.resolve({ ok: true, statusText: 'OK', json: () => Promise.resolve(data) });
+
+describe('sleeperApi', () => {
+    beforeEach(() => {
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    describe('fetchLeagueBundle', () => {
+        const bundleFetch = (url) => {
+            if (url.includes('/rosters/')) return jsonResponse(structuredClone(rosterDataRaw));
+            if (url.includes('/users/')) return jsonResponse(structuredClone(managerData));
+            if (url.includes('/drafts/')) return jsonResponse([{ draft_id: 'draft123' }]);
+            if (url.includes('leagues/nfl/')) return jsonResponse([{ league_id: '1', name: 'Test League' }]);
+            return jsonResponse({ league_id: '1', name: 'Test League', roster_positions: ['QB', 'BN'] });
+        };
+
+        it('returns the five league responses as one object, with rosters decorated', async () => {
+            global.fetch = vi.fn(bundleFetch);
+
+            const bundle = await fetchLeagueBundle({ leagueID: '1', season: '2026' });
+
+            expect(Object.keys(bundle).sort()).toEqual(
+                ['currentLeague', 'currentLeagueDrafts', 'leagueIds', 'managerData', 'rosterData'].sort(),
+            );
+            // Decoration is what turns owner_id into a display name; skipping it
+            // is the exact regression App.test.jsx was originally written for.
+            expect(bundle.rosterData[0].manager_display_name).toBeTruthy();
+        });
+
+        it('requests all five in parallel rather than in sequence', async () => {
+            let inFlight = 0;
+            let peak = 0;
+            global.fetch = vi.fn((url) => {
+                inFlight += 1;
+                peak = Math.max(peak, inFlight);
+                return bundleFetch(url).then((r) => {
+                    inFlight -= 1;
+                    return r;
+                });
+            });
+
+            await fetchLeagueBundle({ leagueID: '1', season: '2026' });
+
+            expect(peak).toBe(5);
+        });
+
+        it('resolves to undefined if any one of the five fails', async () => {
+            // A partial league is not useful, and rendering one silently is how
+            // a wrong board reaches the screen.
+            global.fetch = vi.fn((url) =>
+                url.includes('/drafts/') ? Promise.reject(new Error('down')) : bundleFetch(url),
+            );
+
+            await expect(fetchLeagueBundle({ leagueID: '1', season: '2026' })).resolves.toBeUndefined();
+        });
+    });
+
+    describe('fetchLeagueSeason', () => {
+        it('resolves the season from NFL state', async () => {
+            global.fetch = vi.fn(() => jsonResponse({ league_season: '2026' }));
+            expect(await fetchLeagueSeason()).toBe('2026');
+        });
+
+        it('falls back to the current calendar year when NFL state is unreachable', async () => {
+            // Every league URL needs some season, and a wrong one still renders
+            // - so this failure degrades rather than blocking the whole load.
+            global.fetch = vi.fn(() => Promise.reject(new Error('offline')));
+            expect(await fetchLeagueSeason()).toBe(String(new Date().getFullYear()));
+        });
+
+        it('falls back when NFL state returns a non-ok response', async () => {
+            global.fetch = vi.fn(() => Promise.resolve({ ok: false, statusText: 'Bad Gateway' }));
+            expect(await fetchLeagueSeason()).toBe(String(new Date().getFullYear()));
+        });
+    });
+
+    describe('the requests that must resolve to undefined on failure', () => {
+        // Every caller checks for undefined before reading. #101 and #103 were
+        // both a property read on one of these before the check.
+        const cases = [
+            ['fetchDraft', () => fetchDraft('draft123')],
+            ['fetchTradedDraftPicks', () => fetchTradedDraftPicks('draft123')],
+            ['fetchPlayerData', () => fetchPlayerData()],
+            ['fetchLatestUpdateAttempt', () => fetchLatestUpdateAttempt()],
+        ];
+
+        for (const [name, call] of cases) {
+            it(`${name} resolves to undefined rather than rejecting`, async () => {
+                global.fetch = vi.fn(() => Promise.reject(new Error('offline')));
+                await expect(call()).resolves.toBeUndefined();
+            });
+        }
+    });
+
+    it('fetchDraft returns the draft settings on success', async () => {
+        global.fetch = vi.fn(() => jsonResponse({ draft_id: 'draft123', draft_order: {} }));
+        expect(await fetchDraft('draft123')).toEqual({ draft_id: 'draft123', draft_order: {} });
+    });
+
+    it('fetchTradedDraftPicks returns the picks on success', async () => {
+        global.fetch = vi.fn(() => jsonResponse([{ round: 1, roster_id: 2, owner_id: 3 }]));
+        expect(await fetchTradedDraftPicks('draft123')).toHaveLength(1);
+    });
+});


### PR DESCRIPTION
Stage 3 of the App decomposition — the one with actual value and actual risk. Tests **118 → 132**. `App.jsx` loses ~90 lines net.

App owned six interleaved fetch methods that chained through `setState` callbacks and read each other's results back out of state. That shape *is* #96 and #98: logic reading a value that hasn't settled.

Fetching now lives in `src/lib/sleeperApi.js`, where every function returns its data. App keeps a three-step chain — `loadEverything` → `loadLeague` → `loadDraft` — passing each result to the next as an argument. `getLatestUpdateAttempt`, `getPlayerData`, `getLeagueSeason`, `getLeagueData`, `getTradedDraftPicks`, `getSpecificDraft` and `buildDraft` are gone.

## A latent instance of the same bug, found and fixed

`warnAboutMissingRosterPlayers` read `this.state.playerInfo`, written by the `setState` immediately before the call. With instantly-resolving fetches that hasn't flushed — so it checked rosters against an **empty** database and warned about every player in the league. Same class as #96/#98, never noticed because the symptom is console noise rather than a broken screen.

`playerInfo` is threaded through as an argument now. The new test asserts the warning count equals what the fixture actually omits (291 of 351), which is what distinguishes a loaded database from an empty one.

## The force-re-render spread was vestigial — verified, not assumed

`getLeagueData` ended by spreading `rankingPlayersIdsList` into a new array purely to force a re-render. I wrote a characterization test **first**, covering the exact scenario it would exist for: a populated rank list, a league switch, and a player whose attribution differs between the two leagues. It passes with the spread deleted.

It predates #95 — when flags were written *into* `playerInfo`, a new array identity was how the panel learned to re-render. Now `rosterInfo` derives from `leagueData.rosterData`, which changes identity on a switch anyway.

## Also fixed

- `getSpecificDraft` mutated `leagueData` in place, then called `setState` with the **same object reference**. `loadDraft` composes a new object against `prevState`.
- The five league requests keep their parallelism — now asserted (peak in-flight = 5) rather than assumed.
- The unawaited latest-update fetch stays unawaited. I serialised it at first; that adds a full round trip to every cold start, so it's back to fire-and-forget with a guard so a failure doesn't overwrite `null` with `undefined` and render "Invalid Date".

## Sabotage verification

| Sabotage | Result |
|---|---|
| `warnAboutMissingRosterPlayers` reads state again | 1 failed |
| Traded picks round-tripped through state (#98 shape) | 9 failed |
| `fetchLeagueBundle` skips `decorateRosters` | 10 failed |
| `fetchLeagueBundle` serialised instead of parallel | 2 failed |
| Missing-draft fallback removed (#103 shape) | 1 failed |
| `loadDraft` composes against captured `leagueData`, not `prevState` | **passed — see below** |

## The one sabotage that passed, and why I left it that way

Composing `loadDraft`'s write against the captured `leagueData` instead of `prevState` is invisible to all 132 tests. I tried to write the race — two league switches, the first resolving after the second — and **it cannot be driven through the UI**: `updateLeagueID` sets the loading state, and the dropdown lives *inside* `LeaguePanel`'s loader-gated block, so it unmounts. No second switch can be initiated while one is in flight. `DraftPanel` is unmounted for the same reason, so no manual pick either.

So the `prevState` composition there is **defensive, not load-bearing**, and I've said so in a comment at the call site rather than leaving a false impression of coverage. I kept it because it costs nothing and that gating is incidental — a loader change elsewhere would reintroduce #96's shape one level up. I deleted the contrived test rather than ship one that asserts something unreachable.

## Browser verification

Full flow against the live Sleeper API, zero console errors:

- Cold start: 48 picks, 21 traded attributions, update timestamp rendered (the unawaited fetch lands)
- League switch TBD → 4 QB Madness: panel loader shown, no full-page loader, board 48 → 32 picks, traded picks 21 → 6
- Switch back, then live sync: all 48 slots filled with real players (Jeremiyah Love at 1.1), 21 traded attributions intact
- Weekly lineup: `QB RB RB WR WR TE FLX FLX SFLX` — confirms the extracted `toRosterPositions` drops `BN` and shortens `SUPER_FLEX`/`FLEX`

## Gates

`npm ci`, `lint` (0 problems), `format:check`, `typecheck`, `test:run` (132 pass), `build` — all green. Bundle 340.24 → 339.93 kB.