### PR TITLE
Extract the header, and put firebase behind lib/auth.js

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import './App.css';
 import './loader.css';
-import Button from './Components/Button';
+import Header from './Components/Header';
 import LeaguePanel from './Panels/LeaguePanel';
 import RanksPanel from './Panels/RanksPanel';
-import { onAuthStateChanged, signInAnonymously, signInWithPopup, signOut as firebaseSignOut } from 'firebase/auth';
-import { auth, googleProvider } from './firebase.js';
+import { currentUserIdentity, observeAuthState, signInAnonymous, signInWithGoogle, signOutUser } from './lib/auth.js';
 import createRankings from './helpers.js';
 import { buildDraftRounds } from './lib/draft.js';
 import {
@@ -71,21 +70,17 @@ class App extends React.Component {
     selectRosterInfo = memoizeRosterInfo();
 
     componentDidMount() {
-        this.unsubscribeAuth = onAuthStateChanged(auth, (user) => {
+        this.unsubscribeAuth = observeAuthState((user) => {
             if (user) {
                 const { playerInfo } = this.state;
-                const { currentUser } = auth;
-                this.setState({
-                    signedIn: !currentUser.isAnonymous,
-                    signedInEmail: currentUser.email ? currentUser.email : null,
-                });
+                this.setState(currentUserIdentity());
                 if (playerInfo && Object.keys(playerInfo).length === 0) {
                     this.loadEverything();
                 } else {
                     this.loadLeague(playerInfo);
                 }
             } else {
-                signInAnonymously(auth).catch((err) => console.error('Error:', err));
+                signInAnonymous();
             }
         });
     }
@@ -276,23 +271,16 @@ class App extends React.Component {
         }));
     };
 
-    googleSignIn = () => {
-        signInWithPopup(auth, googleProvider).catch((error) => {
-            console.log(error);
-        });
-    };
+    googleSignIn = () => signInWithGoogle();
 
-    signOut = () => {
-        firebaseSignOut(auth)
-            .then(() => {
-                this.setState({
-                    rankingPlayersIdsList: [],
-                });
-                console.log('Sign-out successful.');
-            })
-            .catch((error) => {
-                console.error('Sign-out failed:', error);
-            });
+    // The rank list is per signed-in user, so it has to go with them. Cleared
+    // only on a sign-out that actually succeeded - a failed one leaves the user
+    // signed in, and dropping their list under them would be worse than the
+    // failure.
+    signOut = async () => {
+        if (await signOutUser()) {
+            this.setState({ rankingPlayersIdsList: [] });
+        }
     };
 
     render() {
@@ -319,29 +307,13 @@ class App extends React.Component {
             const lineupSet = buildLineupSet(rosterPositions);
             return (
                 <div>
-                    <div
-                        style={{
-                            display: 'flex',
-                            flexDirection: 'row',
-                            justifyContent: 'space-between',
-                            padding: `${0}px ${3}px`,
-                        }}
-                    >
-                        <h1 className="title">Sleeper Team Assistant</h1>
-                        {signedIn ? (
-                            <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'baseline' }}>
-                                <p className="latest-update">
-                                    <i>{signedInEmail}</i>
-                                </p>
-                                <Button text="Sign out" onClick={this.signOut} btnStyle="primary" />
-                            </div>
-                        ) : (
-                            <Button text="Sign in" onClick={this.googleSignIn} btnStyle="primary" />
-                        )}
-                    </div>
-                    <p className="latest-update">
-                        <i>Latest player DB update attempt: {new Date(lastUpdate).toString()}</i>
-                    </p>
+                    <Header
+                        signedIn={signedIn}
+                        signedInEmail={signedInEmail}
+                        lastUpdate={lastUpdate}
+                        onSignIn={this.googleSignIn}
+                        onSignOut={this.signOut}
+                    />
                     <div className="main-container">
                         <RanksPanel
                             isLoading={loading === LOADING.RANKS_PANEL}

--- a/src/Components/Header.jsx
+++ b/src/Components/Header.jsx
@@ -1,0 +1,37 @@
+import Button from './Button';
+
+// Purely presentational: the whole top bar, plus the player-database
+// timestamp that sits under it. Nothing here reaches for auth or state - the
+// sign-in and sign-out handlers arrive as props so this stays renderable in
+// isolation.
+const Header = ({ signedIn, signedInEmail, lastUpdate, onSignIn, onSignOut }) => {
+    return (
+        <>
+            <div
+                style={{
+                    display: 'flex',
+                    flexDirection: 'row',
+                    justifyContent: 'space-between',
+                    padding: `${0}px ${3}px`,
+                }}
+            >
+                <h1 className="title">Sleeper Team Assistant</h1>
+                {signedIn ? (
+                    <div style={{ display: 'flex', flexDirection: 'row', alignItems: 'baseline' }}>
+                        <p className="latest-update">
+                            <i>{signedInEmail}</i>
+                        </p>
+                        <Button text="Sign out" onClick={onSignOut} btnStyle="primary" />
+                    </div>
+                ) : (
+                    <Button text="Sign in" onClick={onSignIn} btnStyle="primary" />
+                )}
+            </div>
+            <p className="latest-update">
+                <i>Latest player DB update attempt: {new Date(lastUpdate).toString()}</i>
+            </p>
+        </>
+    );
+};
+
+export default Header;

--- a/src/Components/Header.test.jsx
+++ b/src/Components/Header.test.jsx
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Header from './Header';
+
+// The top bar is the only place the signed-in/signed-out distinction is
+// visible. App.test.jsx runs entirely as an anonymous user, so the signed-in
+// half of this had no coverage at all before it was a component of its own.
+
+const LAST_UPDATE = '2026-01-01T00:00:00.000Z';
+
+function renderHeader(overrides = {}) {
+    const props = {
+        signedIn: false,
+        signedInEmail: null,
+        lastUpdate: LAST_UPDATE,
+        onSignIn: vi.fn(),
+        onSignOut: vi.fn(),
+        ...overrides,
+    };
+    render(<Header {...props} />);
+    return props;
+}
+
+describe('Header', () => {
+    it('offers sign in, and shows no identity, when signed out', () => {
+        renderHeader();
+
+        expect(screen.getByRole('button', { name: 'Sign in' })).toBeTruthy();
+        expect(screen.queryByRole('button', { name: 'Sign out' })).toBeNull();
+    });
+
+    it('shows the signed-in email and offers sign out', () => {
+        renderHeader({ signedIn: true, signedInEmail: 'someone@example.test' });
+
+        expect(screen.getByText('someone@example.test')).toBeTruthy();
+        expect(screen.getByRole('button', { name: 'Sign out' })).toBeTruthy();
+        expect(screen.queryByRole('button', { name: 'Sign in' })).toBeNull();
+    });
+
+    it('reports sign in and sign out to its caller rather than acting itself', async () => {
+        const user = userEvent.setup();
+        const { onSignIn } = renderHeader();
+
+        await user.click(screen.getByRole('button', { name: 'Sign in' }));
+        expect(onSignIn).toHaveBeenCalledTimes(1);
+
+        const { onSignOut } = renderHeader({ signedIn: true, signedInEmail: 'someone@example.test' });
+        await user.click(screen.getByRole('button', { name: 'Sign out' }));
+        expect(onSignOut).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders the player database timestamp', () => {
+        renderHeader();
+
+        expect(screen.getByText(/Latest player DB update attempt:/)).toHaveTextContent(
+            new Date(LAST_UPDATE).toString(),
+        );
+    });
+});

--- a/src/lib/auth.js
+++ b/src/lib/auth.js
@@ -1,0 +1,54 @@
+import { onAuthStateChanged, signInAnonymously, signInWithPopup, signOut } from 'firebase/auth';
+import { auth, googleProvider } from '../firebase.js';
+
+// Thin wrappers so App does not import firebase/auth directly. Each one
+// swallows its own error the same way the rest of the app's requests do: a
+// failed sign-in leaves the user signed out, which is already the state they
+// are in, so there is nothing to recover beyond logging it.
+
+/**
+ * Subscribes to auth state. Returns the unsubscribe function - App calls it on
+ * unmount, and dropping that is a leak (#102).
+ */
+export function observeAuthState(callback) {
+    return onAuthStateChanged(auth, callback);
+}
+
+/**
+ * Signs in anonymously, which is what every visitor gets before they choose to
+ * sign in with Google. Read access to the player database needs some identity.
+ */
+export function signInAnonymous() {
+    return signInAnonymously(auth).catch((err) => console.error('Error:', err));
+}
+
+export function signInWithGoogle() {
+    return signInWithPopup(auth, googleProvider).catch((error) => {
+        console.error('Sign-in failed:', error);
+    });
+}
+
+/**
+ * Resolves to true only when the sign-out actually happened, so the caller
+ * knows whether to clear anything tied to the signed-in user.
+ */
+export function signOutUser() {
+    return signOut(auth)
+        .then(() => true)
+        .catch((error) => {
+            console.error('Sign-out failed:', error);
+            return false;
+        });
+}
+
+/**
+ * Whether the signed-in user is a real Google account rather than the
+ * anonymous identity everyone starts with, plus the email to show for them.
+ */
+export function currentUserIdentity() {
+    const { currentUser } = auth;
+    return {
+        signedIn: !currentUser.isAnonymous,
+        signedInEmail: currentUser.email ? currentUser.email : null,
+    };
+}

--- a/src/lib/auth.test.js
+++ b/src/lib/auth.test.js
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { onAuthStateChanged, signInAnonymously, signInWithPopup, signOut } from 'firebase/auth';
+import { currentUserIdentity, observeAuthState, signInAnonymous, signInWithGoogle, signOutUser } from './auth.js';
+
+const authMock = vi.hoisted(() => ({ currentUser: {} }));
+
+vi.mock('../firebase.js', () => ({
+    auth: authMock,
+    googleProvider: { providerId: 'google.com' },
+}));
+
+vi.mock('firebase/auth', () => ({
+    onAuthStateChanged: vi.fn(),
+    signInAnonymously: vi.fn(),
+    signInWithPopup: vi.fn(),
+    signOut: vi.fn(),
+}));
+
+describe('currentUserIdentity', () => {
+    it('treats the anonymous identity everyone starts with as signed out', () => {
+        authMock.currentUser = { isAnonymous: true, email: null };
+
+        expect(currentUserIdentity()).toEqual({ signedIn: false, signedInEmail: null });
+    });
+
+    it('reports a real account as signed in, with its email', () => {
+        authMock.currentUser = { isAnonymous: false, email: 'someone@example.test' };
+
+        expect(currentUserIdentity()).toEqual({ signedIn: true, signedInEmail: 'someone@example.test' });
+    });
+
+    it('normalises a missing email to null rather than undefined', () => {
+        // The email renders directly, so undefined would reach the DOM.
+        authMock.currentUser = { isAnonymous: false, email: undefined };
+
+        expect(currentUserIdentity().signedInEmail).toBeNull();
+    });
+});
+
+describe('observeAuthState', () => {
+    it('hands back the unsubscribe function, which App needs on unmount', () => {
+        // Losing this is the leak fixed in #102.
+        const unsubscribe = vi.fn();
+        onAuthStateChanged.mockReturnValue(unsubscribe);
+
+        expect(observeAuthState(vi.fn())).toBe(unsubscribe);
+    });
+});
+
+describe('the sign-in and sign-out wrappers', () => {
+    beforeEach(() => {
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('signOutUser resolves true when the sign-out succeeded', async () => {
+        signOut.mockResolvedValue(undefined);
+
+        await expect(signOutUser()).resolves.toBe(true);
+    });
+
+    it('signOutUser resolves false rather than rejecting when it failed', async () => {
+        // App clears the signed-in user's rank list on the strength of this
+        // answer, so a failure has to be distinguishable from a success -
+        // dropping their list while they are still signed in is worse than the
+        // failed sign-out itself.
+        signOut.mockRejectedValue(new Error('network'));
+
+        await expect(signOutUser()).resolves.toBe(false);
+    });
+
+    it('signInWithGoogle swallows a cancelled or failed popup', async () => {
+        signInWithPopup.mockRejectedValue(new Error('popup closed'));
+
+        await expect(signInWithGoogle()).resolves.toBeUndefined();
+    });
+
+    it('signInAnonymous swallows its own failure', async () => {
+        signInAnonymously.mockRejectedValue(new Error('offline'));
+
+        await expect(signInAnonymous()).resolves.toBeUndefined();
+    });
+});


### PR DESCRIPTION
Stage 4, the last of the App decomposition. Tests **132 → 144**. `App.jsx` 379 → **351** lines (460 at the start of this refactor).

- **`src/Components/Header.jsx`** — the top bar plus the player-database timestamp. Purely presentational; handlers arrive as props, so it renders in isolation. `App.test.jsx` runs entirely as an anonymous user, so **the signed-in state had no coverage at all** before this was a component of its own.
- **`src/lib/auth.js`** — wraps the four firebase calls and adds `currentUserIdentity`, which had been inline in the auth callback. `App` no longer imports `firebase/auth`.

`signOutUser` now resolves `true`/`false` rather than relying on a `.then`, so the caller can distinguish a real sign-out from a failed one. App clears the rank list only on success — dropping it while the user is still signed in would be worse than the failed sign-out itself.

## Sabotage verification

| Sabotage | Result |
|---|---|
| Header always renders the signed-out state | 2 failed |
| Header wires both buttons to the same handler | 1 failed |
| `currentUserIdentity` ignores `isAnonymous` | 1 failed |
| `currentUserIdentity` leaks an undefined email | 1 failed |
| `signOutUser` reports success when it failed | 1 failed |
| `observeAuthState` drops the unsubscribe (#102 shape) | 2 failed |

The last one fails both its own unit test and App's existing #102 regression test.

## Scope I dropped, deliberately

The plan for this stage also said "split state into cohesive slices" (e.g. grouping `signedIn`/`signedInEmail` under an `auth` key). **I didn't do it.** After the earlier stages App is down to 12 state fields, all of them read, and nesting them would add `setState` spread ceremony at every call site for no functional gain — churn dressed as cleanup. Extracting the header and the auth module were the parts of this stage with actual value. Say the word if you want the regrouping anyway.

## Browser verification

Header renders correctly signed out — title, Sign in button, timestamp — and anonymous auth still works through the extracted wrappers, with the full app behind it (48 picks, 21 traded attributions, zero console errors).

**I did not exercise the signed-in path in the browser.** That requires entering real Google credentials, which I won't do. It's covered by the Header and `auth.js` unit tests instead.

## Noted, not fixed

`lastUpdate` starts as `null` and renders through `new Date(null).toString()`, so there's a window before the fetch lands where the header reads "Wed Dec 31 1969". Pre-existing, and it's a behaviour change rather than a move, so it doesn't belong in this commit — same reasoning as the `new Error(statusText, status)` misuse flagged in #109.

## Gates

`npm ci`, `lint` (0 problems), `format:check`, `typecheck`, `test:run` (144 pass), `build` — all green.