### PR TITLE
Stop caching derived positions on the shared player database

### DIFF
--- a/src/lib/roster.js
+++ b/src/lib/roster.js
@@ -21,8 +21,14 @@ export function getEligiblePositions(player) {
 /**
  * Pure version of `App.addToRoster`. Finds the first open roster slot that
  * matches one of the player's eligible positions, and returns new
- * `rosterPositions`/`playerInfo`/`player` objects reflecting the assignment.
- * Does not mutate any of its inputs.
+ * `rosterPositions`/`playerInfo` objects reflecting the assignment. Does not
+ * mutate any of its inputs.
+ *
+ * Deliberately does not write the computed eligible positions back onto the
+ * player. `getEligiblePositions` derives them from the player's real position
+ * every time and is idempotent, so caching them bought nothing - and nothing
+ * ever read the extended list. It was one of the last two writes into the
+ * shared player database.
  */
 export function addPlayerToRoster({ player, rosterPositions, playerInfo }) {
     const eligiblePositions = getEligiblePositions(player);
@@ -39,19 +45,12 @@ export function addPlayerToRoster({ player, rosterPositions, playerInfo }) {
         }
     }
 
-    const newPlayer = {
-        ...player,
-        fantasy_positions: eligiblePositions,
-        roster_text: rosterText,
-    };
-
     return {
         rosterPositions: newRosterPositions,
         playerInfo: {
             ...playerInfo,
-            [player.player_id]: newPlayer,
+            [player.player_id]: { ...player, roster_text: rosterText },
         },
-        player: newPlayer,
     };
 }
 

--- a/src/lib/roster.test.js
+++ b/src/lib/roster.test.js
@@ -65,7 +65,10 @@ describe('addPlayerToRoster', () => {
 
         expect(result.rosterPositions).toEqual(['QB', '1001', 'WR', 'FLX', 'BN']);
         expect(result.playerInfo['1001'].roster_text).toEqual('RB');
-        expect(result.playerInfo['1001'].fantasy_positions).toEqual(['RB', 'FLX', 'SFLX']);
+        // The eligible positions are computed to find the slot, but not written
+        // back onto the player: nothing reads the extended list, and
+        // getEligiblePositions re-derives it on demand.
+        expect(result.playerInfo['1001'].fantasy_positions).toEqual(['RB']);
     });
 
     it('falls back to FLX slot when the primary position slot is unavailable', () => {
@@ -103,21 +106,34 @@ describe('addPlayerToRoster', () => {
         expect(playerInfo).toEqual(clonedPlayerInfo);
     });
 
-    it('does not duplicate fantasy_positions entries when the player is added twice in a row', () => {
+    it('leaves the player database entry untouched apart from roster_text', () => {
+        // The whole point of dropping the write-back: adding a player to a
+        // lineup must not rewrite the shared player database with derived
+        // values. roster_text is the last remaining write, and goes next.
         const player = makePlayer();
-        const rosterPositions = ['QB', 'RB', 'WR', 'FLX', 'BN'];
-        const first = addPlayerToRoster({ player, rosterPositions, playerInfo: {} });
+        const playerInfo = { 1001: player };
+        const result = addPlayerToRoster({ player, rosterPositions: ['QB', 'RB', 'BN'], playerInfo });
 
-        // Second call simulates re-adding using the already-updated player/playerInfo,
-        // as would happen if addToRoster were invoked again for the same player.
+        const { roster_text, ...rest } = result.playerInfo['1001'];
+        expect(roster_text).toEqual('RB');
+        expect(rest).toEqual(player);
+    });
+
+    it('assigns the same slot whether or not a previous add cached anything on the player', () => {
+        // getEligiblePositions is idempotent, which is what made the cache
+        // pointless: a second add computes the same eligible list from the
+        // player's real position and picks the same slot.
+        const player = makePlayer();
+        const first = addPlayerToRoster({ player, rosterPositions: ['QB', 'RB', 'WR', 'FLX', 'BN'], playerInfo: {} });
+
         const second = addPlayerToRoster({
             player: first.playerInfo['1001'],
-            rosterPositions: first.rosterPositions,
+            rosterPositions: ['QB', 'RB', 'WR', 'FLX', 'BN'],
             playerInfo: first.playerInfo,
         });
 
-        expect(second.playerInfo['1001'].fantasy_positions).toEqual(['RB', 'FLX', 'SFLX']);
-        expect(second.playerInfo['1001'].fantasy_positions.length).toBe(3);
+        expect(second.rosterPositions).toEqual(first.rosterPositions);
+        expect(second.playerInfo['1001'].roster_text).toEqual('RB');
     });
 });
 


### PR DESCRIPTION
First of two PRs removing the last writes into the shared player database. Tests **144 → 145**.

`addPlayerToRoster` wrote the computed eligible positions back onto the player in `playerInfo`. **Nothing ever read the extended list** — `getEligiblePositions` derives it from the player's real position on every call and is idempotent, so the cache could not change any answer. It also returned a `player` that `App.addToRoster` ignored.

## Sabotage verification

| Sabotage | Result |
|---|---|
| Write the derived positions back onto the player again | 2 failed |
| `getEligiblePositions` stops adding flex slots | 4 failed |
| `roster_text` stops being recorded | 4 failed |

The third is there on purpose: `roster_text` is what the next PR removes, so I wanted to confirm the tests currently notice if it disappears — they do, in four places.

The second confirms the eligible-position logic still drives slot selection with no cache behind it, which is the correctness property that actually matters here.

## Browser verification

The claim is an absence ("nothing read this"), so I exercised the real flow rather than only the unit tests:

- Ranked two free agents; both render with enabled Add buttons
- Added Marlin Klein (TE) → lands in the **TE** slot, rendering `TE Marlin Klein` (that prefix is `roster_text`, still working), and his button flips to `Added` / disabled
- Clicked the filled slot → restored to bare `TE`, full lineup back to `QB RB RB WR WR TE FLX FLX SFLX`
- Added Bryce Ford-Wheaton (WR) → lands in the first open **WR** slot

Zero console errors throughout.

## Next

`roster_text` is the last write. It can't go until the roster-slot shape changes: `rosterPositions` is a mixed array where a slot holds *either* a label or a player id, so adding a player **overwrites the label** — and `roster_text` exists only to remember what was overwritten. Replacing it with `{ label, playerId }[]` means the label is never destroyed, which also removes `buildLineupSet`'s `/^\d+$/` heuristic (that regex is only needed because labels and ids share an array) and drops `playerInfo` from `removePlayerFromLineup`'s signature entirely.

## Gates

`lint` (0 problems), `format:check`, `typecheck`, `test:run` (145 pass), `build` — all green.