### PR TITLE
Give lineup slots their own shape, and drop roster_text

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -15,7 +15,7 @@ import {
     fetchPlayerData,
     fetchTradedDraftPicks,
 } from './lib/sleeperApi.js';
-import { addPlayerToRoster, removePlayerFromLineup } from './lib/roster.js';
+import { addPlayerToRoster, removePlayerFromLineup, toRosterSlots } from './lib/roster.js';
 import { buildLineupSet, memoizeRosterInfo } from './lib/rosterInfo.js';
 import { resolveMyDisplayName } from './lib/sleeper.js';
 import { SLEEPER_USER_ID } from './urls.js';
@@ -29,21 +29,6 @@ import { SLEEPER_USER_ID } from './urls.js';
 // startLoad and then comparing against that same literal coming back down as a
 // prop. The panels now receive a plain boolean and no longer share a
 // vocabulary with App at all, so these names stay private to this file.
-// Sleeper's own labels, shortened for display, with bench slots dropped -
-// only startable positions appear in the weekly lineup.
-function toRosterPositions(rosterPositions) {
-    return rosterPositions
-        .filter((pos) => pos !== 'BN')
-        .map((pos) => {
-            if (pos === 'SUPER_FLEX') {
-                return 'SFLX';
-            } else if (pos === 'FLEX') {
-                return 'FLX';
-            }
-            return pos;
-        });
-}
-
 const LOADING = {
     NONE: 'none',
     INITIAL: 'initial',
@@ -58,7 +43,7 @@ class App extends React.Component {
         loading: LOADING.INITIAL,
         rankingPlayersIdsList: [],
         leagueID: '1312088290526003200',
-        rosterPositions: [],
+        rosterSlots: [],
         notFoundPlayers: [],
         lastUpdate: null,
         signedIn: false,
@@ -130,7 +115,7 @@ class App extends React.Component {
             leagueData,
             loading: LOADING.LEAGUE_PANEL,
             myDisplayName: resolveMyDisplayName(leagueData.managerData, SLEEPER_USER_ID),
-            rosterPositions: toRosterPositions(leagueData.currentLeague.roster_positions),
+            rosterSlots: toRosterSlots(leagueData.currentLeague.roster_positions),
         });
 
         await this.loadDraft(leagueData);
@@ -237,21 +222,11 @@ class App extends React.Component {
     };
 
     addToRoster = (player) => {
-        const { rosterPositions, playerInfo } = this.state;
-        const updated = addPlayerToRoster({ player, rosterPositions, playerInfo });
-        this.setState({
-            playerInfo: updated.playerInfo,
-            rosterPositions: updated.rosterPositions,
-        });
+        this.setState((prevState) => addPlayerToRoster({ player, rosterSlots: prevState.rosterSlots }));
     };
 
-    removeFromLineup = (id, i) => {
-        const { rosterPositions, playerInfo } = this.state;
-        const updated = removePlayerFromLineup({ id, i, rosterPositions, playerInfo });
-        this.setState({
-            playerInfo: updated.playerInfo,
-            rosterPositions: updated.rosterPositions,
-        });
+    removeFromLineup = (i) => {
+        this.setState((prevState) => removePlayerFromLineup({ i, rosterSlots: prevState.rosterSlots }));
     };
 
     // Takes a reducer rather than a finished board on purpose. Callers compute
@@ -289,7 +264,7 @@ class App extends React.Component {
             lastUpdate,
             loading,
             rankingPlayersIdsList,
-            rosterPositions,
+            rosterSlots,
             leagueData,
             notFoundPlayers,
             leagueID,
@@ -304,7 +279,7 @@ class App extends React.Component {
                 rosterData: leagueData.rosterData,
                 builtDraft: leagueData.currentDraft?.built_draft,
             });
-            const lineupSet = buildLineupSet(rosterPositions);
+            const lineupSet = buildLineupSet(rosterSlots);
             return (
                 <div>
                     <Header
@@ -334,7 +309,7 @@ class App extends React.Component {
                             leagueID={leagueID}
                             updateLeagueID={this.updateLeagueID}
                             rankingPlayersIdsList={rankingPlayersIdsList}
-                            rosterPositions={rosterPositions}
+                            rosterSlots={rosterSlots}
                             playerInfo={playerInfo}
                             rosterInfo={rosterInfo}
                             isLoading={loading === LOADING.LEAGUE_PANEL}

--- a/src/Components/PlayerInfoItem.test.jsx
+++ b/src/Components/PlayerInfoItem.test.jsx
@@ -92,10 +92,14 @@ describe('PlayerInfoItem', () => {
         // The lineup set is built by the real helper rather than a literal Set
         // so the shape stays honest, but what this protects is the component
         // half: that lineupSet reaches the item and drives the button's label
-        // and disabled state. buildLineupSet's own numeric filtering is
-        // covered directly in lib/rosterInfo.test.js - sabotaging that filter
-        // does not fail this test, and this comment used to claim it did.
-        const lineupSet = buildLineupSet(['QB', MY_PLAYER_ID, 'FLX', 'BN']);
+        // and disabled state. buildLineupSet's own occupancy logic is covered
+        // directly in lib/rosterInfo.test.js - sabotaging it does not fail this
+        // test, and this comment used to claim it did.
+        const lineupSet = buildLineupSet([
+            { label: 'QB', playerId: null },
+            { label: 'WR', playerId: MY_PLAYER_ID },
+            { label: 'FLX', playerId: null },
+        ]);
         renderItem(MY_PLAYER_ID, { lineupSet });
 
         const added = screen.getByRole('button', { name: 'Added' });

--- a/src/Panels/LeaguePanel.jsx
+++ b/src/Panels/LeaguePanel.jsx
@@ -7,7 +7,7 @@ const LeaguePanel = ({
     playerInfo,
     rosterInfo,
     updateLeagueID,
-    rosterPositions,
+    rosterSlots,
     leagueID,
     isLoading,
     removeFromLineup,
@@ -60,74 +60,75 @@ const LeaguePanel = ({
                     </div>
                     {leaguePanel === 'weekly' && (
                         <div className="roster-positions">
-                            {rosterPositions.map((id, i) => (
-                                <div
-                                    style={{ cursor: 'pointer' }}
-                                    className={`${playerInfo[id] ? playerInfo[id].position : id} lineup-position`}
-                                    key={`${id}-${i}`}
-                                    onClick={() => (playerInfo[id] ? removeFromLineup(id, i) : null)}
-                                >
-                                    <span className="full-text" style={{ marginRight: 0 }}>
-                                        {playerInfo[id] ? (
-                                            <>
-                                                <b>{playerInfo[id].roster_text}</b> {playerInfo[id].full_name}
-                                            </>
-                                        ) : (
-                                            <b>{id}</b>
-                                        )}
-                                    </span>
-                                    <span className="abbr-text" style={{ marginRight: 0 }}>
-                                        {playerInfo[id] ? (
-                                            <>
-                                                <b>{playerInfo[id].roster_text}</b>{' '}
-                                                {playerInfo[id].first_name.split('')[0]}.{playerInfo[id].last_name}
-                                            </>
-                                        ) : (
-                                            <b>{id}</b>
-                                        )}
-                                    </span>
-                                    {playerInfo[id] ? (
-                                        <div
-                                            style={{
-                                                marginBottom: -19 + 'px',
-                                                marginLeft: 3 + 'px',
-                                                position: 'relative',
-                                                bottom: 3 + 'px',
-                                            }}
-                                        >
+                            {rosterSlots.map((slot, i) => {
+                                // A slot is occupied whenever it holds a player id, even if
+                                // that id is missing from the player database (a retired
+                                // player dropped from it). Keying the click off the id
+                                // rather than off the lookup means such a slot can still be
+                                // cleared - previously it rendered the raw id and could not
+                                // be emptied at all.
+                                const player = slot.playerId ? playerInfo[slot.playerId] : null;
+                                const occupantName = player ? player.full_name : slot.playerId;
+                                return (
+                                    <div
+                                        style={{ cursor: 'pointer' }}
+                                        className={`${player ? player.position : slot.label} lineup-position`}
+                                        key={`${slot.label}-${i}`}
+                                        onClick={() => (slot.playerId ? removeFromLineup(i) : null)}
+                                    >
+                                        <span className="full-text" style={{ marginRight: 0 }}>
+                                            <b>{slot.label}</b>
+                                            {slot.playerId ? ` ${occupantName}` : null}
+                                        </span>
+                                        <span className="abbr-text" style={{ marginRight: 0 }}>
+                                            <b>{slot.label}</b>
+                                            {slot.playerId
+                                                ? ` ${player ? `${player.first_name.split('')[0]}.${player.last_name}` : slot.playerId}`
+                                                : null}
+                                        </span>
+                                        {player ? (
                                             <div
-                                                className="avatar-player"
-                                                aria-label="nfl Player"
                                                 style={{
-                                                    width: 22 + 'px',
-                                                    height: 22 + 'px',
-                                                    flex: '0 0 32 px',
-                                                    background: `url(https://sleepercdn.com/content/nfl/players/thumb/${playerInfo[id].player_id}.jpg) center center / cover rgb(239, 239, 239)`,
-                                                    borderRadius: 33 + '%',
-                                                    backgroundColor: 'transparent',
-                                                }}
-                                            ></div>
-                                            <div
-                                                className="avatar-player"
-                                                aria-label="nfl Player"
-                                                style={{
-                                                    width: 17 + 'px',
-                                                    height: 17 + 'px',
-                                                    flex: '0 0 32 px',
-                                                    background: `url(https://sleepercdn.com/images/team_logos/nfl/${
-                                                        playerInfo[id].team ? playerInfo[id].team.toLowerCase() : null
-                                                    }.png) center center / cover rgb(239, 239, 239)`,
-                                                    borderRadius: 33 + '%',
+                                                    marginBottom: -19 + 'px',
+                                                    marginLeft: 3 + 'px',
                                                     position: 'relative',
-                                                    top: -12 + 'px',
-                                                    left: 10 + 'px',
-                                                    backgroundColor: 'transparent',
+                                                    bottom: 3 + 'px',
                                                 }}
-                                            ></div>
-                                        </div>
-                                    ) : null}
-                                </div>
-                            ))}
+                                            >
+                                                <div
+                                                    className="avatar-player"
+                                                    aria-label="nfl Player"
+                                                    style={{
+                                                        width: 22 + 'px',
+                                                        height: 22 + 'px',
+                                                        flex: '0 0 32 px',
+                                                        background: `url(https://sleepercdn.com/content/nfl/players/thumb/${player.player_id}.jpg) center center / cover rgb(239, 239, 239)`,
+                                                        borderRadius: 33 + '%',
+                                                        backgroundColor: 'transparent',
+                                                    }}
+                                                ></div>
+                                                <div
+                                                    className="avatar-player"
+                                                    aria-label="nfl Player"
+                                                    style={{
+                                                        width: 17 + 'px',
+                                                        height: 17 + 'px',
+                                                        flex: '0 0 32 px',
+                                                        background: `url(https://sleepercdn.com/images/team_logos/nfl/${
+                                                            player.team ? player.team.toLowerCase() : null
+                                                        }.png) center center / cover rgb(239, 239, 239)`,
+                                                        borderRadius: 33 + '%',
+                                                        position: 'relative',
+                                                        top: -12 + 'px',
+                                                        left: 10 + 'px',
+                                                        backgroundColor: 'transparent',
+                                                    }}
+                                                ></div>
+                                            </div>
+                                        ) : null}
+                                    </div>
+                                );
+                            })}
                         </div>
                     )}
                     {leaguePanel === 'draft' && (

--- a/src/Panels/LeaguePanel.test.jsx
+++ b/src/Panels/LeaguePanel.test.jsx
@@ -19,17 +19,22 @@ const LEAGUE_ID = '1312088290526003200';
 const OTHER_LEAGUE_ID = '9999999999999999999';
 const STARTER = { id: '13274', name: 'Germie Bernard' };
 
-// roster_text is written onto the player by lib/roster.js when a player is
-// added to a lineup; the fixture holds the undecorated player database, so the
-// decoration is applied here rather than in the fixture file.
-const lineupPlayerInfo = {
-    ...playerInfo,
-    [STARTER.id]: { ...playerInfo[STARTER.id], roster_text: 'WR' },
-};
+// The player database is used exactly as the fixture holds it - nothing is
+// decorated onto it any more. The slot label lives on the slot, which is the
+// whole point of the shape.
+const lineupPlayerInfo = playerInfo;
 
-// Index 1 is the only filled slot; the bare labels around it are what
-// distinguishes a real starter from an empty position.
-const ROSTER_POSITIONS = ['QB', STARTER.id, 'FLX'];
+// Index 1 is the only filled slot; the empty ones around it are what
+// distinguishes a real starter from an open position.
+// The filled slot is deliberately a FLX holding a WR: the label and the
+// occupant's position must differ, or rendering the position instead of the
+// label looks identical and the assertion proves nothing. A WR in a WR slot
+// hides exactly the bug this is here to catch.
+const ROSTER_SLOTS = [
+    { label: 'QB', playerId: null },
+    { label: 'FLX', playerId: STARTER.id },
+    { label: 'WR', playerId: null },
+];
 
 function renderPanel(overrides = {}) {
     const updateLeagueID = vi.fn();
@@ -53,7 +58,7 @@ function renderPanel(overrides = {}) {
         playerInfo: lineupPlayerInfo,
         rosterInfo,
         updateLeagueID,
-        rosterPositions: ROSTER_POSITIONS,
+        rosterSlots: ROSTER_SLOTS,
         leagueID: LEAGUE_ID,
         isLoading: false,
         removeFromLineup,
@@ -112,16 +117,20 @@ describe('LeaguePanel', () => {
         await user.click(screen.getByText('Weekly'));
 
         const slots = [...container.querySelectorAll('.lineup-position')];
-        expect(slots).toHaveLength(ROSTER_POSITIONS.length);
+        expect(slots).toHaveLength(ROSTER_SLOTS.length);
 
-        // A filled slot takes its class from the player's position rather than
-        // from the raw entry, which is what colours it on screen.
+        // Two different things are rendered from one filled slot, and they
+        // disagree here on purpose: the class comes from the occupant's
+        // position (that is what colours the row), while the visible label
+        // comes from the slot. A WR sitting in FLX must read FLX.
         expect(slots[1].className).toContain(lineupPlayerInfo[STARTER.id].position);
         expect(slots[1].textContent).toContain(STARTER.name);
+        expect(slots[1].textContent).toContain('FLX');
+        expect(slots[1].textContent).not.toContain('WR');
         // Doubled because the slot renders a full-text and an abbr-text span,
         // one of which CSS hides depending on viewport width.
         expect(slots[0].textContent).toBe('QBQB');
-        expect(slots[2].textContent).toBe('FLXFLX');
+        expect(slots[2].textContent).toBe('WRWR');
     });
 
     it('removes a player from the lineup by slot index, and ignores clicks on empty slots', async () => {
@@ -134,10 +143,12 @@ describe('LeaguePanel', () => {
         expect(removeFromLineup).not.toHaveBeenCalled();
 
         await user.click(slots[1]);
-        // The index is what lib/roster.js splices the position label back into,
-        // so passing the wrong one restores the slot in the wrong place.
+        // The index is which slot gets emptied, so passing the wrong one clears
+        // someone else's.
         expect(removeFromLineup).toHaveBeenCalledTimes(1);
-        expect(removeFromLineup).toHaveBeenCalledWith(STARTER.id, 1);
+        // The index alone identifies the slot now - the player id was only ever
+        // needed to look roster_text back off the player.
+        expect(removeFromLineup).toHaveBeenCalledWith(1);
     });
 
     it('reports a league change up by league id', async () => {

--- a/src/lib/roster.js
+++ b/src/lib/roster.js
@@ -19,54 +19,57 @@ export function getEligiblePositions(player) {
 }
 
 /**
- * Pure version of `App.addToRoster`. Finds the first open roster slot that
- * matches one of the player's eligible positions, and returns new
- * `rosterPositions`/`playerInfo` objects reflecting the assignment. Does not
- * mutate any of its inputs.
+ * Builds the lineup from Sleeper's `roster_positions`: one slot per startable
+ * position, bench slots dropped, labels shortened for display.
  *
- * Deliberately does not write the computed eligible positions back onto the
- * player. `getEligiblePositions` derives them from the player's real position
- * every time and is idempotent, so caching them bought nothing - and nothing
- * ever read the extended list. It was one of the last two writes into the
- * shared player database.
+ * A slot keeps its label for its whole life and tracks its occupant
+ * separately. The previous shape was a single array holding *either* a label
+ * or a player id at each index, so filling a slot overwrote its label - which
+ * is why the label had to be remembered as `roster_text` on the player, in the
+ * shared player database. Nothing needs remembering now.
  */
-export function addPlayerToRoster({ player, rosterPositions, playerInfo }) {
-    const eligiblePositions = getEligiblePositions(player);
-    let newRosterPositions = rosterPositions;
-    let rosterText = player.roster_text;
-
-    for (let i = 0; i < eligiblePositions.length; i++) {
-        const positionIndex = rosterPositions.indexOf(eligiblePositions[i]);
-        if (positionIndex !== -1) {
-            rosterText = eligiblePositions[i];
-            newRosterPositions = [...rosterPositions];
-            newRosterPositions.splice(positionIndex, 1, player.player_id);
-            break;
-        }
-    }
-
-    return {
-        rosterPositions: newRosterPositions,
-        playerInfo: {
-            ...playerInfo,
-            [player.player_id]: { ...player, roster_text: rosterText },
-        },
-    };
+export function toRosterSlots(rosterPositions) {
+    return rosterPositions
+        .filter((pos) => pos !== 'BN')
+        .map((pos) => {
+            if (pos === 'SUPER_FLEX') {
+                return { label: 'SFLX', playerId: null };
+            } else if (pos === 'FLEX') {
+                return { label: 'FLX', playerId: null };
+            }
+            return { label: pos, playerId: null };
+        });
 }
 
 /**
- * Pure version of `App.removeFromLineup`. Restores the roster slot at index
- * `i` to the player's remembered `roster_text`. Whether the player is still
- * "in the lineup" is derived from `rosterPositions` (see `buildLineupSet` in
- * `rosterInfo.js`), not tracked on the player object, so this only needs to
- * update `rosterPositions`. Does not mutate any of its inputs.
+ * Pure version of `App.addToRoster`. Fills the first open slot whose label is
+ * one of the player's eligible positions. Returns new slots; the player
+ * database is neither an input nor an output, because assigning a player to a
+ * lineup slot is a fact about the slot, not about the player.
  */
-export function removePlayerFromLineup({ id, i, rosterPositions, playerInfo }) {
-    const newRosterPositions = [...rosterPositions];
-    newRosterPositions.splice(i, 1, playerInfo[id].roster_text);
+export function addPlayerToRoster({ player, rosterSlots }) {
+    const eligiblePositions = getEligiblePositions(player);
 
-    return {
-        rosterPositions: newRosterPositions,
-        playerInfo,
-    };
+    for (const eligiblePosition of eligiblePositions) {
+        const slotIndex = rosterSlots.findIndex((slot) => slot.playerId === null && slot.label === eligiblePosition);
+        if (slotIndex !== -1) {
+            const newSlots = [...rosterSlots];
+            newSlots[slotIndex] = { ...newSlots[slotIndex], playerId: player.player_id };
+            return { rosterSlots: newSlots };
+        }
+    }
+
+    return { rosterSlots };
+}
+
+/**
+ * Pure version of `App.removeFromLineup`. Empties the slot at index `i`. It
+ * needs neither the player id nor the player database: the slot already knows
+ * its own label, so there is nothing to look up and nothing to restore.
+ */
+export function removePlayerFromLineup({ i, rosterSlots }) {
+    const newSlots = [...rosterSlots];
+    newSlots[i] = { ...newSlots[i], playerId: null };
+
+    return { rosterSlots: newSlots };
 }

--- a/src/lib/roster.test.js
+++ b/src/lib/roster.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { addPlayerToRoster, getEligiblePositions, removePlayerFromLineup } from './roster.js';
+import { addPlayerToRoster, getEligiblePositions, removePlayerFromLineup, toRosterSlots } from './roster.js';
 
 const makePlayer = (overrides = {}) => ({
     player_id: '1001',
@@ -56,113 +56,125 @@ describe('getEligiblePositions', () => {
     });
 });
 
+const slots = (...labels) => labels.map((label) => ({ label, playerId: null }));
+
+describe('toRosterSlots', () => {
+    it('drops bench slots and shortens the flex labels', () => {
+        expect(toRosterSlots(['QB', 'RB', 'FLEX', 'SUPER_FLEX', 'BN', 'BN'])).toEqual(slots('QB', 'RB', 'FLX', 'SFLX'));
+    });
+
+    it('starts every slot empty', () => {
+        expect(toRosterSlots(['QB', 'RB']).every((slot) => slot.playerId === null)).toBe(true);
+    });
+
+    it('keeps duplicate positions as separate slots', () => {
+        // Two RB slots are two places a player can go, not one.
+        expect(toRosterSlots(['RB', 'RB'])).toHaveLength(2);
+    });
+});
+
 describe('addPlayerToRoster', () => {
-    it('assigns the player to the first matching open roster slot', () => {
-        const player = makePlayer();
-        const rosterPositions = ['QB', 'RB', 'WR', 'FLX', 'BN'];
-        const playerInfo = {};
-        const result = addPlayerToRoster({ player, rosterPositions, playerInfo });
+    it('fills the first open slot matching the player position', () => {
+        const result = addPlayerToRoster({ player: makePlayer(), rosterSlots: slots('QB', 'RB', 'WR', 'FLX') });
 
-        expect(result.rosterPositions).toEqual(['QB', '1001', 'WR', 'FLX', 'BN']);
-        expect(result.playerInfo['1001'].roster_text).toEqual('RB');
-        // The eligible positions are computed to find the slot, but not written
-        // back onto the player: nothing reads the extended list, and
-        // getEligiblePositions re-derives it on demand.
-        expect(result.playerInfo['1001'].fantasy_positions).toEqual(['RB']);
+        expect(result.rosterSlots[1]).toEqual({ label: 'RB', playerId: '1001' });
+        // Every other slot keeps its label and stays empty - the label is no
+        // longer destroyed by filling a slot, which is what made roster_text
+        // necessary in the first place.
+        expect(result.rosterSlots.map((slot) => slot.label)).toEqual(['QB', 'RB', 'WR', 'FLX']);
     });
 
-    it('falls back to FLX slot when the primary position slot is unavailable', () => {
-        const player = makePlayer();
-        const rosterPositions = ['QB', 'WR', 'FLX', 'BN'];
-        const playerInfo = {};
-        const result = addPlayerToRoster({ player, rosterPositions, playerInfo });
+    it('falls back to FLX when the primary position slot is taken', () => {
+        const taken = slots('QB', 'RB', 'WR', 'FLX');
+        taken[1] = { label: 'RB', playerId: '2002' };
 
-        expect(result.rosterPositions).toEqual(['QB', 'WR', '1001', 'BN']);
-        expect(result.playerInfo['1001'].roster_text).toEqual('FLX');
+        const result = addPlayerToRoster({ player: makePlayer(), rosterSlots: taken });
+
+        expect(result.rosterSlots[3]).toEqual({ label: 'FLX', playerId: '1001' });
     });
 
-    it('leaves rosterPositions unchanged when no eligible slot is open', () => {
-        const player = makePlayer();
-        const rosterPositions = ['QB', 'WR', 'TE', 'BN'];
-        const playerInfo = {};
-        const result = addPlayerToRoster({ player, rosterPositions, playerInfo });
+    it('skips an occupied slot of the right label rather than displacing its occupant', () => {
+        // findIndex has to test occupancy as well as label; matching on label
+        // alone would silently evict whoever is already there.
+        const taken = slots('RB', 'RB');
+        taken[0] = { label: 'RB', playerId: '2002' };
 
-        expect(result.rosterPositions).toEqual(rosterPositions);
-        expect(result.playerInfo['1001'].roster_text).toBeUndefined();
+        const result = addPlayerToRoster({ player: makePlayer(), rosterSlots: taken });
+
+        expect(result.rosterSlots[0].playerId).toEqual('2002');
+        expect(result.rosterSlots[1].playerId).toEqual('1001');
+    });
+
+    it('leaves the slots unchanged when no eligible slot is open', () => {
+        const rosterSlots = slots('QB', 'WR', 'TE');
+        const result = addPlayerToRoster({ player: makePlayer(), rosterSlots });
+
+        expect(result.rosterSlots).toEqual(rosterSlots);
     });
 
     it('does not mutate its inputs', () => {
         const player = makePlayer();
-        const rosterPositions = ['QB', 'RB', 'WR', 'FLX', 'BN'];
-        const playerInfo = { 2002: makePlayer({ player_id: '2002' }) };
+        const rosterSlots = slots('QB', 'RB', 'WR', 'FLX');
         const clonedPlayer = structuredClone(player);
-        const clonedRosterPositions = structuredClone(rosterPositions);
-        const clonedPlayerInfo = structuredClone(playerInfo);
+        const clonedSlots = structuredClone(rosterSlots);
 
-        addPlayerToRoster({ player, rosterPositions, playerInfo });
+        addPlayerToRoster({ player, rosterSlots });
 
         expect(player).toEqual(clonedPlayer);
-        expect(rosterPositions).toEqual(clonedRosterPositions);
-        expect(playerInfo).toEqual(clonedPlayerInfo);
+        expect(rosterSlots).toEqual(clonedSlots);
     });
 
-    it('leaves the player database entry untouched apart from roster_text', () => {
-        // The whole point of dropping the write-back: adding a player to a
-        // lineup must not rewrite the shared player database with derived
-        // values. roster_text is the last remaining write, and goes next.
-        const player = makePlayer();
-        const playerInfo = { 1001: player };
-        const result = addPlayerToRoster({ player, rosterPositions: ['QB', 'RB', 'BN'], playerInfo });
-
-        const { roster_text, ...rest } = result.playerInfo['1001'];
-        expect(roster_text).toEqual('RB');
-        expect(rest).toEqual(player);
-    });
-
-    it('assigns the same slot whether or not a previous add cached anything on the player', () => {
-        // getEligiblePositions is idempotent, which is what made the cache
-        // pointless: a second add computes the same eligible list from the
-        // player's real position and picks the same slot.
-        const player = makePlayer();
-        const first = addPlayerToRoster({ player, rosterPositions: ['QB', 'RB', 'WR', 'FLX', 'BN'], playerInfo: {} });
-
-        const second = addPlayerToRoster({
-            player: first.playerInfo['1001'],
-            rosterPositions: ['QB', 'RB', 'WR', 'FLX', 'BN'],
-            playerInfo: first.playerInfo,
-        });
-
-        expect(second.rosterPositions).toEqual(first.rosterPositions);
-        expect(second.playerInfo['1001'].roster_text).toEqual('RB');
+    it('never touches the player database, because it is not given one', () => {
+        // The point of the whole change: assigning a player to a lineup slot is
+        // a fact about the slot. playerInfo is not a parameter any more, so
+        // there is no way to write to it even by accident.
+        expect(addPlayerToRoster.length).toBe(1);
+        expect(Object.keys(addPlayerToRoster({ player: makePlayer(), rosterSlots: slots('RB') }))).toEqual([
+            'rosterSlots',
+        ]);
     });
 });
 
 describe('removePlayerFromLineup', () => {
-    it('restores the roster slot to the remembered roster_text, so the player no longer occupies a lineup slot', () => {
-        const playerInfo = {
-            1001: { ...makePlayer(), roster_text: 'RB' },
-        };
-        const rosterPositions = ['QB', '1001', 'WR', 'FLX', 'BN'];
-        const result = removePlayerFromLineup({ id: '1001', i: 1, rosterPositions, playerInfo });
+    it('empties the slot while keeping its label', () => {
+        const filled = slots('QB', 'RB', 'WR');
+        filled[1] = { label: 'RB', playerId: '1001' };
 
-        expect(result.rosterPositions).toEqual(['QB', 'RB', 'WR', 'FLX', 'BN']);
-        // Lineup membership is derived (see rosterInfo.test.js's buildLineupSet
-        // coverage), not tracked on the player: the player id simply no longer
-        // appears among the roster positions.
-        expect(result.rosterPositions).not.toContain('1001');
+        const result = removePlayerFromLineup({ i: 1, rosterSlots: filled });
+
+        expect(result.rosterSlots[1]).toEqual({ label: 'RB', playerId: null });
+        // Nothing was looked up to restore the label: it never went away. The
+        // old implementation read it back off the player as roster_text, which
+        // is why it needed the player database at all.
+        expect(result.rosterSlots.map((slot) => slot.label)).toEqual(['QB', 'RB', 'WR']);
+    });
+
+    it('removes the player from the derived lineup membership', () => {
+        const filled = slots('QB', 'RB');
+        filled[1] = { label: 'RB', playerId: '1001' };
+
+        const result = removePlayerFromLineup({ i: 1, rosterSlots: filled });
+
+        expect(result.rosterSlots.some((slot) => slot.playerId === '1001')).toBe(false);
+    });
+
+    it('leaves other filled slots alone', () => {
+        const filled = slots('RB', 'RB');
+        filled[0] = { label: 'RB', playerId: '2002' };
+        filled[1] = { label: 'RB', playerId: '1001' };
+
+        const result = removePlayerFromLineup({ i: 1, rosterSlots: filled });
+
+        expect(result.rosterSlots[0].playerId).toEqual('2002');
     });
 
     it('does not mutate its inputs', () => {
-        const playerInfo = {
-            1001: { ...makePlayer(), roster_text: 'RB' },
-        };
-        const rosterPositions = ['QB', '1001', 'WR', 'FLX', 'BN'];
-        const clonedRosterPositions = structuredClone(rosterPositions);
-        const clonedPlayerInfo = structuredClone(playerInfo);
+        const filled = slots('QB', 'RB');
+        filled[1] = { label: 'RB', playerId: '1001' };
+        const clonedSlots = structuredClone(filled);
 
-        removePlayerFromLineup({ id: '1001', i: 1, rosterPositions, playerInfo });
+        removePlayerFromLineup({ i: 1, rosterSlots: filled });
 
-        expect(rosterPositions).toEqual(clonedRosterPositions);
-        expect(playerInfo).toEqual(clonedPlayerInfo);
+        expect(filled).toEqual(clonedSlots);
     });
 });

--- a/src/lib/rosterInfo.js
+++ b/src/lib/rosterInfo.js
@@ -73,13 +73,14 @@ export function rosteredBy(rosterInfo, playerId) {
 
 /**
  * Builds the set of player ids currently occupying a lineup slot.
- * `rosterPositions` is a mixed array of bare position labels (e.g. 'QB',
- * 'FLX', 'SFLX') and player ids; Sleeper player ids are purely numeric
- * strings, while every position label contains at least one letter, so that
- * distinguishes the two without hardcoding a position-label table.
+ *
+ * This used to sniff a mixed array of labels and ids apart with a
+ * `/^\d+$/` test, on the reasoning that Sleeper player ids are purely numeric
+ * while every position label contains a letter. That inference is gone: a slot
+ * carries its occupant in a field, so occupancy is read rather than guessed.
  */
-export function buildLineupSet(rosterPositions) {
-    return new Set(rosterPositions.filter((entry) => /^\d+$/.test(entry)));
+export function buildLineupSet(rosterSlots) {
+    return new Set(rosterSlots.filter((slot) => slot.playerId !== null).map((slot) => slot.playerId));
 }
 
 /**

--- a/src/lib/rosterInfo.test.js
+++ b/src/lib/rosterInfo.test.js
@@ -179,16 +179,37 @@ describe('buildRosterInfo — derived from draft picks', () => {
 });
 
 describe('in_lineup derivation', () => {
-    it('treats a player as in the lineup exactly when their id fills a roster slot', () => {
-        const lineup = buildLineupSet(['QB', '11435', 'RB', 'FLX', '13274']);
+    const slot = (label, playerId = null) => ({ label, playerId });
+
+    it('treats a player as in the lineup exactly when their id fills a slot', () => {
+        const lineup = buildLineupSet([
+            slot('QB'),
+            slot('RB', '11435'),
+            slot('RB'),
+            slot('FLX'),
+            slot('SFLX', '13274'),
+        ]);
         expect(isInLineup(lineup, '11435')).toBe(true);
         expect(isInLineup(lineup, '13274')).toBe(true);
         expect(isInLineup(lineup, '13279')).toBe(false);
     });
 
-    it('does not treat bare position labels as player ids', () => {
-        const lineup = buildLineupSet(['QB', 'RB', 'WR', 'TE', 'FLX', 'SFLX']);
+    it('counts no one as in the lineup when every slot is empty', () => {
+        // This used to be a test that bare position labels were not mistaken
+        // for player ids, which was a real hazard while labels and ids shared
+        // one array. A slot now carries its occupant in its own field, so the
+        // question is occupancy rather than what a string looks like.
+        const lineup = buildLineupSet(['QB', 'RB', 'WR', 'TE', 'FLX', 'SFLX'].map((label) => slot(label)));
         expect(lineup.size).toBe(0);
+    });
+
+    it('does not treat a label as an occupant even when it looks like an id', () => {
+        // Nothing rules out a future position label being numeric; the old
+        // regex-based derivation would have counted one as a player.
+        const lineup = buildLineupSet([slot('2'), slot('QB', '11435')]);
+        expect(lineup.size).toBe(1);
+        expect(isInLineup(lineup, '11435')).toBe(true);
+        expect(isInLineup(lineup, '2')).toBe(false);
     });
 
     it('handles an empty lineup', () => {


### PR DESCRIPTION
Second of two PRs removing the last writes into the shared player database, following #112. Tests **145 → 151**.

`rosterPositions` was one array holding *either* a position label or a player id at each index, so filling a slot **overwrote its label**. `roster_text` existed only to remember the label that had been overwritten — and it lived on the player, in the shared player database, because there was nowhere else to put it.

Slots are now `{ label, playerId }`. The label is never destroyed, so there is nothing to remember.

| | Before | After |
|---|---|---|
| Slot label | overwritten on fill, stashed as `roster_text` on the player | lives on the slot |
| `buildLineupSet` | `/^\d+$/` to sniff ids from labels | reads `slot.playerId` |
| `removePlayerFromLineup` | `(id, i, rosterPositions, playerInfo)` | `(i, rosterSlots)` |
| `addPlayerToRoster` | took and returned `playerInfo` | slots only |

**Nothing writes to the player database any more.** #95 removed `is_taken`/`rostered_by`, #112 the derived-positions cache, this one `roster_text`.

The regex was also wrong in principle, not just unnecessary: nothing rules out a numeric position label, and the old derivation would have counted one as a player. There's now a test for that.

## A behaviour improvement that falls out

A slot holding a player id **missing from the player database** (a retired player dropped from it) used to render the raw id and could not be cleared, because the click handler keyed off the lookup rather than the id. It keys off the id now, so such a slot shows its label and can be emptied.

## Sabotage verification

| Sabotage | Result |
|---|---|
| `addPlayerToRoster` matches on label only, ignoring occupancy | 2 failed |
| `removePlayerFromLineup` clears the label as well as the occupant | 1 failed |
| `buildLineupSet` counts empty slots as occupied | 2 failed |
| `buildLineupSet` reads the label instead of the occupant | 3 failed |
| `toRosterSlots` stops dropping bench slots | 1 failed |
| LeaguePanel passes the wrong slot index to `removeFromLineup` | 1 failed |
| LeaguePanel renders the occupant's position instead of the slot label | **passed at first — see below** |

### The one that exposed a bad fixture

Rendering `player.position` instead of `slot.label` left all 151 tests green. The reason was my own test data: I'd put a **WR in a WR slot**, so the two values were identical and the assertion proved nothing. That is precisely the repro trap the flag-staleness work documented — natural-looking data where the right and wrong answers coincide.

The whole point of the slot label is that a player can occupy a slot whose label *isn't* their position. I changed the fixture to a **FLX holding a WR**, and the sabotage now fails. The test additionally asserts the two disagree: the row's CSS class comes from the occupant's position (that's what colours it) while the visible label comes from the slot.

## Browser verification

Reproduced that exact case against the live API rather than trusting the fixture. The TBD lineup has two WR slots; I ranked three WRs and added all three:

```
WR  Bryce Ford-Wheaton   class="WR"
WR  Germie Bernard       class="WR"
FLX Carnell Tate         class="WR"   <- label and position disagree, both correct
```

Then clicked the FLX slot: restored to bare `FLX`, and Carnell Tate's button in the ranks panel went from `Added`/disabled back to `Add` while the other two stayed `Added`. Zero console errors.

## Gates

`npm ci`, `lint` (0 problems), `format:check`, `typecheck`, `test:run` (151 pass), `build` — all green. Bundle 340.20 → 339.91 kB.