### PR TITLE
Fix two small display and diagnostic bugs

### DIFF
--- a/src/Components/Header.jsx
+++ b/src/Components/Header.jsx
@@ -27,9 +27,19 @@ const Header = ({ signedIn, signedInEmail, lastUpdate, onSignIn, onSignOut }) =>
                     <Button text="Sign in" onClick={onSignIn} btnStyle="primary" />
                 )}
             </div>
-            <p className="latest-update">
-                <i>Latest player DB update attempt: {new Date(lastUpdate).toString()}</i>
-            </p>
+            {/*
+                Rendered only once there is a timestamp. `lastUpdate` starts as
+                null and the request for it is deliberately not awaited, so
+                this used to spend the first moments of every load showing
+                `new Date(null).toString()` - "Wed Dec 31 1969". It also stays
+                hidden if that request fails, which is honest: an absent line
+                beats a confidently wrong date.
+            */}
+            {lastUpdate ? (
+                <p className="latest-update">
+                    <i>Latest player DB update attempt: {new Date(lastUpdate).toString()}</i>
+                </p>
+            ) : null}
         </>
     );
 };

--- a/src/Components/Header.test.jsx
+++ b/src/Components/Header.test.jsx
@@ -57,4 +57,17 @@ describe('Header', () => {
             new Date(LAST_UPDATE).toString(),
         );
     });
+
+    it('shows no timestamp line at all until there is a timestamp', () => {
+        // lastUpdate starts null and its request is deliberately not awaited,
+        // so this state is on screen during every load. `new Date(null)` is the
+        // epoch, which rendered as a confident "Wed Dec 31 1969".
+        renderHeader({ lastUpdate: null });
+
+        expect(screen.queryByText(/Latest player DB update attempt:/)).toBeNull();
+        expect(screen.queryByText(/1969/)).toBeNull();
+        // The rest of the header still renders - the missing timestamp costs
+        // one line, not the sign-in control.
+        expect(screen.getByRole('button', { name: 'Sign in' })).toBeTruthy();
+    });
 });

--- a/src/lib/http.js
+++ b/src/lib/http.js
@@ -5,7 +5,12 @@
  */
 export function checkErrors(response) {
     if (!response.ok) {
-        throw new Error(response.statusText, response.status);
+        // The status goes in the message, not in a second argument. Error's
+        // second parameter is an options object (`{ cause }`), so passing a
+        // number there discarded it silently - and the status is often the
+        // only thing distinguishing a 404 from a 500 in the logged output,
+        // since statusText is routinely empty over HTTP/2.
+        throw new Error(response.status ? `${response.status} ${response.statusText}` : response.statusText);
     }
     return response;
 }

--- a/src/lib/http.test.js
+++ b/src/lib/http.test.js
@@ -19,6 +19,25 @@ describe('checkErrors', () => {
         expect(() => checkErrors({ ok: false, status: 404, statusText: 'Not Found' })).toThrow('Not Found');
     });
 
+    it('puts the status in the message, where the catch handlers will log it', () => {
+        // It used to be passed as Error's second argument, which is an options
+        // object - so it was discarded and every failure logged the same way.
+        expect(() => checkErrors({ ok: false, status: 500, statusText: 'Internal Server Error' })).toThrow(
+            '500 Internal Server Error',
+        );
+    });
+
+    it('omits a missing status rather than printing "undefined"', () => {
+        // statusText is routinely empty over HTTP/2 and some responses carry no
+        // status at all; neither should produce a message with undefined in it.
+        try {
+            checkErrors({ ok: false, statusText: 'Gateway Timeout' });
+            throw new Error('checkErrors did not throw');
+        } catch (error) {
+            expect(error.message).toBe('Gateway Timeout');
+        }
+    });
+
     it('treats any falsy ok as a failure, not just an explicit false', () => {
         expect(() => checkErrors({ ok: undefined, statusText: 'Gateway Timeout' })).toThrow();
     });


### PR DESCRIPTION
Both were flagged during the App refactor and deliberately kept out of it, since each is a behaviour change rather than a move. Tests **151 → 154**.

## 1. `checkErrors` discarded the HTTP status

`new Error(response.statusText, response.status)` — Error's second parameter is an options object (`{ cause }`), so the status went nowhere. It's in the message now, guarded so a response carrying no status doesn't produce `"undefined Gateway Timeout"`. Both halves can legitimately be missing: `statusText` is routinely empty over HTTP/2.

This matters because every `.catch` in the app logs that message, and without the status a 404 and a 500 were indistinguishable in the output.

## 2. The header displayed the epoch as a real date

`new Date(lastUpdate).toString()` rendered unconditionally, and `lastUpdate` starts `null` — so the header could show a confident **"Wed Dec 31 1969"**. The line now renders only once there's a timestamp, which also means it stays hidden if the request fails rather than showing a wrong date.

## Sabotage verification

| Sabotage | Result |
|---|---|
| Status back in Error's second argument (the original bug) | 1 failed |
| Status interpolated unconditionally | 1 failed |
| Timestamp line renders unconditionally again (the 1969 bug) | 1 failed |
| Whole timestamp line dropped | 1 failed |

## Browser verification — and what it could not show

Steady state is correct: the timestamp renders properly, `1969` appears nowhere on the page, app loads fully, zero console errors.

**I could not reproduce the transient window in the browser, and checked rather than assumed.** I reverted `Header.jsx` to the buggy version, armed a `MutationObserver` for an epoch date, and reloaded — it never fired. The reason is timing: the `lastUpdate` request is fired early and deliberately unawaited, while the header only mounts after the initial full-page loader clears, which waits on the entire league chain. On a fast connection the timestamp has landed long before the header first renders.

So the bug's real-world impact is not the load flicker I originally described — it is the **failure** case: if that request fails, `lastUpdate` stays `null` forever and the old code showed "Wed Dec 31 1969" permanently. That state is covered by the new unit test, not by the browser check.

## Gates

`lint` (0 problems), `format:check`, `typecheck`, `test:run` (154 pass), `build` — all green.