### PR TITLE
Show a retryable error instead of a blank page when the league load fails

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -91,6 +91,24 @@
     flex-direction: column;
 }
 
+.error-banner {
+    background-color: #283245;
+    border-radius: 10px;
+    border-left: 4px solid #d9534f;
+    margin: 8px 3px 3px 3px;
+    padding: 12px 15px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.error-banner p {
+    margin: 0px;
+}
+
 .search {
     display: flex;
     flex-direction: column;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import './App.css';
 import './loader.css';
+import ErrorBanner from './Components/ErrorBanner';
 import Header from './Components/Header';
 import LeaguePanel from './Panels/LeaguePanel';
 import RanksPanel from './Panels/RanksPanel';
@@ -29,6 +30,8 @@ import { SLEEPER_USER_ID } from './urls.js';
 // startLoad and then comparing against that same literal coming back down as a
 // prop. The panels now receive a plain boolean and no longer share a
 // vocabulary with App at all, so these names stay private to this file.
+const LEAGUE_LOAD_FAILED = "Couldn't load your league data. The Sleeper API may be unavailable.";
+
 const LOADING = {
     NONE: 'none',
     INITIAL: 'initial',
@@ -39,7 +42,8 @@ const LOADING = {
 class App extends React.Component {
     state = {
         playerInfo: {},
-        leagueData: [],
+        leagueData: {},
+        loadError: null,
         loading: LOADING.INITIAL,
         rankingPlayersIdsList: [],
         leagueID: '1312088290526003200',
@@ -105,7 +109,12 @@ class App extends React.Component {
         const season = this.state.season || (await fetchLeagueSeason());
         const leagueData = await fetchLeagueBundle({ leagueID: this.state.leagueID, season });
         if (!leagueData) {
-            this.setState({ season, loading: LOADING.NONE });
+            // Both panels read league data unconditionally - LeaguePanel goes
+            // straight for currentLeague.name - so there is nothing to render
+            // them from and no partial view worth showing. Before this the app
+            // fell through to a render with leagueData still empty and threw,
+            // leaving a blank page.
+            this.setState({ season, loading: LOADING.NONE, loadError: LEAGUE_LOAD_FAILED });
             return;
         }
 
@@ -113,6 +122,7 @@ class App extends React.Component {
         this.setState({
             season,
             leagueData,
+            loadError: null,
             loading: LOADING.LEAGUE_PANEL,
             myDisplayName: resolveMyDisplayName(leagueData.managerData, SLEEPER_USER_ID),
             rosterSlots: toRosterSlots(leagueData.currentLeague.roster_positions),
@@ -167,6 +177,14 @@ class App extends React.Component {
                 }
             });
         });
+    };
+
+    // Retries only the league load, not the whole app: the player database is
+    // already in memory and is not what failed. The full-page loader comes back
+    // because both panels are hidden while there is no league data, so there is
+    // nowhere for a panel-level spinner to appear.
+    retryLeagueLoad = () => {
+        this.setState({ loadError: null, loading: LOADING.INITIAL }, () => this.loadLeague(this.state.playerInfo));
     };
 
     updateLeagueID = (leagueID) => {
@@ -268,6 +286,7 @@ class App extends React.Component {
             leagueData,
             notFoundPlayers,
             leagueID,
+            loadError,
             signedIn,
             signedInEmail,
             myDisplayName,
@@ -289,34 +308,37 @@ class App extends React.Component {
                         onSignIn={this.googleSignIn}
                         onSignOut={this.signOut}
                     />
-                    <div className="main-container">
-                        <RanksPanel
-                            isLoading={loading === LOADING.RANKS_PANEL}
-                            signedIn={signedIn}
-                            playerInfo={playerInfo}
-                            rosterInfo={rosterInfo}
-                            updateRankingPlayersIdsList={this.updateRankingPlayersIdsList}
-                            startLoad={this.startLoad}
-                            addToRoster={this.addToRoster}
-                            updatePlayerId={this.updatePlayerId}
-                            notFoundPlayers={notFoundPlayers}
-                            rankingPlayersIdsList={rankingPlayersIdsList}
-                            myDisplayName={myDisplayName}
-                            lineupSet={lineupSet}
-                        />
-                        <LeaguePanel
-                            leagueData={leagueData}
-                            leagueID={leagueID}
-                            updateLeagueID={this.updateLeagueID}
-                            rankingPlayersIdsList={rankingPlayersIdsList}
-                            rosterSlots={rosterSlots}
-                            playerInfo={playerInfo}
-                            rosterInfo={rosterInfo}
-                            isLoading={loading === LOADING.LEAGUE_PANEL}
-                            removeFromLineup={this.removeFromLineup}
-                            updateDraftBoard={this.updateDraftBoard}
-                        />
-                    </div>
+                    {loadError ? <ErrorBanner message={loadError} onRetry={this.retryLeagueLoad} /> : null}
+                    {!loadError && leagueData.currentLeague ? (
+                        <div className="main-container">
+                            <RanksPanel
+                                isLoading={loading === LOADING.RANKS_PANEL}
+                                signedIn={signedIn}
+                                playerInfo={playerInfo}
+                                rosterInfo={rosterInfo}
+                                updateRankingPlayersIdsList={this.updateRankingPlayersIdsList}
+                                startLoad={this.startLoad}
+                                addToRoster={this.addToRoster}
+                                updatePlayerId={this.updatePlayerId}
+                                notFoundPlayers={notFoundPlayers}
+                                rankingPlayersIdsList={rankingPlayersIdsList}
+                                myDisplayName={myDisplayName}
+                                lineupSet={lineupSet}
+                            />
+                            <LeaguePanel
+                                leagueData={leagueData}
+                                leagueID={leagueID}
+                                updateLeagueID={this.updateLeagueID}
+                                rankingPlayersIdsList={rankingPlayersIdsList}
+                                rosterSlots={rosterSlots}
+                                playerInfo={playerInfo}
+                                rosterInfo={rosterInfo}
+                                isLoading={loading === LOADING.LEAGUE_PANEL}
+                                removeFromLineup={this.removeFromLineup}
+                                updateDraftBoard={this.updateDraftBoard}
+                            />
+                        </div>
+                    ) : null}
                 </div>
             );
         }

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import App from './App';
 import rosterFlagsFixture from './lib/__fixtures__/roster-flags-2026.json';
@@ -24,12 +24,13 @@ vi.mock('./firebase.js', () => ({
     googleProvider: {},
 }));
 
-const authMockState = vi.hoisted(() => ({ unsubscribe: null }));
+const authMockState = vi.hoisted(() => ({ unsubscribe: null, callback: null }));
 
 vi.mock('firebase/auth', () => ({
     onAuthStateChanged: vi.fn((auth, callback) => {
         // Simplest path: report an already-signed-in (anonymous) user
         // immediately, so App skips the signInAnonymously branch entirely.
+        authMockState.callback = callback;
         callback({ uid: 'test-uid', isAnonymous: true });
         authMockState.unsubscribe = vi.fn();
         return authMockState.unsubscribe;
@@ -404,6 +405,138 @@ describe('App', () => {
         } finally {
             vi.restoreAllMocks();
         }
+    });
+
+    it('shows a retryable error instead of a blank page when the league load fails', async () => {
+        // Nothing covered a failed league bundle, and the app rendered a blank
+        // page: loadLeague bailed to LOADING.NONE, render ran with leagueData
+        // still empty, and buildRosterInfo threw on undefined rosterData.
+        // Before the load chain was reworked this was an infinite spinner
+        // instead - bad, but not a white screen.
+        const rejections = [];
+        const recordRejection = (reason) => rejections.push(reason);
+        process.on('unhandledRejection', recordRejection);
+
+        try {
+            global.fetch = vi.fn((url) => {
+                if (/league\/\d+\//.test(url) || url.includes('leagues/nfl/')) {
+                    return Promise.reject(new Error('Sleeper unavailable'));
+                }
+                return mockFetch(url);
+            });
+
+            const { container } = render(<App />);
+
+            const alert = await screen.findByRole('alert', {}, { timeout: 5000 });
+            expect(alert.textContent).toMatch(/Couldn't load your league data/);
+            expect(screen.getByRole('button', { name: 'Retry' })).toBeTruthy();
+
+            // The page is not blank and not stuck on a spinner.
+            expect(screen.getByText('Sleeper Team Assistant')).toBeTruthy();
+            expect(container.querySelector('.loader')).toBeNull();
+            await new Promise((resolve) => setTimeout(resolve, 0));
+            expect(rejections).toEqual([]);
+        } finally {
+            process.off('unhandledRejection', recordRejection);
+        }
+    });
+
+    it('does not render the panels when there is no league data to render them from', async () => {
+        // LeaguePanel reads leagueData.currentLeague.name unconditionally, so
+        // "render the panels anyway" is not an option - this is why the banner
+        // replaces them rather than sitting above them.
+        global.fetch = vi.fn((url) => {
+            if (/league\/\d+\//.test(url) || url.includes('leagues/nfl/')) {
+                return Promise.reject(new Error('Sleeper unavailable'));
+            }
+            return mockFetch(url);
+        });
+
+        const { container } = render(<App />);
+        await screen.findByRole('alert', {}, { timeout: 5000 });
+
+        expect(container.querySelector('.main-container')).toBeNull();
+        expect(screen.queryByPlaceholderText('Copy + Paste rankings here...')).toBeNull();
+    });
+
+    it('replaces the panels rather than leaving a board that disagrees with the dropdown', async () => {
+        // A league switch that fails leaves the previous league's data in
+        // state. Rendering the panels from it would show one league's board
+        // under a dropdown reading another - the same confidently-wrong shape
+        // the banner exists to avoid. So the banner replaces the panels
+        // whenever a load has failed, not only when there is nothing to render.
+        global.fetch = vi.fn(mockFetch);
+        const user = userEvent.setup();
+        render(<App />);
+        await screen.findAllByText('ryangh', {}, { timeout: 5000 });
+        expect(screen.getByDisplayValue('Test League')).toBeTruthy();
+
+        global.fetch = vi.fn((url) => {
+            if (url.includes(OTHER_LEAGUE_ID)) {
+                return Promise.reject(new Error('Sleeper unavailable'));
+            }
+            return mockFetch(url);
+        });
+        await user.selectOptions(screen.getByDisplayValue('Test League'), OTHER_LEAGUE_ID);
+
+        await screen.findByRole('alert', {}, { timeout: 5000 });
+        expect(document.querySelector('.main-container')).toBeNull();
+    });
+
+    it('recovers when Retry succeeds', async () => {
+        // Only the league load is retried; the player database is already in
+        // memory and is not what failed.
+        let failLeague = true;
+        global.fetch = vi.fn((url) => {
+            if (failLeague && (/league\/\d+\//.test(url) || url.includes('leagues/nfl/'))) {
+                return Promise.reject(new Error('Sleeper unavailable'));
+            }
+            return mockFetch(url);
+        });
+
+        const user = userEvent.setup();
+        render(<App />);
+        await screen.findByRole('alert', {}, { timeout: 5000 });
+
+        const playerDbRequestsBefore = global.fetch.mock.calls.filter((call) =>
+            call[0].includes('legacy/players'),
+        ).length;
+
+        failLeague = false;
+        await user.click(screen.getByRole('button', { name: 'Retry' }));
+
+        await screen.findAllByText('ryangh', {}, { timeout: 5000 });
+        expect(screen.queryByRole('alert')).toBeNull();
+
+        expect(global.fetch.mock.calls.filter((call) => call[0].includes('legacy/players')).length).toBe(
+            playerDbRequestsBefore,
+        );
+    });
+
+    it('clears the error when a load triggered by anything other than Retry succeeds', async () => {
+        // Retry clears the banner itself, so the clear on the success path is
+        // only observable through the other caller: the auth callback, which
+        // re-runs loadLeague whenever auth state changes - signing in, for
+        // instance. Without it the banner would sit on screen next to a fully
+        // working set of panels.
+        let failLeague = true;
+        global.fetch = vi.fn((url) => {
+            if (failLeague && (/league\/\d+\//.test(url) || url.includes('leagues/nfl/'))) {
+                return Promise.reject(new Error('Sleeper unavailable'));
+            }
+            return mockFetch(url);
+        });
+
+        render(<App />);
+        await screen.findByRole('alert', {}, { timeout: 5000 });
+
+        failLeague = false;
+        await act(async () => {
+            authMockState.callback({ uid: 'test-uid', isAnonymous: true });
+        });
+
+        await screen.findAllByText('ryangh', {}, { timeout: 5000 });
+        expect(screen.queryByRole('alert')).toBeNull();
     });
 
     it('unsubscribes from auth state changes on unmount', async () => {

--- a/src/Components/ErrorBanner.jsx
+++ b/src/Components/ErrorBanner.jsx
@@ -1,0 +1,15 @@
+import Button from './Button';
+
+// Shown in place of the panels when there is no league data to render them
+// from. Deliberately blocking rather than a dismissible toast: both panels
+// read league data unconditionally, so there is nothing useful behind it.
+const ErrorBanner = ({ message, onRetry }) => {
+    return (
+        <div className="error-banner" role="alert">
+            <p>{message}</p>
+            <Button text="Retry" btnStyle="primary" onClick={onRetry} />
+        </div>
+    );
+};
+
+export default ErrorBanner;

--- a/src/lib/rosterInfo.js
+++ b/src/lib/rosterInfo.js
@@ -27,7 +27,10 @@ export function decorateRosters({ rosterData, managerData }) {
 export function buildRosterInfo({ rosterData, builtDraft }) {
     const rosterInfo = new Map();
 
-    rosterData.forEach((roster) => {
+    // Missing roster data is a real state, not a caller error: it is what the
+    // app holds before the first load finishes and after one that failed.
+    // Nobody is rostered in that case, which is exactly what an empty map says.
+    (rosterData || []).forEach((roster) => {
         if (!roster.players) {
             return;
         }


### PR DESCRIPTION
Tests **151 → 156**, five of them covering the failed-league paths, which had **no coverage at all**.

## This fixes a regression I introduced in #110

A failed league bundle rendered a **blank page**. `loadLeague` bailed to `LOADING.NONE`, `render` then ran with `leagueData` still empty, and `buildRosterInfo` threw on `undefined` rosterData before anything reached the DOM.

I confirmed it's a regression rather than assuming, by running the same probe against both commits:

| | League fetch fails |
|---|---|
| Before #110 (`39cde55`) | full-page loader stays up — infinite spinner |
| After #110 | **blank page** + `TypeError: ... reading 'forEach'` |

Bailing out of the load was the right call; letting render continue with no data was not. An infinite spinner became a white screen.

## The fix

Both panels read league data unconditionally — `LeaguePanel` goes straight for `currentLeague.name` — so there is no partial view worth rendering. An `ErrorBanner` takes their place with a Retry button.

**The banner replaces the panels whenever a load has failed, not only when there's nothing to render.** This came out of the browser check: a failed league *switch* leaves the previous league's data in state, and my first implementation rendered the panels from it — showing one league's board under a dropdown reading another. That's the same confidently-wrong shape the banner exists to avoid, so it now takes precedence in both cases.

**Retry re-runs only the league load.** The player database is already in memory and isn't what failed; refetching it would mean a large download to fix an unrelated request. Asserted in both a unit test and the browser.

Also: `buildRosterInfo` treats missing rosterData as "nobody is rostered" rather than throwing — a real state, before the first load and after a failed one. And App's initial `leagueData` was `[]` despite every use treating it as an object.

## Sabotage verification

| Sabotage | Result |
|---|---|
| `buildRosterInfo` guard removed (the actual crash) | 3 failed |
| `loadLeague` bails without recording the error | 3 failed |
| Panels render even without league data | 3 failed |
| Retry reloads everything, including the player database | 1 failed |
| The error is never cleared on a successful load | **passed at first — see below** |

The last one initially passed because Retry clears the error itself, so the clear on the success path looked redundant. It isn't: the auth callback re-runs `loadLeague` on any auth-state change (signing in, for instance), and without it the banner would sit on screen beside fully working panels. Added a test that drives exactly that path; the sabotage now fails.

## Browser verification

Drove the real failure by patching `window.fetch` in-page to reject Sleeper league requests, so the whole flow ran against the real app:

- Failed initial load (via a temporarily invalid API host): banner renders under the header, panels absent, no spinner — screenshot below
- Failed league *switch*: banner replaces the panels rather than leaving a stale board
- Cleared the outage, clicked **Retry**: banner gone, board loaded as **4 QB Madness** (the league that had been selected), 32 picks / 6 traded correct for that 8-team league, and **0 player-database refetches**

## Gates

`npm ci`, `lint` (0 problems), `format:check`, `typecheck`, `test:run` (156 pass), `build` — all green.