### PR TITLE
Stop the draft board crashing on a failed sync or an unknown player

### DIFF
--- a/src/Panels/DraftPanel.jsx
+++ b/src/Panels/DraftPanel.jsx
@@ -37,12 +37,26 @@ const DraftPanel = ({ leagueData, playerInfo, rosterInfo, rankingPlayersIdsList,
                 console.error('Error:', error);
             });
 
-        // Applied against the board as it stands when the update runs, not the
-        // one this closure captured before the two awaits above: a manual pick
-        // assigned while they were in flight would otherwise be discarded.
+        // Both fetches resolve to undefined on failure, and syncLiveDraft's
+        // helpers forEach over their lists unguarded - so an unsubstituted
+        // failure threw and took the board down. That is worse here than
+        // anywhere else in the app: this runs on the 3-second poll during a
+        // live draft, so one network blip killed the board and the poll kept
+        // firing into the wreckage.
+        //
+        // Substituting an empty list rather than bailing out is deliberate. It
+        // makes the failed half a no-op - applyLivePicks fills picks in and
+        // applyTradedPicks only ever sets owner_id, neither clears anything -
+        // so the board keeps what it already had while the half that succeeded
+        // still lands. Bailing would discard a good live pick because an
+        // unrelated traded-picks request failed.
         updateDraftBoard(
             (builtDraft) =>
-                syncLiveDraft({ liveDraft: { built_draft: builtDraft }, livePicks, tradedPicks }).built_draft,
+                syncLiveDraft({
+                    liveDraft: { built_draft: builtDraft },
+                    livePicks: livePicks || [],
+                    tradedPicks: tradedPicks || [],
+                }).built_draft,
         );
     };
 

--- a/src/Panels/DraftPanel.test.jsx
+++ b/src/Panels/DraftPanel.test.jsx
@@ -207,6 +207,102 @@ describe('DraftPanel', () => {
         expect(next.find((round) => round.round === 2)).toBe(builtDraft.find((round) => round.round === 2));
     });
 
+    // Both live-sync fetches swallow their failure and resolve to undefined, and
+    // syncLiveDraft's helpers forEach over the result - so before the guard in
+    // getLiveDraft either failure threw `Cannot read properties of undefined
+    // (reading 'forEach')`. That fires on the 3-second poll as well as the
+    // button, so a single blip mid-draft killed the board and the poll kept
+    // running. What matters is not just that nothing throws, but that the half
+    // that succeeded still reaches the board: bailing out entirely would also
+    // stop the crash while quietly dropping a live pick.
+    //
+    // These run against a board with the trades stripped back out. The shared
+    // builtDraft fixture already has all 21 traded picks applied, so asserting
+    // an owner_id the fixture ships with passes whether or not applyTradedPicks
+    // ever ran.
+    const pristineBoard = () =>
+        builtDraft.map((round) => ({
+            ...round,
+            picks: round.picks.map((pick) => ({ ...pick, is_traded: false, owner_id: pick.roster_id })),
+        }));
+
+    const failing = (shouldFail) =>
+        vi.fn((url) => (shouldFail(url) ? Promise.reject(new Error('network blip')) : instantFetch(url)));
+
+    const livePicksFail = (url) => url.includes('picks/') && !url.includes('traded_picks');
+
+    it('still applies traded picks when the live-picks request fails', async () => {
+        global.fetch = failing(livePicksFail);
+        const { updateDraftBoard } = renderPanel();
+
+        await click(button('Update'));
+        await settle(0);
+
+        expect(updateDraftBoard).toHaveBeenCalledTimes(1);
+        const next = updateDraftBoard.mock.calls[0][0](pristineBoard());
+
+        // Round 2 / roster 2 goes to owner 6 in the tradedPicks fixture, and
+        // starts at owner 2 on the pristine board.
+        const traded = next.find((round) => round.round === 2).picks.find((pick) => pick.roster_id === 2);
+        expect(traded.owner_id).toBe(6);
+        expect(traded.is_traded).toBe(true);
+        // No live picks landed, and the board was not blanked to compensate.
+        expect(next.find((round) => round.round === 1).picks.every((pick) => pick.player_id === null)).toBe(true);
+        expect(next.flatMap((round) => round.picks).length).toBe(builtDraft.flatMap((round) => round.picks).length);
+    });
+
+    it('still applies live picks when the traded-picks request fails', async () => {
+        global.fetch = failing((url) => url.includes('traded_picks'));
+        const { updateDraftBoard } = renderPanel();
+
+        await click(button('Update'));
+        await settle(0);
+
+        expect(updateDraftBoard).toHaveBeenCalledTimes(1);
+        const next = updateDraftBoard.mock.calls[0][0](pristineBoard());
+
+        const firstPick = next.find((round) => round.round === 1).picks.find((pick) => pick.board_spot === 1);
+        expect(firstPick.player_id).toBe('13287');
+        expect(firstPick.picked).toBe(true);
+        // Nothing claimed a trade off the back of a failed request.
+        expect(next.every((round) => round.picks.every((pick) => !pick.is_traded))).toBe(true);
+    });
+
+    it('keeps polling after a failed sync rather than dying on the first blip', async () => {
+        let calls = 0;
+        // Fails the first live-picks request only; the poll must survive it and
+        // recover on a later tick.
+        global.fetch = vi.fn((url) => {
+            if (livePicksFail(url)) {
+                calls += 1;
+                if (calls === 1) {
+                    return Promise.reject(new Error('network blip'));
+                }
+            }
+            return instantFetch(url);
+        });
+        const { updateDraftBoard } = renderPanel();
+
+        await click(button('Sync draft'));
+        await settle(0);
+        await settle(3000);
+        await settle(3000);
+
+        expect(updateDraftBoard.mock.calls.length).toBeGreaterThanOrEqual(3);
+
+        // Every reducer has to be applied, in order, starting with the one from
+        // the failed tick. updateDraftBoard is a mock here and never invokes
+        // what it is handed, so asserting only on the last tick's reducer would
+        // pass even with the guard removed - the throw would simply never
+        // happen. App's real updateDraftBoard is a setState updater and does
+        // invoke it, so folding them is what reproduces the live-draft path.
+        const board = updateDraftBoard.mock.calls.reduce((acc, [reducer]) => reducer(acc), pristineBoard());
+
+        expect(board.find((round) => round.round === 1).picks.find((pick) => pick.board_spot === 1).player_id).toBe(
+            '13287',
+        );
+    });
+
     it('syncs against the draft id typed into the input rather than the original one', async () => {
         renderPanel();
 

--- a/src/Panels/DraftRound.jsx
+++ b/src/Panels/DraftRound.jsx
@@ -43,56 +43,75 @@ const DraftRound = ({ round, playerInfo, rosterInfo, rosterData, rankingPlayersI
                     <h4 className="round-number clickable-item" onClick={() => setShowRound(!showRound)}>
                         Round {round.round}
                     </h4>
-                    {round.picks.map((pick) => (
-                        <div
-                            key={pick.pick_number}
-                            className={`draft-pick clickable-item ${!showRound ? 'is-hidden' : null}`}
-                            onClick={() => manualPickSelection(pick)}
-                        >
-                            <p className="pick-string">{`${round.round}.${pick.pick_number}`}</p>
-                            <div className="player-info-item draft-pick-rows">
-                                <div style={{ display: 'flex' }}>
-                                    <img
-                                        className="avatar"
-                                        src={`https://sleepercdn.com/avatars/thumbs/${
-                                            rosterData.find((roster) => roster.roster_id === pick.owner_id)?.avatar
-                                        }`}
-                                        alt="Users avatar"
-                                    />
-                                    <p className="draft-pick">
-                                        {pick.owner_id
-                                            ? rosterData.find((roster) => roster.roster_id === pick.owner_id)
-                                                  ?.manager_display_name
-                                            : 'Pick owner missing'}
-                                        {pick.is_traded && pick.roster_id !== pick.owner_id
-                                            ? ` via ${
-                                                  rosterData.find((roster) => roster.roster_id === pick.roster_id)
+                    {round.picks.map((pick) => {
+                        // The player database is a snapshot and a drafted player
+                        // can be absent from it. The className below already
+                        // allowed for that; the four reads under it did not, so
+                        // one unknown id threw on `.full_name` and took the whole
+                        // board down. Render the id itself rather than a blank
+                        // cell - that is what makes the gap diagnosable, and it
+                        // matches warnAboutMissingRosterPlayers, which logs the
+                        // same situation on the roster side.
+                        const player = playerInfo[pick.player_id];
+                        return (
+                            <div
+                                key={pick.pick_number}
+                                className={`draft-pick clickable-item ${!showRound ? 'is-hidden' : null}`}
+                                onClick={() => manualPickSelection(pick)}
+                            >
+                                <p className="pick-string">{`${round.round}.${pick.pick_number}`}</p>
+                                <div className="player-info-item draft-pick-rows">
+                                    <div style={{ display: 'flex' }}>
+                                        <img
+                                            className="avatar"
+                                            src={`https://sleepercdn.com/avatars/thumbs/${
+                                                rosterData.find((roster) => roster.roster_id === pick.owner_id)?.avatar
+                                            }`}
+                                            alt="Users avatar"
+                                        />
+                                        <p className="draft-pick">
+                                            {pick.owner_id
+                                                ? rosterData.find((roster) => roster.roster_id === pick.owner_id)
                                                       ?.manager_display_name
-                                              }`
-                                            : null}
-                                    </p>
-                                </div>
-                                {pick.player_id && (
-                                    <div
-                                        className={`${
-                                            playerInfo[pick.player_id] ? playerInfo[pick.player_id].position : null
-                                        } draft-pick-details`}
-                                    >
-                                        <span className="full-text" style={{ paddingRight: 3 + 'px' }}>
-                                            {playerInfo[pick.player_id].full_name}
-                                        </span>
-                                        <span className="abbr-text" style={{ paddingRight: 3 + 'px' }}>
-                                            {`${playerInfo[pick.player_id].first_name.split('')[0]}.${
-                                                playerInfo[pick.player_id].last_name
-                                            }`}{' '}
-                                        </span>
-                                        <p>{playerInfo[pick.player_id].team}</p>
-                                        <p>{playerInfo[pick.player_id].position}</p>
+                                                : 'Pick owner missing'}
+                                            {pick.is_traded && pick.roster_id !== pick.owner_id
+                                                ? ` via ${
+                                                      rosterData.find((roster) => roster.roster_id === pick.roster_id)
+                                                          ?.manager_display_name
+                                                  }`
+                                                : null}
+                                        </p>
                                     </div>
-                                )}
+                                    {pick.player_id && (
+                                        <div className={`${player ? player.position : null} draft-pick-details`}>
+                                            {player ? (
+                                                <>
+                                                    <span className="full-text" style={{ paddingRight: 3 + 'px' }}>
+                                                        {player.full_name}
+                                                    </span>
+                                                    <span className="abbr-text" style={{ paddingRight: 3 + 'px' }}>
+                                                        {`${player.first_name.split('')[0]}.${player.last_name}`}{' '}
+                                                    </span>
+                                                    <p>{player.team}</p>
+                                                    <p>{player.position}</p>
+                                                </>
+                                            ) : (
+                                                // Deliberately not `full-text`: that class is
+                                                // display:none in portrait, where `abbr-text`
+                                                // takes over. There is no abbreviated form of
+                                                // an unresolved id, so an unclassed span is
+                                                // what keeps the cell from going blank on a
+                                                // phone.
+                                                <span style={{ paddingRight: 3 + 'px' }}>
+                                                    {`Unknown player ${pick.player_id}`}
+                                                </span>
+                                            )}
+                                        </div>
+                                    )}
+                                </div>
                             </div>
-                        </div>
-                    ))}
+                        );
+                    })}
                 </div>
             </div>
             {showPickSelection && (

--- a/src/Panels/DraftRound.test.jsx
+++ b/src/Panels/DraftRound.test.jsx
@@ -56,6 +56,66 @@ const openPickModal = async (user, pickLabel) => {
     return screen.getByText(/^Manually select pick/).closest('div').parentElement;
 };
 
+// The player database is a snapshot - it is fetched wholesale and its last
+// update attempt reads Nov 2022 - so a drafted player can simply not be in it.
+// DraftRound already allowed for that when choosing the position className and
+// then read `.full_name` off the same lookup unconditionally on the next line,
+// so one unknown id threw and took the entire board down, not just that cell.
+describe('DraftRound with a player missing from the player database', () => {
+    const UNKNOWN_ID = '99999999';
+
+    const roundWithUnknownPick = () => ({
+        ...round,
+        picks: round.picks.map((pick, i) => (i === 0 ? { ...pick, player_id: UNKNOWN_ID, picked: true } : pick)),
+    });
+
+    it('renders the rest of the board instead of throwing', () => {
+        expect(playerInfo[UNKNOWN_ID]).toBeUndefined();
+
+        renderRound({ round: roundWithUnknownPick() });
+
+        // Every pick slot still rendered - the failure mode was the whole
+        // component throwing, so the count is the assertion that matters.
+        expect(document.querySelectorAll('.draft-pick.clickable-item').length).toBe(round.picks.length);
+        expect(screen.getByText(`Round ${round.round}`)).toBeInTheDocument();
+    });
+
+    it('shows the unresolved player id so the gap is diagnosable', () => {
+        renderRound({ round: roundWithUnknownPick() });
+
+        expect(screen.getByText(`Unknown player ${UNKNOWN_ID}`)).toBeInTheDocument();
+    });
+
+    it('renders the fallback outside the full-text/abbr-text pair', () => {
+        // `full-text` is display:none in portrait, where `abbr-text` replaces
+        // it. The first cut of this fix put the fallback in a `full-text` span,
+        // which rendered a blank cell on a phone - caught in the browser, not
+        // here, because jsdom applies no stylesheet and getByText found it
+        // regardless.
+        renderRound({ round: roundWithUnknownPick() });
+
+        const fallback = screen.getByText(`Unknown player ${UNKNOWN_ID}`);
+        expect(fallback.className).toBe('');
+    });
+
+    it('still renders known players on the same round normally', () => {
+        const knownId = Object.keys(playerInfo)[0];
+        const mixed = {
+            ...round,
+            picks: round.picks.map((pick, i) => {
+                if (i === 0) return { ...pick, player_id: UNKNOWN_ID, picked: true };
+                if (i === 1) return { ...pick, player_id: knownId, picked: true };
+                return pick;
+            }),
+        };
+
+        renderRound({ round: mixed });
+
+        expect(screen.getByText(`Unknown player ${UNKNOWN_ID}`)).toBeInTheDocument();
+        expect(screen.getByText(playerInfo[knownId].full_name)).toBeInTheDocument();
+    });
+});
+
 describe('DraftRound manual pick selection', () => {
     let user;
 


### PR DESCRIPTION
Two unguarded dereferences, both on the draft board. Both are the shape of #101, #103 and #115 — a swallowed failure resolves to `undefined`, then something reads a property off it. That is now five recurrences, so I grepped the tree for the rest of the pattern; the remainder are in `loadDraft`/`buildDraftRounds` and follow in a second PR.

### 1. Live sync died on either fetch failing

`getLiveDraft`'s two `.catch` handlers resolve to `undefined`, and `syncLiveDraft`'s helpers `forEach` over both lists. Either failure threw `Cannot read properties of undefined (reading 'forEach')`.

This is the worst of the set because of where it sits: the 3-second poll loop as well as the Update button. A single blip mid-draft took out the board and the poll kept firing into the wreckage.

Substituting an empty list rather than bailing out is deliberate — `applyLivePicks` only fills picks in and `applyTradedPicks` only sets `owner_id`, neither clears anything, so the failed half becomes a no-op while the half that succeeded still lands. Bailing would drop a good live pick because an unrelated traded-picks request failed.

### 2. The board died on a player missing from the player database

`DraftRound` checked `playerInfo[pick.player_id]` for the position className and then read `.full_name` off the same lookup on the next line — the author knew it could be missing. One unknown id took the whole board down rather than one cell. It now renders `Unknown player <id>`, matching what `warnAboutMissingRosterPlayers` already logs on the roster side. The player DB is a snapshot whose last update attempt reads Nov 2022, so this is reachable today.

## Sabotage results

| Sabotage | Result |
|---|---|
| Drop `\|\| []` in `getLiveDraft` | **3 failed** — both single-failure tests and the poll test |
| Make the `player ?` branch unconditional in `DraftRound` | **4 failed** — all the new missing-player tests |

One sabotage **passed** on the first run and is worth recording. `updateDraftBoard` is a `vi.fn()` in `DraftPanel.test.jsx`, so it never invokes the reducer it is handed — the throw simply never happened, and the poll test passed with the guard removed. App's real `updateDraftBoard` is a `setState` updater and does invoke it. The test now folds every recorded reducer over the board in order, which reproduces the live-draft path and fails under sabotage.

Two fixture traps also showed up. `builtDraft` ships with all 21 traded picks already applied, so asserting an `owner_id` the fixture already has passes whether or not `applyTradedPicks` ran — the live-sync tests run against a board with the trades stripped back out. And `.draft-pick` matches both the pick container and an inner `<p>`, so the "every slot still rendered" count needs `.draft-pick.clickable-item`.

## Browser check

Driven against the real app with `window.fetch` patched in-page.

| | picks before → after | errors |
|---|---|---|
| master, live-picks fetch rejects | 48 → **0** | `TypeError: Cannot read properties of undefined (reading 'forEach')` |
| this branch, live-picks rejects | 48 → 48 | none |
| this branch, both reject, 3 poll ticks (6 failed fetches) | 48 → 48 | none |
| this branch, live pick for an unknown id | 48 → 48, cell reads `Unknown player 99999999` | none |

The browser also caught something no unit test would have. The first cut put the fallback in a `full-text` span, which is `display: none` in portrait where `abbr-text` takes over — a blank cell on a phone. jsdom applies no stylesheet, so `getByText` found it regardless. The fallback is now unclassed, with a test asserting that.

Tests 159 → 166. Lint, `format:check`, `typecheck`, `build` all clean.