### PR TITLE
Check what buildDraftRounds actually needs before building a board

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -141,10 +141,32 @@ class App extends React.Component {
         // real object even when the request fails or the next render crashes
         // (#103).
         const currentDraft = draftData || { draft_id: draftId };
-        const built =
-            draftData && draftData.draft_order
-                ? buildDraftRounds({ currentDraft, rosterData: leagueData.rosterData, tradedDraftPicks })
-                : null;
+
+        // The old guard here checked `draft_order`, which buildDraftRounds never
+        // reads - it was standing in for "this is a real draft" rather than for
+        // what the builder actually needs. A response carrying draft_order but
+        // no settings threw on settings.player_type, and one with no
+        // slot_to_roster_id threw in createPickOrder. Check the two fields that
+        // are genuinely dereferenced instead.
+        const canBuild = Boolean(draftData && draftData.settings && draftData.slot_to_roster_id);
+        if (draftData && !canBuild) {
+            console.warn(`Draft ${draftId} is missing settings or slot_to_roster_id; rendering an empty board`);
+        }
+
+        // fetchTradedDraftPicks also resolves to undefined on failure, and
+        // buildDraftRounds forEaches over it. That took out the whole load
+        // chain: loadDraft threw, its setState never ran, and the app sat on
+        // the LEAGUE_PANEL loader forever. Trades are an overlay on a board
+        // that is perfectly renderable without them, so build without them.
+        // Note this is silent - the board looks authoritative while missing
+        // every trade - which is the tradeoff the follow-up notice addresses.
+        const built = canBuild
+            ? buildDraftRounds({
+                  currentDraft,
+                  rosterData: leagueData.rosterData,
+                  tradedDraftPicks: tradedDraftPicks || [],
+              })
+            : null;
 
         // Composed against prevState rather than the leagueData this call
         // captured. Note this is defensive, not load-bearing today: the only

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -539,6 +539,88 @@ describe('App', () => {
         expect(screen.queryByRole('alert')).toBeNull();
     });
 
+    // loadDraft's guard used to check `draft_order`, a field buildDraftRounds
+    // never reads. Everything the builder actually dereferences went unchecked,
+    // so a malformed or partly-failed draft response threw inside loadDraft -
+    // and because nothing catches it, the setState that clears the loader never
+    // ran and the app sat on the LEAGUE_PANEL spinner forever. These assert on
+    // what reaches the screen, since "it threw" and "it hung" look identical
+    // from a unit test of the builder alone.
+    describe('a draft response the board cannot be built from', () => {
+        const without = (key) => (draft) => {
+            const copy = { ...draft };
+            delete copy[key];
+            return copy;
+        };
+
+        const draftOverride = (transform) =>
+            vi.fn((url) => {
+                if (/draft\/[\w]+$/.test(url)) {
+                    return jsonResponse(
+                        transform({
+                            ...structuredClone(draftSettings),
+                            draft_id: DRAFT_ID,
+                            season: '2026',
+                            status: 'drafting',
+                            draft_order: {},
+                        }),
+                    );
+                }
+                return mockFetch(url);
+            });
+
+        const renderAndSettle = async () => {
+            render(<App />);
+            // The draft header renders from currentDraft regardless of whether a
+            // board could be built, so it is the signal that the load chain ran
+            // to completion rather than throwing partway.
+            // Scoped to the <b> header: the panel tab is also called "Draft".
+            return await screen.findByText(/Draft$/, { selector: 'b' }, { timeout: 5000 });
+        };
+
+        it('renders the panels when the draft response has no settings', async () => {
+            global.fetch = draftOverride(without('settings'));
+
+            await renderAndSettle();
+
+            expect(screen.getByDisplayValue(DRAFT_ID)).toBeInTheDocument();
+            // No board, but a live app rather than a permanent loader.
+            expect(document.querySelectorAll('.draft-pick.clickable-item').length).toBe(0);
+        });
+
+        it('renders the panels when the draft response has no slot_to_roster_id', async () => {
+            global.fetch = draftOverride(without('slot_to_roster_id'));
+
+            await renderAndSettle();
+
+            expect(screen.getByDisplayValue(DRAFT_ID)).toBeInTheDocument();
+            expect(document.querySelectorAll('.draft-pick.clickable-item').length).toBe(0);
+        });
+    });
+
+    it('builds the board without trades when the traded-picks request fails', async () => {
+        // fetchTradedDraftPicks resolves to undefined on failure and
+        // buildDraftRounds forEaches over it, so this used to throw inside
+        // loadDraft and hang the app on the loader. Trades are an overlay on a
+        // board that renders fine without them.
+        global.fetch = vi.fn((url) => {
+            if (/draft\/[\w]+\/traded_picks\//.test(url)) {
+                return Promise.reject(new Error('simulated traded_picks failure'));
+            }
+            return mockFetch(url);
+        });
+
+        render(<App />);
+        await screen.findAllByText('ryangh', {}, { timeout: 5000 });
+
+        // The board is fully built...
+        expect(document.querySelectorAll('.draft-pick.clickable-item').length).toBeGreaterThan(0);
+        // ...and carries no trade attribution, since that is what failed. The
+        // successful case asserts the opposite in 'applies every traded pick to
+        // the board' above, so this is not vacuous.
+        expect(screen.queryByText(/ via /)).toBeNull();
+    });
+
     it('unsubscribes from auth state changes on unmount', async () => {
         global.fetch = vi.fn(mockFetch);
 


### PR DESCRIPTION
The rest of the `undefined` dereference family, all in `loadDraft`. Follows #116; same pattern as #101, #103 and #115.

Two of these three were not in the known list — I found them grepping for the pattern, then confirmed each by probe before writing anything.

### 1. The guard checked the wrong field

`loadDraft` gated the build on `draft_order`, which `buildDraftRounds` never reads. It was a proxy for "this is a real draft" rather than for anything the builder dereferences. So a response with `draft_order` but no `settings` threw on `settings.player_type` (the known case), and one with no `slot_to_roster_id` threw in `createPickOrder` (not previously known). The guard now checks the two fields that are actually read, and warns when it declines to build.

### 2. A failed traded-picks request took down the whole load

`fetchTradedDraftPicks` resolves to `undefined` on failure and `buildDraftRounds` `forEach`es over it. `loadDraft` threw, nothing catches it, its `setState` never ran — so the app sat on the `LEAGUE_PANEL` loader indefinitely on a cold load, and on a league switch the board simply emptied.

**The failure taxonomy in the handoff and in project memory records this as "board renders silently missing all trades", which is wrong** — it never renders at all. Worth flagging because that entry is also the premise of the queued follow-up work: that item was scoped as "add a notice to a board that already renders". The board does not render, so the crash had to be fixed first. Trades are an overlay on a board that is perfectly renderable without them, so `loadDraft` now builds without them. That produces the behaviour the taxonomy claimed, and the notice remains a genuine follow-up on top of it.

## Sabotage results

| Sabotage | Result |
|---|---|
| Restore the `draft_order` guard | **2 failed** — the no-`settings` and no-`slot_to_roster_id` tests |
| Drop `\|\| []` on `tradedDraftPicks` | **1 failed** — the traded-picks test |

No sabotage passed. Re-ran the first after rewriting the tests for lint.

The tests are at the App level rather than on `buildDraftRounds` directly, deliberately: "it threw" and "it hung on the loader" are indistinguishable from a unit test of the builder, and the hang is the part that matters. Two selector traps worth recording — `/Draft$/` also matches the panel *tab*, so the header assertion needs `{ selector: 'b' }`, and `.draft-pick` matches both the pick container and an inner `<p>`.

## Browser check

`window.fetch` patched in-page, then the league dropdown switched to re-run the whole load chain with the patch already installed (a reload would discard it).

| | result |
|---|---|
| master, `traded_picks` rejects | board 48 → **0 picks**, `unhandledrejection: Cannot read properties of undefined (reading 'forEach')` |
| this branch, `traded_picks` rejects | board builds — 32 picks, 0 trade attributions, no loader, no errors |
| this branch, `settings` stripped from the draft response | empty board, panels and Sync button alive, the new warn logged, no errors |

Tests 166 → 169. Lint, `format:check`, `typecheck`, `build` all clean.

---

Unrelated and left alone: with no `settings`, the draft header renders `2026 undefined Draft`, since `player_pool` is only set when a board is built. Cosmetic, in an already-degraded state, and a different bug class — flagging rather than folding it in.