### PR TITLE
Say so when the board is missing its traded picks

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -109,6 +109,24 @@
     margin: 0px;
 }
 
+.warning-banner {
+    background-color: #283245;
+    border-radius: 10px;
+    border-left: 4px solid #e0a832;
+    margin: 8px 3px 3px 3px;
+    padding: 12px 15px;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    flex-wrap: wrap;
+}
+
+.warning-banner p {
+    margin: 0px;
+}
+
 .search {
     display: flex;
     flex-direction: column;

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,6 +31,7 @@ import { SLEEPER_USER_ID } from './urls.js';
 // prop. The panels now receive a plain boolean and no longer share a
 // vocabulary with App at all, so these names stay private to this file.
 const LEAGUE_LOAD_FAILED = "Couldn't load your league data. The Sleeper API may be unavailable.";
+const TRADED_PICKS_FAILED = "Couldn't load traded draft picks. The board shows every pick under its original owner.";
 
 const LOADING = {
     NONE: 'none',
@@ -44,6 +45,7 @@ class App extends React.Component {
         playerInfo: {},
         leagueData: {},
         loadError: null,
+        draftWarning: null,
         loading: LOADING.INITIAL,
         rankingPlayersIdsList: [],
         leagueID: '1312088290526003200',
@@ -158,8 +160,10 @@ class App extends React.Component {
         // chain: loadDraft threw, its setState never ran, and the app sat on
         // the LEAGUE_PANEL loader forever. Trades are an overlay on a board
         // that is perfectly renderable without them, so build without them.
-        // Note this is silent - the board looks authoritative while missing
-        // every trade - which is the tradeoff the follow-up notice addresses.
+        // Building without them cannot be silent, though: 42 of 48 picks in the
+        // real league carry a "via" attribution, so the board would look
+        // authoritative while misattributing most of itself. Hence draftWarning
+        // in the setState below.
         const built = canBuild
             ? buildDraftRounds({
                   currentDraft,
@@ -183,6 +187,7 @@ class App extends React.Component {
                 currentDraft: built ? { ...currentDraft, ...built } : currentDraft,
             },
             loading: LOADING.NONE,
+            draftWarning: canBuild && !tradedDraftPicks ? TRADED_PICKS_FAILED : null,
         }));
     };
 
@@ -207,6 +212,15 @@ class App extends React.Component {
     // nowhere for a panel-level spinner to appear.
     retryLeagueLoad = () => {
         this.setState({ loadError: null, loading: LOADING.INITIAL }, () => this.loadLeague(this.state.playerInfo));
+    };
+
+    // Retries only the draft load, not the whole league: leagueData is already
+    // in state and is not what failed, mirroring retryLeagueLoad's reasoning
+    // about the player database above.
+    retryDraftLoad = () => {
+        this.setState({ draftWarning: null, loading: LOADING.LEAGUE_PANEL }, () =>
+            this.loadDraft(this.state.leagueData),
+        );
     };
 
     updateLeagueID = (leagueID) => {
@@ -309,6 +323,7 @@ class App extends React.Component {
             notFoundPlayers,
             leagueID,
             loadError,
+            draftWarning,
             signedIn,
             signedInEmail,
             myDisplayName,
@@ -331,6 +346,9 @@ class App extends React.Component {
                         onSignOut={this.signOut}
                     />
                     {loadError ? <ErrorBanner message={loadError} onRetry={this.retryLeagueLoad} /> : null}
+                    {!loadError && draftWarning ? (
+                        <ErrorBanner message={draftWarning} variant="warning" onRetry={this.retryDraftLoad} />
+                    ) : null}
                     {!loadError && leagueData.currentLeague ? (
                         <div className="main-container">
                             <RanksPanel

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -621,6 +621,95 @@ describe('App', () => {
         expect(screen.queryByText(/ via /)).toBeNull();
     });
 
+    it('shows a warning notice when the traded-picks request fails but the board builds', async () => {
+        global.fetch = vi.fn((url) => {
+            if (/draft\/[\w]+\/traded_picks\//.test(url)) {
+                return Promise.reject(new Error('simulated traded_picks failure'));
+            }
+            return mockFetch(url);
+        });
+
+        render(<App />);
+        await screen.findAllByText('ryangh', {}, { timeout: 5000 });
+
+        expect(document.querySelectorAll('.draft-pick.clickable-item').length).toBeGreaterThan(0);
+        expect(await screen.findByRole('status', {}, { timeout: 5000 })).toHaveTextContent(
+            "Couldn't load traded draft picks",
+        );
+    });
+
+    it('does not show the traded-picks notice on a fully successful load', async () => {
+        global.fetch = vi.fn(mockFetch);
+
+        render(<App />);
+        await screen.findAllByText('ryangh', {}, { timeout: 5000 });
+
+        expect(screen.queryByRole('status')).toBeNull();
+    });
+
+    it('does not show the traded-picks notice when the board could not be built at all', async () => {
+        // A draft response missing `settings` means canBuild is false, so a
+        // failed traded-picks request alongside it would just be noise on top
+        // of an already-empty board.
+        global.fetch = vi.fn((url) => {
+            if (/draft\/[\w]+\/traded_picks\//.test(url)) {
+                return Promise.reject(new Error('simulated traded_picks failure'));
+            }
+            if (/draft\/[\w]+$/.test(url)) {
+                const copy = {
+                    ...structuredClone(draftSettings),
+                    draft_id: DRAFT_ID,
+                    season: '2026',
+                    status: 'drafting',
+                    draft_order: {},
+                };
+                delete copy.settings;
+                return jsonResponse(copy);
+            }
+            return mockFetch(url);
+        });
+
+        // Scoped to the <b> header: the panel tab is also called "Draft".
+        render(<App />);
+        await screen.findByText(/Draft$/, { selector: 'b' }, { timeout: 5000 });
+
+        expect(document.querySelectorAll('.draft-pick.clickable-item').length).toBe(0);
+        expect(screen.queryByRole('status')).toBeNull();
+    });
+
+    it('retries only the draft load and clears the notice when Retry succeeds', async () => {
+        let failTradedPicks = true;
+        global.fetch = vi.fn((url) => {
+            if (failTradedPicks && /draft\/[\w]+\/traded_picks\//.test(url)) {
+                return Promise.reject(new Error('simulated traded_picks failure'));
+            }
+            return mockFetch(url);
+        });
+
+        const user = userEvent.setup();
+        render(<App />);
+        await screen.findAllByText('ryangh', {}, { timeout: 5000 });
+        await screen.findByRole('status', {}, { timeout: 5000 });
+
+        const playerDbRequestsBefore = global.fetch.mock.calls.filter((call) =>
+            call[0].includes('legacy/players'),
+        ).length;
+        const rostersRequestsBefore = global.fetch.mock.calls.filter((call) => call[0].includes('/rosters/')).length;
+
+        failTradedPicks = false;
+        await user.click(screen.getByRole('button', { name: 'Retry' }));
+
+        await waitFor(() => expect(screen.queryByRole('status')).toBeNull());
+        expect(screen.getAllByText(/ via /).length).toBeGreaterThan(0);
+
+        expect(global.fetch.mock.calls.filter((call) => call[0].includes('legacy/players')).length).toBe(
+            playerDbRequestsBefore,
+        );
+        expect(global.fetch.mock.calls.filter((call) => call[0].includes('/rosters/')).length).toBe(
+            rostersRequestsBefore,
+        );
+    });
+
     it('unsubscribes from auth state changes on unmount', async () => {
         global.fetch = vi.fn(mockFetch);
 

--- a/src/Components/ErrorBanner.jsx
+++ b/src/Components/ErrorBanner.jsx
@@ -1,11 +1,23 @@
 import Button from './Button';
 
-// Shown in place of the panels when there is no league data to render them
-// from. Deliberately blocking rather than a dismissible toast: both panels
-// read league data unconditionally, so there is nothing useful behind it.
-const ErrorBanner = ({ message, onRetry }) => {
+// Two modes, chosen by `variant`:
+// - 'error' (default): shown in place of the panels when there is no league
+//   data to render them from. Deliberately blocking rather than a dismissible
+//   toast - both panels read league data unconditionally, so there is nothing
+//   useful behind it. Uses role="alert" so it interrupts a screen reader.
+// - 'warning': a non-blocking notice rendered alongside the panels, for a
+//   partial failure the app can still render around. Uses role="status" so
+//   it does not interrupt.
+// Both modes require an `onRetry`. An optional one was written first and then
+// removed: both call sites pass a handler, so the "no button" branch was
+// unreachable, and a sabotage that made the button unconditional passed the
+// whole suite. Untested speculative generality is worse than the one-line
+// change it would save if a retryless notice ever turns up.
+const ErrorBanner = ({ message, onRetry, variant = 'error' }) => {
+    const className = variant === 'warning' ? 'warning-banner' : 'error-banner';
+    const role = variant === 'warning' ? 'status' : 'alert';
     return (
-        <div className="error-banner" role="alert">
+        <div className={className} role={role}>
             <p>{message}</p>
             <Button text="Retry" btnStyle="primary" onClick={onRetry} />
         </div>


### PR DESCRIPTION
The last silent failure in the taxonomy. Closes the follow-up left open by #117.

Traded picks come from a request separate from the draft itself. Since #117 a failed one no longer takes the app down — but the board then renders every pick under its **original** roster, with no "via" attribution and nothing to say anything is missing. In the real league **42 of 48 picks carry a "via"**, so one failed request silently misattributes most of the board while looking completely authoritative.

This was worth doing only after #117. Before it, the request failing threw inside `loadDraft` and hung the app on the loader, so a misleading board was unreachable. Making it degrade is what made the wrongness visible, and this is the other half of that fix.

## Design

`ErrorBanner` grows a `variant` rather than gaining a near-duplicate component:

| | `error` (existing) | `warning` (new) |
|---|---|---|
| Placement | **replaces** the panels | renders **alongside** them |
| Role | `alert` — interrupts a screen reader | `status` — does not |
| Border | red | amber |

Blocking is right for a failed league load, since both panels read league data unconditionally and there is nothing useful behind it. A board missing only its trades is the opposite case — it is worth reading, you just need to know what is wrong with it.

**Retry re-runs only `loadDraft`.** `leagueData` is already in state and is not what failed, mirroring `retryLeagueLoad` deliberately not refetching the player database.

**The notice is suppressed when no board could be built at all** (`canBuild &&
!tradedDraftPicks`). With an empty board there is nothing to misattribute, so it would be noise stacked on a problem the user can already see.

## Sabotage results

| Sabotage | Result |
|---|---|
| `draftWarning` never set | **2 failed** |
| Drop the `canBuild` half of the condition | **1 failed** — the empty-board case |
| Warning variant keeps `role="alert"` | **2 failed** |
| Make the Retry button unconditional | **passed** — see below |

That last one **passed**, and it changed the diff. `onRetry` had been optional, with the button rendering only when a handler was passed — but both call sites pass one, so the branch was unreachable and nothing tested it. Rather than write a contrived test for an impossible case, I deleted the optionality, following the precedent in #107 and #110. A comment at the component records why, so the next person does not re-add it.

## Browser check

`window.fetch` patched in-page, then the league dropdown switched to re-run the load chain with the patch already installed (a reload discards it).

| | result |
|---|---|
| `traded_picks` rejects | notice shown, `warning-banner`, **panels still render underneath**, board builds — 32 picks, 0 "via", no errors |
| Retry, with the request succeeding | notice clears, 12 "via" attributions appear |
| Retry — what it refetched | player DB **0**, rosters **0** |

The screenshot below is the 48-pick league. Picks 1.4, 1.7 and 1.8 read `gdavidson`, `kpresley` and `Bloomberg4`; with trades loaded they read "Bloomberg4 via gdavidson", "CHood20 via kpresley" and "CHood20 via Bloomberg4". That is the misattribution, and it is invisible without the notice.

Tests 169 → 173. Lint, `format:check`, `typecheck`, `build` all clean.