### PR TITLE
Delete CSS rules no component references

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,19 +1,3 @@
-.App {
-    text-align: center;
-    overflow: visible;
-}
-
-.App-logo {
-    height: 40vmin;
-    pointer-events: none;
-}
-
-@media (prefers-reduced-motion: no-preference) {
-    .App-logo {
-        animation: App-logo-spin infinite 20s linear;
-    }
-}
-
 @media screen and (max-width: 767px) {
     .title {
         font-size: x-large;
@@ -46,30 +30,6 @@
     }
     .team-name {
         font-size: smaller;
-    }
-}
-
-.App-header {
-    background-color: #282c34;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    font-size: calc(10px + 2vmin);
-    color: white;
-}
-
-.App-link {
-    color: #61dafb;
-}
-
-@keyframes App-logo-spin {
-    from {
-        transform: rotate(0deg);
-    }
-    to {
-        transform: rotate(360deg);
     }
 }
 
@@ -230,12 +190,6 @@
     display: flex;
     flex-direction: column;
     padding: 5px 15px 15px 15px;
-}
-
-.search-box {
-    display: flex;
-    flex-direction: column;
-    margin: 3px 0px 16px;
 }
 
 .latest-update {


### PR DESCRIPTION
First move of redesign step 00: shrink `App.css` before anything is converted onto Tailwind.

Six rule blocks are Create React App leftovers or orphans — `.App`, `.App-logo` (and its `prefers-reduced-motion` animation), `.App-header`, `.App-link`, the `App-logo-spin` keyframes, and `.search-box`. No component, `index.html` or asset in `public/` names any of them.

`App.css` 427 → 381 lines. No source file changes.

**Verification.** Pure deletion, so sabotage does not apply — the substitute is a reachability proof. These are class names, reachable only as literal text in a `className`, and grep across all of `src`, `index.html` and `public/` finds no reference outside `App.css`. All six gates clean; 173 tests unchanged and green.

Note in passing: `src/logo.svg` is also unreferenced. Left alone — this PR is CSS only.