### PR TITLE
Key abbreviated names to width, not orientation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -238,7 +238,9 @@
     display: none;
 }
 
-@media all and (orientation: portrait) {
+/* This is a width breakpoint, not an orientation check: below 640px
+   (Tailwind's `sm`), abbreviate names; at 640px and up, show full names. */
+@media all and (max-width: 639px) {
     .abbr-text {
         display: inline-block;
         text-overflow: ellipsis;

--- a/src/Panels/DraftRound.jsx
+++ b/src/Panels/DraftRound.jsx
@@ -97,11 +97,11 @@ const DraftRound = ({ round, playerInfo, rosterInfo, rosterData, rankingPlayersI
                                                 </>
                                             ) : (
                                                 // Deliberately not `full-text`: that class is
-                                                // display:none in portrait, where `abbr-text`
-                                                // takes over. There is no abbreviated form of
-                                                // an unresolved id, so an unclassed span is
-                                                // what keeps the cell from going blank on a
-                                                // phone.
+                                                // display:none below the narrow-width breakpoint,
+                                                // where `abbr-text` takes over. There is no
+                                                // abbreviated form of an unresolved id, so an
+                                                // unclassed span is what keeps the cell from
+                                                // going blank on a phone.
                                                 <span style={{ paddingRight: 3 + 'px' }}>
                                                     {`Unknown player ${pick.player_id}`}
                                                 </span>

--- a/src/Panels/DraftRound.test.jsx
+++ b/src/Panels/DraftRound.test.jsx
@@ -87,7 +87,7 @@ describe('DraftRound with a player missing from the player database', () => {
     });
 
     it('renders the fallback outside the full-text/abbr-text pair', () => {
-        // `full-text` is display:none in portrait, where `abbr-text` replaces
+        // `full-text` is display:none below 640px, where `abbr-text` replaces
         // it. The first cut of this fix put the fallback in a `full-text` span,
         // which rendered a blank cell on a phone - caught in the browser, not
         // here, because jsdom applies no stylesheet and getByText found it


### PR DESCRIPTION
Step 01 of the UI redesign, kept as its own PR so the fix is not buried in a redesign diff.

The draft board and the lineup slots swapped full player names for abbreviated ones under `@media (orientation: portrait)`. Orientation is not width — a 700×900 desktop window is "portrait" and got abbreviations it had plenty of room for, while a phone in landscape is not portrait and got full names in a 375px-wide layout. This is the same rule that once shipped an invisible "Unknown player" fallback, because a `full-text` span is `display: none` on the other side of it.

Now `@media all and (max-width: 639px)`.

**Why 639px.** Measured, not chosen: with full names forced on against a real 12-team board, cells truncate at viewport 375px (4 cells, worst 15px) and 414px (2 cells, 2px), and nothing truncates from 500px up. 639px clears that with margin and is one below Tailwind's `sm`, which the redesign already uses.

**A/B against master, same viewports, same league:**

| Viewport | master | this branch |
|---|---|---|
| 375×320 (landscape phone) | full names, **13 cells clipped**, worst 21px | abbreviated, nothing clipped |
| 700×900 (portrait-shaped window) | abbreviated | full names, nothing clipped |
| 639 / 640 boundary | — | abbreviated / full, exactly |

CSS-only. The components keep their `full-text` / `abbr-text` spans and get rebuilt in step 03; two comments describing the old orientation behaviour are updated to match.

**Sabotage.** Reverting the query to `orientation: portrait` leaves all 176 tests green — expected, and worth stating plainly: jsdom applies no stylesheet, so nothing in the suite can see this. The A/B measurements above are the evidence. The one test that does guard the related failure still works: putting the "Unknown player" fallback back into a `full-text` span fails "renders the fallback outside the full-text/abbr-text pair" and nothing else.

All six gates clean, including `npm ci`. 176 tests, no test behaviour changed (one comment reworded).