### PR TITLE
Cover the shell's aside placement

### DIFF
--- a/src/Components/AppShell.test.jsx
+++ b/src/Components/AppShell.test.jsx
@@ -59,6 +59,27 @@ describe('AppShell', () => {
         expect(screen.getByTestId('section-content')).toHaveTextContent('draft');
     });
 
+    it('renders the aside alongside a league section', () => {
+        window.location.hash = '#/draft';
+
+        renderShell();
+
+        expect(screen.getByTestId('aside-content')).toBeInTheDocument();
+    });
+
+    it('drops the aside when Ranks is the active section', () => {
+        // Ranks IS the aside's content, so rendering both would put the same
+        // panel on screen twice on a wide screen. Whether the aside is visible
+        // at a given width is a stylesheet question jsdom cannot answer - this
+        // pins the half that is structural.
+        window.location.hash = '#/ranks';
+
+        renderShell();
+
+        expect(screen.getByTestId('section-content')).toHaveTextContent('ranks');
+        expect(screen.queryByTestId('aside-content')).toBeNull();
+    });
+
     it('does not render the leagueBar for a global-scope section', () => {
         // No real global section exists yet - this fixture is the only thing
         // holding the cross-league decision up: a section with scope


### PR DESCRIPTION
These two tests belong with [#122](https://github.com/rghart/my-sleeper-app/pull/122) and were left out of it by mistake — they were written after that PR's sabotage run and never staged, so the merged commit carries the behaviour without the tests that pin it. #122's description says 184 tests; what landed was 182. This closes the difference.

The gap is the one sabotage found there: rendering the aside for **every** section — which puts Ranks on screen twice when Ranks is the active section — passed the entire suite.

| Sabotage | Now |
|---|---|
| aside rendered for every section | fails "drops the aside when Ranks is the active section" |
| aside never rendered | fails "renders the aside alongside a league section" |

Whether the aside is *visible* at a given width stays a browser question — jsdom applies no stylesheet, and that half was verified at 375 and 1280 in #122. These pin the structural half.

Tests 182 → 184. Gates clean.