### PR TITLE
Flip the app to the redesign palette

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -31,7 +31,7 @@
 
 .panel {
     padding: 5px 15px 15px 15px;
-    background-color: #283245;
+    background-color: #1b2530;
     border-radius: 10px;
     height: 100%;
     margin: 8px 3px 3px 3px;
@@ -62,7 +62,7 @@
 }
 
 .single-player-item {
-    border: 2px solid #4b576b;
+    border: 2px solid #2c3846;
     display: grid;
     grid-template-columns: 2fr 1fr;
     padding: 5px;
@@ -130,9 +130,9 @@
 
 .dropdown {
     background: transparent;
-    caret-color: #ddd;
-    color: #fff;
-    border: 2px solid #4b576b;
+    caret-color: #8fa3b8;
+    color: #e8edf2;
+    border: 2px solid #2c3846;
     border-radius: 10px;
     margin-top: 8px;
     width: 85%;
@@ -149,9 +149,9 @@
     margin-top: 8px;
     margin-right: 3px;
     background: transparent;
-    caret-color: #ddd;
-    color: #fff;
-    border: 2px solid #4b576b;
+    caret-color: #8fa3b8;
+    color: #e8edf2;
+    border: 2px solid #2c3846;
     border-radius: 10px;
     height: 100px;
     width: 85%;
@@ -161,15 +161,15 @@
     margin-top: 1px;
     margin-bottom: 16px;
     background: transparent;
-    caret-color: #ddd;
-    color: #fff;
-    border: 2px solid #4b576b;
+    caret-color: #8fa3b8;
+    color: #e8edf2;
+    border: 2px solid #2c3846;
     border-radius: 10px;
     margin: 0;
 }
 
 .radio-label {
-    border: 1px solid #a3bbd3;
+    border: 1px solid #8fa3b8;
     border-radius: 22px;
     padding: 6px;
     cursor: pointer;
@@ -179,10 +179,6 @@
 
 .radioPad {
     display: none;
-}
-
-.checked {
-    background-color: #00ceb8;
 }
 
 .lineup-position {
@@ -208,7 +204,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    color: #fff;
+    color: #e8edf2;
     height: 20px;
     width: 20px;
 }
@@ -241,7 +237,7 @@
 
 .draft-pick-rows {
     display: flex;
-    border: 2px solid #a3bbd3;
+    border: 2px solid #8fa3b8;
     border-radius: 6px;
     margin-bottom: 3px;
     width: 95%;
@@ -250,7 +246,7 @@
 
 .draft-pick-rows:hover {
     display: flex;
-    border: 2px solid #00d8a7;
+    border: 2px solid #8fa3b8;
     border-radius: 6px;
     margin-bottom: 3px;
     width: 95%;
@@ -273,14 +269,14 @@
 .round-number {
     margin: 0;
     padding: 5px 15px 2px 25px;
-    background-color: #283245;
+    background-color: #1b2530;
     position: sticky;
     top: 0;
 }
 
 .custom-horizontal-select {
     display: flex;
-    border: 1px solid #a3bbd3;
+    border: 1px solid #8fa3b8;
     border-radius: 22px;
     width: 100%;
     max-width: 85%;
@@ -312,8 +308,13 @@
     margin-top: 3px;
 }
 
+/* Selection reads through contrast and elevation, never hue: the teal these
+   two carried was byte-identical to the RB position colour. */
+.checked,
 .custom-horizontal-select .custom-horizontal-select-item.selected {
-    background-color: #00ceb8;
+    background-color: #2c3846;
+    color: #e8edf2;
+    border: 1px solid #8fa3b8;
     transition: all 0.1s ease;
 }
 

--- a/src/Components/Button/Button.css
+++ b/src/Components/Button/Button.css
@@ -9,8 +9,8 @@
 @layer base {
     button {
         background: transparent;
-        color: #fff;
-        border: 1px solid #a3bbd3;
+        color: #e8edf2;
+        border: 1px solid #8fa3b8;
         border-radius: 5px;
         min-width: max-content;
         margin-bottom: 7px;
@@ -22,8 +22,8 @@
 
     :disabled {
         transform: none !important;
-        border: 1px solid #4b576b !important;
-        color: #4b576b !important;
+        border: 1px solid #2c3846 !important;
+        color: #2c3846 !important;
     }
 
     .primary-large {
@@ -37,8 +37,8 @@
 
     .primary:hover,
     .primary-large:hover {
-        color: #00d8a7;
-        border-color: #00d8a7;
+        color: #e8edf2;
+        border-color: #8fa3b8;
     }
 
     .alert {
@@ -51,18 +51,19 @@
     }
 
     .active {
-        background-color: #00d8a7;
+        background-color: #2c3846;
+        border-color: #8fa3b8;
         overflow: hidden;
     }
 
     .active:hover {
-        color: #fff;
+        color: #e8edf2;
     }
 
     .primary-invert,
     .player-add-button {
-        color: #18202f;
-        border-color: #18202f;
+        color: #0f1720;
+        border-color: #0f1720;
     }
 
     .player-add-button {
@@ -84,8 +85,8 @@
 
     .player-add-button:hover,
     .primary-invert:hover {
-        color: #4b576b;
-        border-color: #4b576b;
+        color: #2c3846;
+        border-color: #2c3846;
     }
 
     .clickable-item:hover {

--- a/src/Panels/DraftRound.jsx
+++ b/src/Panels/DraftRound.jsx
@@ -25,7 +25,7 @@ const DraftRound = ({ round, playerInfo, rosterInfo, rosterData, rankingPlayersI
     const style = {
         manualPickModal: {
             position: 'fixed',
-            background: '#18202f',
+            background: '#0F1720',
             zIndex: 999,
             bottom: 0,
             top: 45 + '%',

--- a/src/index.css
+++ b/src/index.css
@@ -13,8 +13,8 @@
             'Droid Sans', 'Helvetica Neue', sans-serif;
         -webkit-font-smoothing: antialiased;
         -moz-osx-font-smoothing: grayscale;
-        background-color: #18202f;
-        color: #fff;
+        background-color: #0f1720;
+        color: #e8edf2;
         font-family: 'Lato', Arial, Helvetica, sans-serif;
         min-height: 500px;
     }

--- a/src/styles/legacy-css.test.js
+++ b/src/styles/legacy-css.test.js
@@ -20,7 +20,14 @@ const APP_CSS = resolve(process.cwd(), 'src/App.css');
 // 427 lines before the redesign started; 381 after the dead CRA rules went;
 // 345 with ErrorBanner converted; 340 once the shell replaced .main-container;
 // 326 once Header's .title and .latest-update went with it.
-const MAX_LINES = 326;
+//
+// 328 after the palette flip, and this is the one time the ceiling has gone
+// UP. Selection used to be a teal fill that was byte-identical to the RB
+// position colour; replacing it with contrast and elevation costs two extra
+// declarations. Raising the ceiling for a deliberate, explained reason is the
+// ratchet doing its job - the thing it exists to stop is growth nobody
+// noticed.
+const MAX_LINES = 328;
 
 const CONVERTED = ['error-banner', 'warning-banner', 'main-container', 'latest-update', '.title {'];
 
@@ -36,5 +43,23 @@ describe('App.css drain', () => {
 
     it.each(CONVERTED)('has no rules left for the converted %s', (selector) => {
         expect(css).not.toContain(selector);
+    });
+});
+
+// The rule the palette derives from: saturation is reserved for data. The old
+// UI chrome broke it in the worst possible way - selected filters and the
+// selected panel tab were filled with #00ceb8, which is byte-identical to the
+// RB position colour, and rows hovered to #00d8a7 next door to it. Both are
+// gone; this is what stops them coming back as "just a highlight".
+describe('position colours are not reused as chrome', () => {
+    const CHROME_SHEETS = ['src/App.css', 'src/Components/Button/Button.css', 'src/index.css'];
+
+    it.each(CHROME_SHEETS)('%s does not fill anything with the RB colour', (sheet) => {
+        const contents = readFileSync(resolve(process.cwd(), sheet), 'utf8').toLowerCase();
+
+        // The position palette itself is written in rgb() in App.css, so the
+        // hex spelling appearing anywhere means something borrowed the hue.
+        expect(contents).not.toContain('#00ceb8');
+        expect(contents).not.toContain('#00d8a7');
     });
 });

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -22,16 +22,16 @@
  * a second theme is a matter of redefining this block under a selector rather
  * than touching any call site.
  *
- * These are the app's CURRENT colours, not the redesign palette. This step ships
- * pixel-identical, so the names arrive first and the values change later, in the
- * step that rebuilds the shell.
+ * The flip has happened: these are the redesign palette now, not the app's
+ * former colours. The names arrived first and the values have since changed,
+ * in the step that rebuilds the shell.
  */
 :root {
-    --raw-ground: #18202f;
-    --raw-raised: #283245;
-    --raw-line: #4b576b;
-    --raw-ink: #ffffff;
-    --raw-ink-muted: #a3bbd3;
+    --raw-ground: #0f1720;
+    --raw-raised: #1b2530;
+    --raw-line: #2c3846;
+    --raw-ink: #e8edf2;
+    --raw-ink-muted: #8fa3b8;
 
     /*
      * The accent is named `mine`, not `accent`, because violet is reserved for
@@ -53,8 +53,8 @@
     --raw-wr: #58a7ff;
     --raw-te: #ffae58;
 
-    --raw-danger: #d9534f;
-    --raw-warn: #e0a832;
+    --raw-danger: #ff7a70;
+    --raw-warn: #e8b154;
 }
 
 /* `inline` so the utilities resolve through the variable at runtime, which is


### PR DESCRIPTION
Step 02, final PR. The tokens shipped holding the app's existing colours so each earlier step could prove itself pixel-identical. This changes the values — and the legacy hexes still spread through the stylesheets — in one move, because a half-flipped app just looks broken.

| | old → new | | old → new |
|---|---|---|---|
| ground | `#18202f` → `#0F1720` | ink | `#fff` → `#E8EDF2` |
| raised | `#283245` → `#1B2530` | muted | `#a3bbd3` → `#8FA3B8` |
| line | `#4b576b` → `#2C3846` | danger | `#d9534f` → `#FF7A70` |
| | | warning | `#e0a832` → `#E8B154` |

**The position palette is untouched** — QB `#ff2a6d`, RB `#00ceb8`, WR `#58a7ff`, TE `#ffae58` encode data and keep the loud end of the spectrum.

### The real point of the change

Selected filter chips and the selected segment were filled with `#00ceb8` — **byte-identical to the RB position colour** — and row hovers and primary buttons used `#00d8a7`, its next-door neighbour. That is the collision the whole palette derives from: saturation is reserved for data, so chrome earns attention through contrast and elevation instead.

Selection is now a raised fill with a hairline border, measured at **10.1:1**. Violet is not used for any of it — it means "yours", not "selected".

Verified against master that nothing was lost: every selected chip there was the same teal, not a position colour, so the grey-plus-border carries the same information.

### Verification

Measured in the browser on the new ramp: ink on ground **15.3:1**, ink on panels **13.2:1**, muted on panels **6.0:1**, selected chip **10.1:1** — all comfortably past AA.

**Sabotage:** putting the RB teal back on selected chips fails the new "does not fill anything with the RB colour" test and nothing else. Reverting the ground token to the old navy passes the whole suite — expected and worth saying: nothing in the suite asserts a colour, which is why the collision got a test of its own and the rest is browser-measured.

`App.css` 326 → 328. **The ceiling goes up for the first time, deliberately:** two extra declarations buy the border that replaces the hue. The ratchet exists to stop growth nobody noticed, not to make a justified change awkward — the comment in the test says so.

Tests 195 → 198. All six gates clean including `npm ci`.