### PR TITLE
Read the draft's pace from the API: clock and poll cadence

### DIFF
--- a/src/Components/PickClock.jsx
+++ b/src/Components/PickClock.jsx
@@ -1,0 +1,74 @@
+import { useEffect, useState } from 'react';
+import { pickClockMode, pickDeadline, formatTimeLeft } from '../lib/draftClock.js';
+
+// Re-render cadence per mode: a `live` clock ticking seconds needs a 1s
+// timer, `slow` only needs to move once a minute, and `untimed` / `not-started`
+// have nothing to count down so no timer runs at all - there is nothing for
+// it to invalidate.
+const TICK_MS = {
+    live: 1000,
+    slow: 60000,
+};
+
+const PickClock = ({ draft }) => {
+    const mode = pickClockMode(draft);
+    const [, forceTick] = useState(0);
+
+    useEffect(() => {
+        const interval = TICK_MS[mode];
+        if (!interval) {
+            return undefined;
+        }
+        const timer = setInterval(() => forceTick((n) => n + 1), interval);
+        return () => clearInterval(timer);
+    }, [mode]);
+
+    const WRAPPER = 'border border-solid border-line rounded-[5px] bg-raised px-3 py-2';
+
+    if (mode === 'not-started') {
+        return (
+            <div className={WRAPPER}>
+                <p className="text-ink-muted text-sm">Draft hasn&apos;t started</p>
+            </div>
+        );
+    }
+
+    if (mode === 'complete') {
+        // A finished draft still carries a real `last_picked` and a real
+        // `pick_timer`, so the arithmetic produces a deadline that expired
+        // when the draft did. Saying so beats counting down to it.
+        return (
+            <div className={WRAPPER}>
+                <p className="text-ink-muted text-sm">Draft complete</p>
+            </div>
+        );
+    }
+
+    if (mode === 'untimed') {
+        // Never render a countdown here - there is no deadline to count down
+        // to, and rendering the raw arithmetic anyway is exactly how a bare
+        // `0:00` or `NaN` would leak onto an untimed draft's screen.
+        return (
+            <div className={WRAPPER}>
+                <p className="text-ink-muted text-sm">Untimed draft</p>
+            </div>
+        );
+    }
+
+    const deadline = pickDeadline(draft);
+    const msLeft = deadline - Date.now();
+    // Deliberately not "until autopick": whether an expired pick is
+    // auto-made depends on league settings nobody here has verified.
+    const label = 'Time left';
+
+    return (
+        <div className={WRAPPER}>
+            <p className="text-ink text-sm">
+                <span className="text-ink-muted">{label}: </span>
+                <span className="font-semibold tabular-nums">{formatTimeLeft(msLeft, mode)}</span>
+            </p>
+        </div>
+    );
+};
+
+export default PickClock;

--- a/src/Components/PickClock.test.jsx
+++ b/src/Components/PickClock.test.jsx
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import PickClock from './PickClock';
+
+// draftClock.js itself is tested exhaustively in src/lib/draftClock.test.js -
+// this file only has to prove PickClock wires it up correctly: the right
+// text per mode, the right timer cadence (or none), and that the interval is
+// torn down on unmount and swapped when the mode changes.
+
+const NOW = Date.UTC(2026, 6, 27, 12, 0, 0);
+
+describe('PickClock', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(NOW);
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('reads not-started for a pre_draft league and starts no timer', () => {
+        render(<PickClock draft={{ status: 'pre_draft', start_time: null, last_picked: null, settings: {} }} />);
+
+        expect(screen.getByText("Draft hasn't started")).toBeTruthy();
+        expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('says a finished draft is finished rather than counting down to a past deadline', () => {
+        render(
+            <PickClock
+                draft={{
+                    status: 'complete',
+                    start_time: NOW - 86400000,
+                    last_picked: NOW - 3600000,
+                    settings: { pick_timer: 43200 },
+                }}
+            />,
+        );
+
+        expect(screen.getByText('Draft complete')).toBeTruthy();
+        expect(screen.queryByText(/Time expired/)).toBeNull();
+        expect(screen.queryByText(/Time left/)).toBeNull();
+        expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('reads untimed without rendering any countdown, NaN, or bare 0:00', () => {
+        render(
+            <PickClock
+                draft={{ status: 'drafting', start_time: NOW, last_picked: null, settings: { pick_timer: 0 } }}
+            />,
+        );
+
+        expect(screen.getByText('Untimed draft')).toBeTruthy();
+        expect(screen.queryByText(/NaN/)).toBeNull();
+        expect(screen.queryByText(/0:00/)).toBeNull();
+        expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('counts down seconds in live mode and ticks every second', () => {
+        render(
+            <PickClock
+                draft={{ status: 'drafting', start_time: NOW, last_picked: null, settings: { pick_timer: 90 } }}
+            />,
+        );
+
+        expect(screen.getByText('1:30')).toBeTruthy();
+
+        act(() => {
+            vi.advanceTimersByTime(1000);
+        });
+        expect(screen.getByText('1:29')).toBeTruthy();
+    });
+
+    it('counts down coarsely in slow mode and ticks every minute, not every second', () => {
+        render(
+            <PickClock
+                draft={{ status: 'drafting', start_time: NOW, last_picked: null, settings: { pick_timer: 86400 } }}
+            />,
+        );
+
+        expect(screen.getByText('1d 0h')).toBeTruthy();
+
+        act(() => {
+            vi.advanceTimersByTime(1000);
+        });
+        // A 1s tick must not move a slow-mode clock.
+        expect(screen.getByText('1d 0h')).toBeTruthy();
+
+        act(() => {
+            vi.advanceTimersByTime(59000);
+        });
+        expect(screen.getByText('23h 59m')).toBeTruthy();
+    });
+
+    it('clears the interval on unmount', () => {
+        const { unmount } = render(
+            <PickClock
+                draft={{ status: 'drafting', start_time: NOW, last_picked: null, settings: { pick_timer: 90 } }}
+            />,
+        );
+
+        expect(vi.getTimerCount()).toBe(1);
+        unmount();
+        expect(vi.getTimerCount()).toBe(0);
+    });
+
+    it('swaps the interval rather than stacking one when the mode changes', () => {
+        const { rerender } = render(
+            <PickClock
+                draft={{ status: 'drafting', start_time: NOW, last_picked: null, settings: { pick_timer: 90 } }}
+            />,
+        );
+        expect(vi.getTimerCount()).toBe(1);
+
+        rerender(
+            <PickClock
+                draft={{ status: 'drafting', start_time: NOW, last_picked: null, settings: { pick_timer: 0 } }}
+            />,
+        );
+
+        // untimed runs no timer at all - the live one must have been cleared,
+        // not left running alongside nothing.
+        expect(vi.getTimerCount()).toBe(0);
+    });
+});

--- a/src/Panels/DraftPanel.jsx
+++ b/src/Panels/DraftPanel.jsx
@@ -1,8 +1,10 @@
 import { useState, useEffect, useRef } from 'react';
 import Button from '../Components/Button';
 import DraftRound from './DraftRound';
+import PickClock from '../Components/PickClock';
 import { SLEEPER_API_URLS } from '../urls';
 import { syncLiveDraft } from '../lib/liveDraft.js';
+import { pollIntervalMs } from '../lib/draftClock.js';
 const { DRAFT, PICKS, TRADED_PICKS } = SLEEPER_API_URLS;
 
 const DraftPanel = ({ leagueData, playerInfo, rosterInfo, rankingPlayersIdsList, updateDraftBoard }) => {
@@ -65,6 +67,15 @@ const DraftPanel = ({ leagueData, playerInfo, rosterInfo, rankingPlayersIdsList,
         getLiveDraftRef.current = getLiveDraft;
     });
 
+    // Read through a ref, same as getLiveDraftRef above: the poll effect
+    // below only re-runs on isSyncing, so a stale closure over currentDraft
+    // would keep polling at whatever cadence was current the moment sync
+    // was switched on, rather than following the draft's own pace.
+    const currentDraftRef = useRef(currentDraft);
+    useEffect(() => {
+        currentDraftRef.current = currentDraft;
+    });
+
     useEffect(() => {
         if (!isSyncing) {
             return;
@@ -78,7 +89,7 @@ const DraftPanel = ({ leagueData, playerInfo, rosterInfo, rankingPlayersIdsList,
             if (cancelled) {
                 return;
             }
-            timer = setTimeout(poll, 3000);
+            timer = setTimeout(poll, pollIntervalMs(currentDraftRef.current));
         };
         poll();
         return () => {
@@ -104,6 +115,7 @@ const DraftPanel = ({ leagueData, playerInfo, rosterInfo, rankingPlayersIdsList,
                     <b>{`${currentDraft.season} ${currentDraft.player_pool} Draft`}</b>
                 </p>
                 <p>Status: {currentDraft.status}</p>
+                <PickClock draft={currentDraft} />
                 <Button
                     text={!isSyncing ? 'Sync draft' : 'Stop sync'}
                     btnStyle={isSyncing ? 'primary-large active' : 'primary-large'}

--- a/src/Panels/DraftPanel.test.jsx
+++ b/src/Panels/DraftPanel.test.jsx
@@ -56,6 +56,12 @@ function gatedFetch() {
     return { fetchMock, release: () => release() };
 }
 
+// A fixed base time plus a live-paced pick_timer (well under the 900s
+// live/slow boundary in draftClock.js) so the default fixture keeps the same
+// 3s poll cadence every pre-existing test in this file already assumes.
+// Tests that care about a slower cadence override `currentDraft` directly.
+const DRAFT_BASE_TIME = Date.UTC(2026, 6, 27, 12, 0, 0);
+
 function renderPanel(overrides = {}) {
     const updateDraftBoard = vi.fn();
     const props = {
@@ -65,6 +71,9 @@ function renderPanel(overrides = {}) {
                 season: '2026',
                 player_pool: 'Rookie',
                 status: 'drafting',
+                start_time: DRAFT_BASE_TIME,
+                last_picked: null,
+                settings: { pick_timer: 30 },
                 built_draft: builtDraft,
             },
             rosterData,
@@ -316,5 +325,67 @@ describe('DraftPanel', () => {
         expect(urlsFetched().length).toBeGreaterThan(0);
         expect(urlsFetched().every((url) => url.includes('other456'))).toBe(true);
         expect(urlsFetched().some((url) => url.includes(DRAFT_ID))).toBe(false);
+    });
+
+    // pollIntervalMs (src/lib/draftClock.js) is unit-tested in isolation;
+    // what needs proving here is that DraftPanel actually reads it off
+    // currentDraft rather than the hard-coded 3000ms the loop used to carry,
+    // for both paces the real leagues use. Asserting on fetch call counts
+    // after advancing time - not on the timer id - is what actually shows
+    // the cadence, since a wrong interval still schedules *a* timer.
+    it('polls a live-paced draft every 3s', async () => {
+        renderPanel({
+            leagueData: {
+                currentDraft: {
+                    draft_id: DRAFT_ID,
+                    season: '2026',
+                    player_pool: 'Rookie',
+                    status: 'drafting',
+                    start_time: DRAFT_BASE_TIME,
+                    last_picked: null,
+                    settings: { pick_timer: 30 },
+                    built_draft: builtDraft,
+                },
+                rosterData,
+            },
+        });
+
+        await click(button('Sync draft'));
+        expect(global.fetch.mock.calls.length).toBe(2); // one tick: two requests
+
+        await settle(3000);
+        expect(global.fetch.mock.calls.length).toBe(4); // a second tick landed
+
+        await settle(3000);
+        expect(global.fetch.mock.calls.length).toBe(6); // and a third
+    });
+
+    it('polls a slow (24h dynasty) draft every 30s, not every 3s', async () => {
+        renderPanel({
+            leagueData: {
+                currentDraft: {
+                    draft_id: DRAFT_ID,
+                    season: '2026',
+                    player_pool: 'Rookie',
+                    status: 'drafting',
+                    start_time: DRAFT_BASE_TIME,
+                    last_picked: null,
+                    settings: { pick_timer: 86400 },
+                    built_draft: builtDraft,
+                },
+                rosterData,
+            },
+        });
+
+        await click(button('Sync draft'));
+        expect(global.fetch.mock.calls.length).toBe(2); // one tick: two requests
+
+        await settle(3000);
+        // A live cadence would have landed a second tick by now; a slow one
+        // must not have.
+        expect(global.fetch.mock.calls.length).toBe(2);
+
+        await settle(27000); // total 30s since the first tick
+        expect(global.fetch.mock.calls.length).toBe(4); // now the second tick lands
     });
 });

--- a/src/lib/draftClock.js
+++ b/src/lib/draftClock.js
@@ -1,0 +1,153 @@
+// Pure helpers for reading the pick clock off a draft object. No React here -
+// PickClock.jsx owns the timer and the rendering, this module only owns the
+// arithmetic, so the arithmetic can be tested without mounting anything.
+//
+// The API facts this module encodes, established against the five real
+// leagues rather than assumed:
+//   - `settings.pick_timer` of `0` (or missing) means untimed - a first-class
+//     state, not a null to route around.
+//   - `last_picked` is absent (`null`) before the first pick lands.
+//   - `start_time` is also `null` while `status` is `pre_draft` - a clock
+//     that assumes it exists renders garbage on exactly the draft you are
+//     waiting on.
+//   - `settings.autopause_enabled` is `0` on all five real leagues, so the
+//     pause maths below is unexercised in practice. See the comment on
+//     `applyAutopauseShift` for what that means for confidence in it.
+
+const LIVE_THRESHOLD_SECONDS = 900; // 15 minutes
+
+/**
+ * `'not-started' | 'complete' | 'untimed' | 'slow' | 'live'`.
+ *
+ * The two terminal states take priority over everything else. A `pre_draft`
+ * draft (or one with neither `last_picked` nor `start_time` to count from)
+ * has nothing to clock yet, and a finished one has nothing left to clock -
+ * its `last_picked` is real and its `pick_timer` is real, so the arithmetic
+ * happily produces a deadline that expired whenever the draft ended. Three
+ * of the five real leagues are `complete`, and every one of them would read
+ * "Time expired" without this.
+ */
+export function pickClockMode(draft) {
+    const { status, last_picked: lastPicked, start_time: startTime } = draft;
+
+    if (status === 'pre_draft' || (lastPicked == null && startTime == null)) {
+        return 'not-started';
+    }
+
+    if (status === 'complete') {
+        return 'complete';
+    }
+
+    const pickTimer = draft.settings?.pick_timer;
+    if (!pickTimer) {
+        // `0` and "missing" both read as untimed - Sleeper uses `0` for the
+        // one untimed real league, but a defensively-missing field should not
+        // be treated as a live, near-instant clock.
+        return 'untimed';
+    }
+
+    return pickTimer < LIVE_THRESHOLD_SECONDS ? 'live' : 'slow';
+}
+
+/**
+ * Autopause shift: if the naive deadline lands inside the pause window, push
+ * it out by the window's length so the countdown does not run down during a
+ * pause.
+ *
+ * `autopause_start_time` / `autopause_end_time` are read here as minutes
+ * since local midnight (e.g. 420 -> 07:00, 780 -> 13:00). That reading is an
+ * assumption, not a verified fact - every one of the five real leagues has
+ * `autopause_enabled: 0`, so this path has never been exercised against a
+ * real pause window. Because it is only ever reached when the flag is
+ * truthy, every real league today gets the naive deadline computed above,
+ * untouched.
+ */
+function applyAutopauseShift(deadline, settings) {
+    const startMinutes = settings.autopause_start_time;
+    const endMinutes = settings.autopause_end_time;
+    if (startMinutes == null || endMinutes == null) {
+        return deadline;
+    }
+
+    const deadlineDate = new Date(deadline);
+    const localMidnight = new Date(
+        deadlineDate.getFullYear(),
+        deadlineDate.getMonth(),
+        deadlineDate.getDate(),
+    ).getTime();
+    const windowStart = localMidnight + startMinutes * 60000;
+    const windowEnd = localMidnight + endMinutes * 60000;
+
+    if (deadline >= windowStart && deadline < windowEnd) {
+        return deadline + (windowEnd - windowStart);
+    }
+    return deadline;
+}
+
+/**
+ * Ms timestamp the current pick is due, or `null` when there is nothing to
+ * count from (`not-started`, `untimed`). Base is `last_picked ?? start_time`,
+ * plus `pick_timer` seconds, shifted for autopause when the league has it on.
+ */
+export function pickDeadline(draft) {
+    const mode = pickClockMode(draft);
+    if (mode === 'not-started' || mode === 'complete' || mode === 'untimed') {
+        return null;
+    }
+
+    const settings = draft.settings ?? {};
+    const base = draft.last_picked ?? draft.start_time;
+    const naiveDeadline = base + settings.pick_timer * 1000;
+
+    if (!settings.autopause_enabled) {
+        return naiveDeadline;
+    }
+    return applyAutopauseShift(naiveDeadline, settings);
+}
+
+function formatCoarse(msLeft) {
+    const totalMinutes = Math.floor(msLeft / 60000);
+    const days = Math.floor(totalMinutes / 1440);
+    const hours = Math.floor((totalMinutes % 1440) / 60);
+    const minutes = totalMinutes % 60;
+
+    if (days > 0) {
+        return `${days}d ${hours}h`;
+    }
+    if (hours > 0) {
+        return `${hours}h ${minutes}m`;
+    }
+    return `${minutes}m`;
+}
+
+/**
+ * Renders time remaining for `live`/`slow` modes. `live` counts seconds as
+ * `M:SS`; `slow` uses the largest two coarse units (`3h 42m`, `1d 4h`,
+ * `12m`). Anything at or past the deadline reads `'Time expired'` - the one
+ * exception is a `live` countdown whose true remainder has floored to
+ * (0, 1000)ms, which still reads as the terminal `0:00` rather than jumping
+ * straight to the expired message.
+ */
+export function formatTimeLeft(msLeft, mode) {
+    if (msLeft <= 0) {
+        return 'Time expired';
+    }
+
+    if (mode === 'live') {
+        const totalSeconds = Math.floor(msLeft / 1000);
+        const minutes = Math.floor(totalSeconds / 60);
+        const seconds = totalSeconds % 60;
+        return `${minutes}:${String(seconds).padStart(2, '0')}`;
+    }
+
+    return formatCoarse(msLeft);
+}
+
+/**
+ * How often to re-poll the sync endpoint: fast for a live-paced draft, slow
+ * otherwise. Hammering the endpoint every 3 seconds against a 24-hour clock
+ * is wasted battery on the device that matters.
+ */
+export function pollIntervalMs(draft) {
+    return pickClockMode(draft) === 'live' ? 3000 : 30000;
+}

--- a/src/lib/draftClock.test.js
+++ b/src/lib/draftClock.test.js
@@ -1,0 +1,239 @@
+import { describe, expect, it } from 'vitest';
+import { pickClockMode, pickDeadline, formatTimeLeft, pollIntervalMs } from './draftClock';
+
+const NOW = Date.UTC(2026, 6, 27, 12, 0, 0);
+
+describe('pickClockMode', () => {
+    it('is not-started for a pre_draft league regardless of pick_timer', () => {
+        expect(
+            pickClockMode({ status: 'pre_draft', start_time: null, last_picked: null, settings: { pick_timer: 60 } }),
+        ).toBe('not-started');
+    });
+
+    it('is not-started when neither last_picked nor start_time exists, even mid-draft status', () => {
+        expect(
+            pickClockMode({
+                status: 'drafting',
+                start_time: null,
+                last_picked: null,
+                settings: { pick_timer: 60 },
+            }),
+        ).toBe('not-started');
+    });
+
+    // Three of the five real leagues are complete. Their last_picked and
+    // pick_timer are both real, so the arithmetic yields a deadline that
+    // expired when the draft ended - a finished board would have read
+    // "Time expired" indefinitely.
+    it('is complete for a finished draft that still carries a timer', () => {
+        expect(
+            pickClockMode({
+                status: 'complete',
+                start_time: NOW - 86400000,
+                last_picked: NOW - 3600000,
+                settings: { pick_timer: 43200 },
+            }),
+        ).toBe('complete');
+    });
+
+    it('has no deadline to count down to once the draft is complete', () => {
+        expect(
+            pickDeadline({
+                status: 'complete',
+                start_time: NOW - 86400000,
+                last_picked: NOW - 3600000,
+                settings: { pick_timer: 43200 },
+            }),
+        ).toBeNull();
+    });
+
+    it('is untimed when pick_timer is 0', () => {
+        expect(
+            pickClockMode({ status: 'drafting', start_time: NOW, last_picked: null, settings: { pick_timer: 0 } }),
+        ).toBe('untimed');
+    });
+
+    it('is untimed when pick_timer is missing entirely', () => {
+        expect(pickClockMode({ status: 'drafting', start_time: NOW, last_picked: null, settings: {} })).toBe('untimed');
+    });
+
+    it('is live at 899 seconds', () => {
+        expect(
+            pickClockMode({ status: 'drafting', start_time: NOW, last_picked: null, settings: { pick_timer: 899 } }),
+        ).toBe('live');
+    });
+
+    it('is slow at exactly 900 seconds - the boundary belongs to slow', () => {
+        expect(
+            pickClockMode({ status: 'drafting', start_time: NOW, last_picked: null, settings: { pick_timer: 900 } }),
+        ).toBe('slow');
+    });
+
+    it('is slow for a 24-hour dynasty rookie pace', () => {
+        expect(
+            pickClockMode({
+                status: 'drafting',
+                start_time: NOW,
+                last_picked: null,
+                settings: { pick_timer: 86400 },
+            }),
+        ).toBe('slow');
+    });
+});
+
+describe('pickDeadline', () => {
+    it('is null when not-started', () => {
+        expect(pickDeadline({ status: 'pre_draft', start_time: null, last_picked: null, settings: {} })).toBeNull();
+    });
+
+    it('is null when untimed', () => {
+        expect(
+            pickDeadline({ status: 'drafting', start_time: NOW, last_picked: null, settings: { pick_timer: 0 } }),
+        ).toBeNull();
+    });
+
+    it('bases the deadline on last_picked over start_time once a pick has landed', () => {
+        const lastPicked = NOW;
+        const deadline = pickDeadline({
+            status: 'drafting',
+            start_time: NOW - 100000,
+            last_picked: lastPicked,
+            settings: { pick_timer: 60 },
+        });
+        expect(deadline).toBe(lastPicked + 60000);
+    });
+
+    it('falls back to start_time before the first pick', () => {
+        const deadline = pickDeadline({
+            status: 'drafting',
+            start_time: NOW,
+            last_picked: null,
+            settings: { pick_timer: 60 },
+        });
+        expect(deadline).toBe(NOW + 60000);
+    });
+
+    it('leaves the deadline untouched when autopause_enabled is falsy, even with a window that would otherwise apply', () => {
+        // last_picked lands right at local midnight; autopause window is
+        // 07:00-13:00 the same day, so a naive deadline shortly after
+        // midnight would NOT fall in the window anyway. Use a base that
+        // lands inside 07:00-13:00 to prove the flag - not the window - is
+        // what gates the shift.
+        const midnight = new Date(2026, 6, 27, 0, 0, 0).getTime();
+        const lastPicked = midnight + 8 * 3600000; // 08:00 local
+        const deadline = pickDeadline({
+            status: 'drafting',
+            start_time: null,
+            last_picked: lastPicked,
+            settings: {
+                pick_timer: 60,
+                autopause_enabled: 0,
+                autopause_start_time: 420, // 07:00
+                autopause_end_time: 780, // 13:00
+            },
+        });
+        // Naive deadline, no shift applied because autopause is disabled.
+        expect(deadline).toBe(lastPicked + 60000);
+    });
+
+    it('pushes the deadline out by the window length when autopause is enabled and the deadline lands inside it', () => {
+        const midnight = new Date(2026, 6, 27, 0, 0, 0).getTime();
+        const lastPicked = midnight + 8 * 3600000; // 08:00 local
+        const windowStart = midnight + 420 * 60000; // 07:00
+        const windowEnd = midnight + 780 * 60000; // 13:00
+        const deadline = pickDeadline({
+            status: 'drafting',
+            start_time: null,
+            last_picked: lastPicked,
+            settings: {
+                pick_timer: 60,
+                autopause_enabled: 1,
+                autopause_start_time: 420,
+                autopause_end_time: 780,
+            },
+        });
+        const naiveDeadline = lastPicked + 60000;
+        expect(naiveDeadline).toBeGreaterThanOrEqual(windowStart);
+        expect(naiveDeadline).toBeLessThan(windowEnd);
+        expect(deadline).toBe(naiveDeadline + (windowEnd - windowStart));
+    });
+
+    it('does not shift a deadline that falls outside the autopause window even when enabled', () => {
+        const midnight = new Date(2026, 6, 27, 0, 0, 0).getTime();
+        const lastPicked = midnight + 20 * 3600000; // 20:00 local, well after the window
+        const deadline = pickDeadline({
+            status: 'drafting',
+            start_time: null,
+            last_picked: lastPicked,
+            settings: {
+                pick_timer: 60,
+                autopause_enabled: 1,
+                autopause_start_time: 420,
+                autopause_end_time: 780,
+            },
+        });
+        expect(deadline).toBe(lastPicked + 60000);
+    });
+});
+
+describe('formatTimeLeft', () => {
+    it('formats live mode as M:SS', () => {
+        expect(formatTimeLeft(88000, 'live')).toBe('1:28');
+    });
+
+    it('floors a small positive remainder to 0:00 rather than showing a negative', () => {
+        expect(formatTimeLeft(400, 'live')).toBe('0:00');
+    });
+
+    it('reports Time expired once truly past the deadline in live mode', () => {
+        expect(formatTimeLeft(-1, 'live')).toBe('Time expired');
+        expect(formatTimeLeft(0, 'live')).toBe('Time expired');
+    });
+
+    it('formats slow mode with the largest two coarse units - hours and minutes', () => {
+        const msLeft = 3 * 3600000 + 42 * 60000;
+        expect(formatTimeLeft(msLeft, 'slow')).toBe('3h 42m');
+    });
+
+    it('formats slow mode with days and hours once a full day is left', () => {
+        const msLeft = 1 * 86400000 + 4 * 3600000;
+        expect(formatTimeLeft(msLeft, 'slow')).toBe('1d 4h');
+    });
+
+    it('formats slow mode with just minutes under an hour', () => {
+        expect(formatTimeLeft(12 * 60000, 'slow')).toBe('12m');
+    });
+
+    it('reports Time expired for a past deadline in slow mode too', () => {
+        expect(formatTimeLeft(-60000, 'slow')).toBe('Time expired');
+    });
+});
+
+describe('pollIntervalMs', () => {
+    it('polls every 3 seconds in live mode', () => {
+        expect(
+            pollIntervalMs({ status: 'drafting', start_time: NOW, last_picked: null, settings: { pick_timer: 30 } }),
+        ).toBe(3000);
+    });
+
+    it('polls every 30 seconds in slow mode', () => {
+        expect(
+            pollIntervalMs({
+                status: 'drafting',
+                start_time: NOW,
+                last_picked: null,
+                settings: { pick_timer: 86400 },
+            }),
+        ).toBe(30000);
+    });
+
+    it('polls every 30 seconds when untimed', () => {
+        expect(
+            pollIntervalMs({ status: 'drafting', start_time: NOW, last_picked: null, settings: { pick_timer: 0 } }),
+        ).toBe(30000);
+    });
+
+    it('polls every 30 seconds when not-started', () => {
+        expect(pollIntervalMs({ status: 'pre_draft', start_time: null, last_picked: null, settings: {} })).toBe(30000);
+    });
+});


### PR DESCRIPTION
First piece of step 03. One field drives both halves: `settings.pick_timer` decides what the clock says *and* how often the sync poll runs, so the same screen serves a 24-hour dynasty rookie draft and a live one without being configured for either.

| Mode | When | Shows | Poll |
|---|---|---|---|
| `not-started` | `pre_draft`, or nothing to count from | "Draft hasn't started" | 30s |
| `complete` | finished | "Draft complete" | 30s |
| `untimed` | `pick_timer: 0` | "Untimed draft" | 30s |
| `slow` | ≥ 15 min | `3h 42m` | 30s |
| `live` | < 15 min | `1:28`, ticking | **3s** |

The arithmetic is pure functions in `src/lib/draftClock.js` (a new module — no existing one was touched) and is tested there. `PickClock` only owns the timer and the rendering, and starts **no interval at all** in the three static states.

**Untimed is a first-class state, not a null.** One of the five real leagues is `pick_timer: 0`, and it is the state most likely to render as "NaN left".

### The `complete` state came from the browser, not the spec

I asked for four modes. A finished draft still carries a real `last_picked` and a real `pick_timer`, so the naive deadline expired whenever the draft ended — **four of the five real leagues rendered "Time expired"**, indefinitely. Every one now reads "Draft complete", and District 13 (`pre_draft`, null `start_time`) reads "Draft hasn't started". Verified by driving all five leagues through the switcher.

`live` and `slow` have no real league to exercise them — none of the five is currently drafting — so those two are covered by unit tests only, and this PR does not claim otherwise.

**Autopause is implemented but gated and unverified.** Every real league has `autopause_enabled: 0`, so all of them take the naive deadline. The minutes-since-local-midnight reading of `autopause_start_time`/`autopause_end_time` is an assumption, and the comment in the code says exactly that.

`DraftPanel`'s poll now follows `pollIntervalMs`, keeping the `cancelled` re-check that lets the loop stop mid-flight.

### Sabotage

| Sabotage | Result |
|---|---|
| drop the `complete` state | fails 3 tests, all of them the new ones |
| poll always at 3s | fails 4 cadence tests |
| untimed falls through to the countdown | fails "reads untimed without rendering any countdown, NaN, or bare 0:00" |

Also changed the slow-mode label from "Time left until autopick" to "Time left": whether an expired pick is auto-made depends on league settings nobody has verified, and the clock shouldn't assert it.

Tests 201 → 237. All six gates clean including `npm ci`.