### PR TITLE
Add the grid view of the draft board

### DIFF
--- a/src/Components/SegmentedControl.jsx
+++ b/src/Components/SegmentedControl.jsx
@@ -1,0 +1,32 @@
+// A two-state (or more) segmented control. Used both for the Feed/Grid
+// toggle in DraftPanel and the Overview/Readable zoom switch in DraftGrid -
+// pulled out here rather than written twice so the two don't drift apart.
+const SegmentedControl = ({ label, options, value, onChange }) => (
+    <div
+        role="group"
+        aria-label={label}
+        className="border-line m-0 inline-flex gap-0.5 rounded-[6px] border border-solid p-0.5"
+    >
+        {options.map((option) => (
+            <button
+                key={option.value}
+                type="button"
+                aria-pressed={value === option.value}
+                onClick={() => onChange(option.value)}
+                // Selection reads through contrast and elevation, not hue. Violet
+                // is reserved for "yours" - your picks, your slots, your turn - so
+                // a filled violet segment would say this view belongs to you.
+                // Same rule that took the old teal fill off the filter chips.
+                className={`m-0 min-h-11 appearance-none rounded-[4px] px-3 py-1 text-sm ${
+                    value === option.value
+                        ? 'border-ink-muted! bg-line! text-ink! border border-solid font-semibold'
+                        : 'text-ink-muted border-0 bg-transparent'
+                }`}
+            >
+                {option.label}
+            </button>
+        ))}
+    </div>
+);
+
+export default SegmentedControl;

--- a/src/Panels/DraftGrid.jsx
+++ b/src/Panels/DraftGrid.jsx
@@ -1,0 +1,221 @@
+import { useState, useMemo } from 'react';
+import ManualPickModal from './ManualPickModal';
+import SegmentedControl from '../Components/SegmentedControl';
+import { applyManualPick } from '../lib/liveDraft.js';
+import { managerLabel, pickAccessibleName, pickNumberLabel, positionClass } from './pickLabels.js';
+
+const ZOOM_OPTIONS = [
+    { value: 'overview', label: 'Overview' },
+    { value: 'readable', label: 'Readable' },
+];
+
+// First-initial + surname, e.g. "Jordan Love" -> "J.Love". A multi-word
+// surname (a suffix, "St. Brown") keeps everything after the first token as
+// one piece - this only has to fit a 75px cell, not read as a full name.
+const shortPlayerName = (fullName) => {
+    const [first, ...rest] = fullName.trim().split(' ');
+    return rest.length === 0 ? first : `${first[0]}.${rest.join(' ')}`;
+};
+
+// Team columns are keyed by board_spot, not by pick_number: pick_number
+// reverses every other round on a snake draft, but board_spot - the original
+// slot_to_roster_id slot - does not, so it is the one column identity that
+// stays put across every round. Read off round 0 because that mapping is
+// fixed for the whole draft (see buildDraftRounds/createPickOrder).
+const buildTeamColumns = (builtDraft) =>
+    [...builtDraft[0].picks]
+        .sort((a, b) => a.board_spot - b.board_spot)
+        .map((pick) => ({ boardSpot: pick.board_spot, rosterId: pick.roster_id }));
+
+const findPick = (round, boardSpot) => round.picks.find((pick) => pick.board_spot === boardSpot);
+
+// One cell of the board: a button carrying the same accessible name PickRow
+// builds for the feed, so the same pick reads identically in either view.
+const GridCell = ({ round, pick, playerInfo, rosterData, myDisplayName, zoom, onSelect }) => {
+    const player = pick.player_id ? playerInfo[pick.player_id] : null;
+    const owner = pick.owner_id ? rosterData.find((roster) => roster.roster_id === pick.owner_id) : null;
+    const isMine = Boolean(owner?.manager_display_name) && owner.manager_display_name === myDisplayName;
+    const manager = managerLabel({ pick, rosterData, myDisplayName });
+    const accessibleName = pickAccessibleName({ round, pick, player, manager });
+    const isMade = Boolean(pick.player_id);
+
+    // A made pick fills with the position colour (near-black text on top of
+    // it); an unmade one stays a dashed, unfilled cell so the two can never be
+    // confused for one another, even at a glance in overview mode.
+    const stateClasses = isMade
+        ? `border-0 text-ground ${positionClass(player?.position)}`
+        : 'border border-dashed border-line bg-transparent text-ink-muted';
+
+    // Violet marks "yours" as an outline, not a fill, so the position colour
+    // underneath a made pick still shows through. `!` because outline and
+    // border/background utilities can otherwise be reordered by Tailwind's
+    // group-based stylesheet output rather than by where they read here.
+    const mineClasses = isMine ? 'outline! outline-2! outline-mine! outline-offset-[-2px]!' : '';
+
+    return (
+        <td className="box-border p-0">
+            <button
+                type="button"
+                aria-label={accessibleName}
+                onClick={onSelect}
+                className={`m-0 flex h-[var(--cell-h)] w-[var(--cell-w)] appearance-none flex-col items-center justify-center overflow-hidden rounded-none p-0.5 text-[10px] leading-tight ${stateClasses} ${mineClasses}`}
+            >
+                {/* Overview is position colour only, no text at all - that is
+                    the whole point of the zoom level, so nothing renders here
+                    when zoom !== 'readable'. */}
+                {zoom === 'readable' && (
+                    <>
+                        <span className="w-full truncate text-center font-semibold">
+                            {isMade ? (player ? shortPlayerName(player.full_name) : `#${pick.player_id}`) : ''}
+                        </span>
+                        <span className="w-full truncate text-center text-[9px] opacity-80">
+                            {isMade
+                                ? `${player?.team ?? '—'} · ${pickNumberLabel(round, pick)}`
+                                : pickNumberLabel(round, pick)}
+                        </span>
+                    </>
+                )}
+            </button>
+        </td>
+    );
+};
+
+// The grid view of the draft board: teams across the top, rounds down the
+// side, both frozen so a cell scrolled into the middle of the board is still
+// identifiable. See the PR description for why this layout (not the
+// transposed one) and why two zoom stops (not four).
+const DraftGrid = ({
+    builtDraft,
+    playerInfo,
+    rosterInfo,
+    rosterData,
+    rankingPlayersIdsList,
+    myDisplayName,
+    onPickChange,
+}) => {
+    const [zoom, setZoom] = useState('overview');
+    const [activePick, setActivePick] = useState(null);
+
+    const teamColumns = useMemo(() => buildTeamColumns(builtDraft), [builtDraft]);
+
+    const openPick = (round, pick) => setActivePick({ round, pick });
+    const closeModal = () => setActivePick(null);
+
+    const selectPlayer = (playerID) => {
+        const updatedRound = applyManualPick({
+            round: activePick.round,
+            currentManualPick: activePick.pick,
+            playerID,
+        });
+        onPickChange(updatedRound);
+        closeModal();
+    };
+
+    const teamLabel = (rosterId) => {
+        const roster = rosterData.find((r) => r.roster_id === rosterId);
+        return roster?.manager_display_name ?? `Unassigned ${rosterId}`;
+    };
+
+    const headerCellClasses =
+        'border-line bg-ground text-ink sticky top-0 z-10 box-border border border-solid p-1 text-xs font-semibold truncate';
+    const gutterCellClasses =
+        'border-line bg-ground text-ink sticky left-0 z-10 box-border w-10 border border-solid p-1 text-xs font-semibold';
+
+    return (
+        <div>
+            <SegmentedControl label="Zoom level" options={ZOOM_OPTIONS} value={zoom} onChange={setZoom} />
+            {/* This scroll container is the containing block every sticky cell
+                below travels within. The table must NOT be told to fill it
+                (no w-full, no flex-1) - it needs its own natural, wider-than-
+                the-container width for the sticky round gutter and team
+                header to have anywhere to travel to as the container scrolls. */}
+            <div className="max-h-[70vh] overflow-auto">
+                {/* table-layout: fixed only truly ignores cell content - a long
+                    manager name, in particular - when the table ALSO has an
+                    explicit width rather than 'auto'. Verified directly: with
+                    `width: auto`, Chrome still expands columns to fit content
+                    even though computed tableLayout reads 'fixed' and a
+                    <colgroup> sets 23px columns; only pinning the table's own
+                    width (here, gutter + one `--cell-w` per team, via calc())
+                    made columns actually hold their specified width. That is
+                    also what keeps overview's "never scrolls horizontally"
+                    guarantee true regardless of how long a manager's display
+                    name is. calc() re-reads `--cell-w` live, so the table
+                    width updates by itself on a zoom switch. */}
+                <table
+                    data-zoom={zoom}
+                    className="draft-grid table-fixed border-collapse"
+                    style={{ width: `calc(2.5rem + ${teamColumns.length} * var(--cell-w))` }}
+                >
+                    <colgroup>
+                        <col className="w-10" />
+                        {teamColumns.map((team) => (
+                            <col key={team.boardSpot} className="w-[var(--cell-w)]" />
+                        ))}
+                    </colgroup>
+                    <thead>
+                        <tr>
+                            <th scope="col" className={`${gutterCellClasses} left-0 z-20`}>
+                                Rd
+                            </th>
+                            {teamColumns.map((team) => (
+                                <th key={team.boardSpot} scope="col" className={headerCellClasses}>
+                                    {teamLabel(team.rosterId)}
+                                </th>
+                            ))}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {builtDraft.map((round) => (
+                            <tr key={round.round}>
+                                {/* Visibly just the number - the column is 40px
+                                    wide - but named in full, so a screen reader
+                                    announcing the row says "Round 2" rather than
+                                    "2". */}
+                                <th scope="row" aria-label={`Round ${round.round}`} className={gutterCellClasses}>
+                                    {round.round}
+                                </th>
+                                {teamColumns.map((team) => {
+                                    const pick = findPick(round, team.boardSpot);
+                                    if (!pick) {
+                                        return (
+                                            <td
+                                                key={team.boardSpot}
+                                                className="border-line box-border h-[var(--cell-h)] w-[var(--cell-w)] border border-solid"
+                                            />
+                                        );
+                                    }
+                                    return (
+                                        <GridCell
+                                            key={team.boardSpot}
+                                            round={round}
+                                            pick={pick}
+                                            playerInfo={playerInfo}
+                                            rosterData={rosterData}
+                                            myDisplayName={myDisplayName}
+                                            zoom={zoom}
+                                            onSelect={() => openPick(round, pick)}
+                                        />
+                                    );
+                                })}
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+            {activePick && (
+                <ManualPickModal
+                    round={activePick.round}
+                    currentManualPick={activePick.pick}
+                    playerInfo={playerInfo}
+                    rosterInfo={rosterInfo}
+                    rankingPlayersIdsList={rankingPlayersIdsList}
+                    onSelect={selectPlayer}
+                    onClose={closeModal}
+                />
+            )}
+        </div>
+    );
+};
+
+export default DraftGrid;

--- a/src/Panels/DraftGrid.test.jsx
+++ b/src/Panels/DraftGrid.test.jsx
@@ -1,0 +1,211 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DraftGrid from './DraftGrid';
+import { pickAccessibleName, managerLabel } from './pickLabels.js';
+import { buildRosterInfo, decorateRosters } from '../lib/rosterInfo.js';
+import rosterFlagsFixture from '../lib/__fixtures__/roster-flags-2026.json';
+import goldenDraft from '../lib/__fixtures__/golden-draft-output.json';
+
+// DraftGrid is the second view of the same board PickFeed already covers, so
+// this file only asserts what's specific to the grid: every pick shows up as
+// a cell at both zoom stops, the accessible name matches the feed's builder
+// exactly (both read off pickLabels.js, so they cannot drift), "mine" marking,
+// unmade-vs-made, and that a cell opens the same modal.
+
+const { rosterDataRaw, managerData, playerInfo, builtDraft } = rosterFlagsFixture;
+
+const rosterData = decorateRosters({ rosterData: rosterDataRaw, managerData });
+const rosterInfo = buildRosterInfo({ rosterData, builtDraft: null });
+
+const FREE_AGENT = { id: '13307', name: 'Marlin Klein' };
+
+// Board spot 3 is roster 1 ("ryangh") in every round of this fixture (the
+// draft is linear, not snake) - same fact PickFeed.test.jsx and
+// App.test.jsx key off.
+const MY_DISPLAY_NAME = 'ryangh';
+
+const rankEntry = (playerId) => ({
+    match_results: [[playerId, '0.000']],
+    ranking: '1',
+    search_string: 'a pasted rank line',
+});
+
+const round = builtDraft[0];
+
+function renderGrid(overrides = {}) {
+    const onPickChange = vi.fn();
+    const props = {
+        builtDraft: [round],
+        playerInfo,
+        rosterInfo,
+        rosterData,
+        rankingPlayersIdsList: [rankEntry(FREE_AGENT.id)],
+        myDisplayName: MY_DISPLAY_NAME,
+        onPickChange,
+        ...overrides,
+    };
+    render(<DraftGrid {...props} />);
+    return { onPickChange };
+}
+
+// Every cell's accessible name follows "Round R, pick N, <manager>[, <player>, <position>]" -
+// build the expected name off the same fixture data pickLabels.js itself reads,
+// rather than hardcoding one example, so this asserts the whole round at once.
+const expectedNameFor = (pick) => {
+    const manager = managerLabel({ pick, rosterData, myDisplayName: MY_DISPLAY_NAME });
+    const player = pick.player_id ? playerInfo[pick.player_id] : null;
+    return pickAccessibleName({ round, pick, player, manager });
+};
+
+const setZoom = async (user, label) => {
+    await user.click(screen.getByRole('button', { name: label }));
+};
+
+describe('DraftGrid cell coverage', () => {
+    it('renders every pick in the round as a cell in overview mode', () => {
+        renderGrid();
+
+        round.picks.forEach((pick) => {
+            expect(screen.getByRole('button', { name: expectedNameFor(pick) })).toBeInTheDocument();
+        });
+    });
+
+    it('renders every pick in the round as a cell in readable mode too', async () => {
+        const user = userEvent.setup();
+        renderGrid();
+
+        await setZoom(user, 'Readable');
+
+        round.picks.forEach((pick) => {
+            expect(screen.getByRole('button', { name: expectedNameFor(pick) })).toBeInTheDocument();
+        });
+    });
+
+    it('gives a cell the same accessible name PickRow builds for the identical pick', () => {
+        renderGrid();
+
+        // Pick 1 of this round is unmade in the raw fixture: manager only, no
+        // player/position segment - matches PickFeed's own "unmade" test.
+        const unmadePick = round.picks.find((pick) => pick.pick_number === 1);
+        expect(unmadePick.player_id).toBeNull();
+        expect(screen.getByRole('button', { name: 'Round 1, pick 1, HEFFinAround305' })).toBeInTheDocument();
+    });
+});
+
+describe('DraftGrid your-pick marking', () => {
+    it('outlines my own pick and leaves everyone else unmarked', () => {
+        renderGrid();
+
+        const myPick = round.picks.find((pick) => pick.pick_number === 3);
+        const othersPick = round.picks.find((pick) => pick.pick_number === 1);
+
+        const myCell = screen.getByRole('button', { name: expectedNameFor(myPick) });
+        const othersCell = screen.getByRole('button', { name: expectedNameFor(othersPick) });
+
+        expect(myCell.className).toMatch(/outline-mine/);
+        expect(othersCell.className).not.toMatch(/outline-mine/);
+    });
+});
+
+describe('DraftGrid unmade vs made picks', () => {
+    it('renders an unmade pick as empty in readable mode rather than as a made pick', async () => {
+        const user = userEvent.setup();
+        renderGrid();
+        await setZoom(user, 'Readable');
+
+        const unmadePick = round.picks.find((pick) => pick.pick_number === 1);
+        const cell = screen.getByRole('button', { name: expectedNameFor(unmadePick) });
+
+        // A made pick's cell shows the player's short name over "TEAM · pick";
+        // an unmade one shows the pick number and nothing else. Asserting the
+        // whole text, rather than just the absence of a short name, is what
+        // makes this fail if the cell ever renders in its made state with no
+        // player - which reads as an em dash where the team should be.
+        expect(cell.textContent.trim()).toBe('1.01');
+        expect(cell.textContent).not.toContain('—');
+    });
+
+    it('renders a made pick with the player visible in readable mode', async () => {
+        const user = userEvent.setup();
+        const filledRound = {
+            ...round,
+            picks: round.picks.map((pick) => (pick.pick_number === 1 ? { ...pick, player_id: FREE_AGENT.id } : pick)),
+        };
+        renderGrid({ builtDraft: [filledRound] });
+        await setZoom(user, 'Readable');
+
+        const filledPick = filledRound.picks.find((pick) => pick.pick_number === 1);
+        const cell = screen.getByRole('button', { name: expectedNameFor(filledPick) });
+
+        expect(within(cell).getByText('M.Klein')).toBeInTheDocument();
+    });
+});
+
+describe('DraftGrid column identity on a snake board', () => {
+    // On a linear board pick_number and board_spot are the same number in
+    // every round, so keying the columns off the wrong one looks perfectly
+    // correct - the right and wrong answers coincide. Round 2 of the snake
+    // fixture reverses: pick_number 1 sits in board_spot 12.
+    const snakeBoard = goldenDraft.snake.built_draft;
+    const snakeRound2 = snakeBoard[1];
+
+    it('puts a pick in its board_spot column, not its pick_number column', async () => {
+        const user = userEvent.setup();
+        render(
+            <DraftGrid
+                builtDraft={snakeBoard}
+                playerInfo={playerInfo}
+                rosterInfo={rosterInfo}
+                rosterData={rosterData}
+                rankingPlayersIdsList={[]}
+                myDisplayName={MY_DISPLAY_NAME}
+                onPickChange={vi.fn()}
+            />,
+        );
+        await setZoom(user, 'Readable');
+
+        const reversed = snakeRound2.picks.find((pick) => pick.pick_number === 1);
+        expect(reversed.board_spot).not.toBe(reversed.pick_number);
+
+        const row = screen.getByRole('rowheader', { name: 'Round 2' }).closest('tr');
+        const cells = within(row).getAllByRole('button');
+        const columnIndex = snakeBoard[0].picks
+            .map((pick) => pick.board_spot)
+            .sort((a, b) => a - b)
+            .indexOf(reversed.board_spot);
+
+        expect(cells[columnIndex].getAttribute('aria-label')).toContain('pick 1,');
+    });
+});
+
+describe('DraftGrid modal', () => {
+    it('opens the manual-pick modal for the clicked cell', async () => {
+        const user = userEvent.setup();
+        renderGrid();
+
+        const unmadePick = round.picks.find((pick) => pick.pick_number === 1);
+        await user.click(screen.getByRole('button', { name: expectedNameFor(unmadePick) }));
+
+        expect(screen.getByText(`Manually select pick ${round.round}.${unmadePick.pick_number}`)).toBeInTheDocument();
+    });
+});
+
+describe('DraftGrid zoom control', () => {
+    it('starts in overview, where cells carry no visible player text', () => {
+        renderGrid();
+
+        expect(screen.getByRole('button', { name: 'Overview' })).toHaveAttribute('aria-pressed', 'true');
+        expect(screen.getByRole('button', { name: 'Readable' })).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('switches to readable mode on click', async () => {
+        const user = userEvent.setup();
+        renderGrid();
+
+        await setZoom(user, 'Readable');
+
+        expect(screen.getByRole('button', { name: 'Readable' })).toHaveAttribute('aria-pressed', 'true');
+        expect(screen.getByRole('button', { name: 'Overview' })).toHaveAttribute('aria-pressed', 'false');
+    });
+});

--- a/src/Panels/DraftPanel.jsx
+++ b/src/Panels/DraftPanel.jsx
@@ -1,11 +1,18 @@
 import { useState, useEffect, useRef } from 'react';
 import Button from '../Components/Button';
+import SegmentedControl from '../Components/SegmentedControl';
 import PickFeed from './PickFeed';
+import DraftGrid from './DraftGrid';
 import PickClock from '../Components/PickClock';
 import { SLEEPER_API_URLS } from '../urls';
 import { syncLiveDraft } from '../lib/liveDraft.js';
 import { pollIntervalMs } from '../lib/draftClock.js';
 const { DRAFT, PICKS, TRADED_PICKS } = SLEEPER_API_URLS;
+
+const VIEW_OPTIONS = [
+    { value: 'feed', label: 'Feed' },
+    { value: 'grid', label: 'Grid' },
+];
 
 const DraftPanel = ({ leagueData, playerInfo, rosterInfo, rankingPlayersIdsList, myDisplayName, updateDraftBoard }) => {
     const { currentDraft, rosterData } = leagueData;
@@ -13,6 +20,9 @@ const DraftPanel = ({ leagueData, playerInfo, rosterInfo, rankingPlayersIdsList,
     const [isSyncing, setIsSyncing] = useState(false);
     const [currentDraftId, setCurrentDraftId] = useState(currentDraft.draft_id);
     const [DRAFT_PATH, setDraftPath] = useState(draftPath);
+    // Feed is the default view - the grid is the newer, denser one and
+    // shouldn't change what people already sync a draft against.
+    const [boardView, setBoardView] = useState('feed');
 
     const updateDraftID = (val) => {
         setCurrentDraftId(val);
@@ -124,15 +134,35 @@ const DraftPanel = ({ leagueData, playerInfo, rosterInfo, rankingPlayersIdsList,
             </div>
             <div className="player-grid">
                 {currentDraft.built_draft && (
-                    <PickFeed
-                        builtDraft={currentDraft.built_draft}
-                        playerInfo={playerInfo}
-                        rosterInfo={rosterInfo}
-                        rankingPlayersIdsList={rankingPlayersIdsList}
-                        rosterData={rosterData}
-                        myDisplayName={myDisplayName}
-                        onPickChange={handlePickChange}
-                    />
+                    <>
+                        <SegmentedControl
+                            label="Draft board view"
+                            options={VIEW_OPTIONS}
+                            value={boardView}
+                            onChange={setBoardView}
+                        />
+                        {boardView === 'feed' ? (
+                            <PickFeed
+                                builtDraft={currentDraft.built_draft}
+                                playerInfo={playerInfo}
+                                rosterInfo={rosterInfo}
+                                rankingPlayersIdsList={rankingPlayersIdsList}
+                                rosterData={rosterData}
+                                myDisplayName={myDisplayName}
+                                onPickChange={handlePickChange}
+                            />
+                        ) : (
+                            <DraftGrid
+                                builtDraft={currentDraft.built_draft}
+                                playerInfo={playerInfo}
+                                rosterInfo={rosterInfo}
+                                rankingPlayersIdsList={rankingPlayersIdsList}
+                                rosterData={rosterData}
+                                myDisplayName={myDisplayName}
+                                onPickChange={handlePickChange}
+                            />
+                        )}
+                    </>
                 )}
             </div>
         </div>

--- a/src/Panels/DraftPanel.test.jsx
+++ b/src/Panels/DraftPanel.test.jsx
@@ -389,3 +389,39 @@ describe('DraftPanel', () => {
         expect(global.fetch.mock.calls.length).toBe(4); // now the second tick lands
     });
 });
+
+describe('DraftPanel board view toggle', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        global.fetch = vi.fn(instantFetch);
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('renders the feed by default', () => {
+        renderPanel();
+
+        // The feed groups picks into per-round lists; the grid does not.
+        expect(screen.getByRole('list', { name: 'Round 1' })).toBeInTheDocument();
+        expect(button('Feed')).toHaveAttribute('aria-pressed', 'true');
+        expect(button('Grid')).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('switches to the grid view and back on click', async () => {
+        renderPanel();
+
+        await click(button('Grid'));
+
+        expect(screen.queryByRole('list', { name: 'Round 1' })).toBeNull();
+        expect(button('Grid')).toHaveAttribute('aria-pressed', 'true');
+        // The grid's own zoom control is now on screen alongside the toggle.
+        expect(button('Overview')).toBeInTheDocument();
+
+        await click(button('Feed'));
+
+        expect(screen.getByRole('list', { name: 'Round 1' })).toBeInTheDocument();
+        expect(screen.queryByRole('button', { name: 'Overview' })).toBeNull();
+    });
+});

--- a/src/Panels/PickRow.jsx
+++ b/src/Panels/PickRow.jsx
@@ -1,37 +1,4 @@
-// Position colour classes have to be static strings for Tailwind's scanner to
-// pick them up - a template literal built from `player.position` at runtime
-// would never appear in the generated stylesheet.
-const POSITION_BG = {
-    QB: 'bg-qb',
-    RB: 'bg-rb',
-    WR: 'bg-wr',
-    TE: 'bg-te',
-};
-
-// K and DEF have no colour in the palette - only the four skill positions
-// encode data - so they fall back to a neutral chip rather than to the string
-// "undefined" as a class name.
-const positionClass = (position) => POSITION_BG[position] ?? 'bg-line text-ink';
-
-const pickNumberLabel = (round, pick) => `${round.round}.${String(pick.pick_number).padStart(2, '0')}`;
-
-// Builds the manager attribution text once so the visible label and the
-// button's accessible name can't drift apart - both read off this same
-// string.
-const managerLabel = ({ pick, rosterData, myDisplayName }) => {
-    const owner = pick.owner_id ? rosterData.find((roster) => roster.roster_id === pick.owner_id) : null;
-    if (!owner?.manager_display_name) {
-        return 'Pick owner missing';
-    }
-    let label = owner.manager_display_name;
-    if (pick.is_traded && pick.roster_id !== pick.owner_id) {
-        const original = rosterData.find((roster) => roster.roster_id === pick.roster_id);
-        label += ` via ${original?.manager_display_name}`;
-    }
-    // "you" marks the whole attribution, so it goes last: a traded pick of
-    // yours reads "ryangh via crbiehl · you", not "ryangh · you via crbiehl".
-    return owner.manager_display_name === myDisplayName ? `${label} · you` : label;
-};
+import { managerLabel, pickAccessibleName, pickNumberLabel, positionClass } from './pickLabels.js';
 
 const PickRow = ({ round, pick, playerInfo, rosterData, myDisplayName, onSelect }) => {
     // The player database is a snapshot and a drafted player can be absent
@@ -45,15 +12,7 @@ const PickRow = ({ round, pick, playerInfo, rosterData, myDisplayName, onSelect 
     const isMine = Boolean(owner?.manager_display_name) && owner.manager_display_name === myDisplayName;
     const manager = managerLabel({ pick, rosterData, myDisplayName });
     const pickNumber = pickNumberLabel(round, pick);
-
-    const nameParts = [`Round ${round.round}`, `pick ${pick.pick_number}`, manager];
-    if (pick.player_id) {
-        nameParts.push(player ? player.full_name : `Unknown player ${pick.player_id}`);
-        if (player) {
-            nameParts.push(player.position);
-        }
-    }
-    const accessibleName = nameParts.join(', ');
+    const accessibleName = pickAccessibleName({ round, pick, player, manager });
 
     return (
         <li>

--- a/src/Panels/pickLabels.js
+++ b/src/Panels/pickLabels.js
@@ -1,0 +1,55 @@
+// Shared between PickFeed's rows and DraftGrid's cells so the accessible name
+// and the position colour classes can't drift between the two views of the
+// same board - they used to live only inside PickRow, duplicated here would
+// have been a second copy of exactly the logic the tests key off.
+
+// Position colour classes have to be static strings for Tailwind's scanner to
+// pick them up - a template literal built from `player.position` at runtime
+// would never appear in the generated stylesheet.
+const POSITION_BG = {
+    QB: 'bg-qb',
+    RB: 'bg-rb',
+    WR: 'bg-wr',
+    TE: 'bg-te',
+};
+
+// K and DEF have no colour in the palette - only the four skill positions
+// encode data - so they fall back to a neutral chip rather than to the string
+// "undefined" as a class name.
+export const positionClass = (position) => POSITION_BG[position] ?? 'bg-line text-ink';
+
+export const pickNumberLabel = (round, pick) => `${round.round}.${String(pick.pick_number).padStart(2, '0')}`;
+
+// Builds the manager attribution text once so the visible label and the
+// button's accessible name can't drift apart - both read off this same
+// string.
+export const managerLabel = ({ pick, rosterData, myDisplayName }) => {
+    const owner = pick.owner_id ? rosterData.find((roster) => roster.roster_id === pick.owner_id) : null;
+    if (!owner?.manager_display_name) {
+        return 'Pick owner missing';
+    }
+    let label = owner.manager_display_name;
+    if (pick.is_traded && pick.roster_id !== pick.owner_id) {
+        const original = rosterData.find((roster) => roster.roster_id === pick.roster_id);
+        label += ` via ${original?.manager_display_name}`;
+    }
+    // "you" marks the whole attribution, so it goes last: a traded pick of
+    // yours reads "ryangh via crbiehl · you", not "ryangh · you via crbiehl".
+    return owner.manager_display_name === myDisplayName ? `${label} · you` : label;
+};
+
+// Builds the accessible name shared by the feed's rows and the grid's cells:
+// "Round 1, pick 3, ryangh · you, Carnell Tate, WR" for a made pick, or
+// "Round 1, pick 1, HEFFinAround305" for one that hasn't happened yet. `player`
+// is null both when the pick is unmade and when the drafted id is missing from
+// the player database - the two are told apart by `pick.player_id`.
+export const pickAccessibleName = ({ round, pick, player, manager }) => {
+    const nameParts = [`Round ${round.round}`, `pick ${pick.pick_number}`, manager];
+    if (pick.player_id) {
+        nameParts.push(player ? player.full_name : `Unknown player ${pick.player_id}`);
+        if (player) {
+            nameParts.push(player.position);
+        }
+    }
+    return nameParts.join(', ');
+};

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -77,3 +77,22 @@
     --color-danger: var(--raw-danger);
     --color-warn: var(--raw-warn);
 }
+
+/*
+ * DraftGrid's two zoom stops. Cell size is runtime state (a click on the
+ * zoom control), not something a fixed set of utility classes can express -
+ * so it lives here as plain custom properties switched by the `data-zoom`
+ * attribute DraftGrid sets on its table root, and the component consumes them
+ * through arbitrary-value utilities (`w-[var(--cell-w)]` etc).
+ */
+@layer components {
+    .draft-grid[data-zoom='overview'] {
+        --cell-w: 23px;
+        --cell-h: 23px;
+    }
+
+    .draft-grid[data-zoom='readable'] {
+        --cell-w: 75px;
+        --cell-h: 38px;
+    }
+}


### PR DESCRIPTION
Step 03's third piece: the board's second view, plus the Feed/Grid toggle. Ranks sheet and jump-to-feed-from-a-cell are still to come.

**Classic orientation** — teams across, rounds down — because its horizontal cost is set by *teams* (~12 in every league here), so it stays a constant ~2.8 screens whether the draft runs 4 rounds or 24. Transposed spends the phone's narrow axis on rounds and by 24 of them needs 1.9 screens for its *overview* alone.

**Two zoom stops, not four:**

| | Cell | Content | Measured |
|---|---|---|---|
| Overview | 23px | position colour only | 347px of content in a 347px container at 375, 597 in 597 at 1280 — **never scrolls horizontally** |
| Readable | 75×38 | `J.Love` over `LAC · 1.03` | scrolls, ~2.7 screens |

The position abbreviation is deliberately **not** in the cell — the background already is the position, and printing it costs the room that carries the team and pick number instead (`WAS · RB · 1.01` needs 71px of a 65px interior; `WAS · 1.01` needs 47px).

### Frozen headers, verified by scrolling rather than by looking

At 375, scrolled to the middle of both axes: the team header sits at the container's top (362 vs 361) and the round gutter at its left (14 vs 14). Same at 1280.

The table needs its own explicit width for this: **`table-layout: fixed` only ignores cell content when the width is pinned** — with `width: auto` Chrome still widened columns to fit a long manager name even though computed `tableLayout` read `fixed`. That was the subagent's find, isolated with injected test tables in the live page, and it is what keeps overview's no-scroll guarantee true regardless of how long a display name is.

### Two sabotages passed, and both are now closed

| Sabotage | First run | After |
|---|---|---|
| columns keyed off `pick_number` instead of `board_spot` | **passed everything** | fails the new snake-board test |
| unmade picks render in their made state | **passed everything** | fails the strengthened empty-cell test |

The first is the "right and wrong answers coincide" trap: on a linear board `pick_number` and `board_spot` are the same number in every round, so only the `snake` golden fixture (where round 2's pick 1 sits in board spot 12) can tell them apart. The second passed because "shows no short name" is satisfied by an empty first line; it now asserts the cell's whole text.

Three more sabotages failed correctly: dropping the "yours" outline, and diverging the grid's accessible name from the feed's (fails 4, since both views read one builder).

Cells and rows share `pickLabels.js`, so the same pick reads identically in either view. Round gutters carry `aria-label="Round 2"` so a screen reader doesn't just hear "2".

**Selected segments use contrast and elevation, not hue.** The first cut filled the active segment with violet; violet is reserved for "yours" and would have said the view belongs to you. It marks your picks in the grid as an *outline* so the position colour underneath survives.

Tests 243 → 255. All six gates clean including `npm ci`.