### PR TITLE
Add a best-available sheet under the draft board on phones

### DIFF
--- a/src/Components/AppShell.jsx
+++ b/src/Components/AppShell.jsx
@@ -41,7 +41,7 @@ const AppShell = ({ sections, renderSection, renderAside, leagueBar, defaultSect
                 </main>
                 <nav
                     aria-label="Sections"
-                    className="border-line bg-raised fixed inset-x-0 bottom-0 z-10 flex border-t border-solid md:static md:order-1 md:border-t-0 md:border-b md:border-solid"
+                    className="border-line bg-raised fixed inset-x-0 bottom-0 z-10 box-border flex h-[var(--tab-bar-h)] border-t border-solid md:static md:order-1 md:h-auto md:border-t-0 md:border-b md:border-solid"
                 >
                     {sections.map((section) => {
                         const isActive = section.id === activeId;

--- a/src/Panels/BestAvailableSheet.jsx
+++ b/src/Panels/BestAvailableSheet.jsx
@@ -1,0 +1,85 @@
+import { useState } from 'react';
+import { isTaken } from '../lib/rosterInfo.js';
+import { positionClass } from './pickLabels.js';
+
+// Mobile-only companion to the Ranks column that already sits beside the
+// board at md+ (see AppShell's SECTIONS_WITH_ASIDE). Below that width there is
+// nowhere to put Ranks beside the board, so this collapses the same "who's
+// left that I wanted" answer into a bottom sheet instead. `md:hidden` is the
+// whole story for why this never renders on wide screens - the aside already
+// covers it there.
+//
+// The app's tab bar (AppShell's <nav>) is fixed at the viewport bottom, so
+// this sheet has to clear it rather than sit underneath. Both read the same
+// --tab-bar-h custom property (theme.css) so the two cannot drift apart.
+
+const playerId = (entry) => entry.match_results[0][0];
+
+const sheetClasses =
+    'border-line bg-raised fixed inset-x-0 bottom-[var(--tab-bar-h)] z-10 flex flex-col border-t border-solid md:hidden';
+
+const BestAvailableSheet = ({ rankingPlayersIdsList, playerInfo, rosterInfo }) => {
+    const [isExpanded, setIsExpanded] = useState(false);
+
+    // No rank list at all is the normal state for a signed-out user (or one
+    // who hasn't pasted anything yet), not an edge case of an otherwise-full
+    // sheet - so it gets its own plain message rather than a collapse/expand
+    // control guarding an empty list underneath it.
+    if (rankingPlayersIdsList.length === 0) {
+        return (
+            <div aria-label="Best available" className={sheetClasses}>
+                <p className="text-ink-muted m-0 flex min-h-11 items-center px-4 text-sm">
+                    No rank list yet - paste one in the Ranks section to see who is still left.
+                </p>
+            </div>
+        );
+    }
+
+    const available = rankingPlayersIdsList.filter((entry) => !isTaken(rosterInfo, playerId(entry)));
+
+    return (
+        <div aria-label="Best available" className={sheetClasses}>
+            <button
+                type="button"
+                aria-expanded={isExpanded}
+                onClick={() => setIsExpanded((expanded) => !expanded)}
+                className="m-0 flex min-h-11 w-full appearance-none items-center justify-between rounded-none border-0 bg-transparent px-4 py-2"
+            >
+                <span className="text-ink text-sm font-semibold">Best available</span>
+                <span className="text-ink-muted text-sm">{available.length} left</span>
+            </button>
+            {isExpanded && (
+                <div className="max-h-[45vh] overflow-y-auto px-4 pb-4">
+                    <ul className="m-0 flex list-none flex-col gap-1 p-0">
+                        {available.map((entry) => {
+                            const id = playerId(entry);
+                            const player = playerInfo[id];
+                            // Same tolerance RanksPanel's filterPlayers already has for a
+                            // pasted id the player DB doesn't know (a retired player) -
+                            // skip the row rather than render a name-shaped hole.
+                            if (!player) {
+                                return null;
+                            }
+                            return (
+                                <li key={id} className="flex items-center gap-2 py-1">
+                                    <span className="text-ink-muted w-8 shrink-0 text-right text-xs">
+                                        {entry.ranking}
+                                    </span>
+                                    <span className="text-ink min-w-0 flex-1 truncate text-sm">{player.full_name}</span>
+                                    <span className="text-ink-muted shrink-0 text-xs">{player.team}</span>
+                                    <span
+                                        className={`text-ground shrink-0 rounded-[4px] px-1.5 py-0.5 text-[10px] font-semibold ${positionClass(player.position)}`}
+                                    >
+                                        {player.position}
+                                    </span>
+                                </li>
+                            );
+                        })}
+                    </ul>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default BestAvailableSheet;

--- a/src/Panels/BestAvailableSheet.test.jsx
+++ b/src/Panels/BestAvailableSheet.test.jsx
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import BestAvailableSheet from './BestAvailableSheet';
+import { buildRosterInfo, decorateRosters } from '../lib/rosterInfo.js';
+import rosterFlagsFixture from '../lib/__fixtures__/roster-flags-2026.json';
+
+// 13307 is a genuine free agent - on nobody's roster. 13294 and 13274 are
+// really taken (roster 2 and roster 1 respectively). Using those three is
+// what makes "correctly excluded" and "wrongly excluded" distinguishable -
+// see PickFeed.test.jsx for the same trap against the manual-pick filter.
+const { rosterDataRaw, managerData, playerInfo } = rosterFlagsFixture;
+
+const rosterData = decorateRosters({ rosterData: rosterDataRaw, managerData });
+const rosterInfo = buildRosterInfo({ rosterData, builtDraft: null });
+
+const FREE_AGENT = { id: '13307', name: 'Marlin Klein' };
+// Also unrostered in this fixture - used alongside FREE_AGENT to prove
+// ordering survives the taken-player filter rather than just checking a
+// single-item list.
+const OTHER_FREE_AGENT = { id: '289', name: 'Drew Brees' };
+const TAKEN_BY_OTHERS = { id: '13294', name: 'Makai Lemon' };
+const TAKEN_BY_ME = { id: '13274', name: 'Germie Bernard' };
+
+const rankEntry = (playerId, ranking) => ({
+    match_results: [[playerId, '0.000']],
+    ranking,
+    search_string: 'a pasted rank line',
+});
+
+const rankingPlayersIdsList = [
+    rankEntry(TAKEN_BY_ME.id, 1),
+    rankEntry(FREE_AGENT.id, 2),
+    rankEntry(TAKEN_BY_OTHERS.id, 3),
+    rankEntry(OTHER_FREE_AGENT.id, 4),
+];
+
+const renderSheet = (overrides = {}) =>
+    render(
+        <BestAvailableSheet
+            rankingPlayersIdsList={rankingPlayersIdsList}
+            playerInfo={playerInfo}
+            rosterInfo={rosterInfo}
+            {...overrides}
+        />,
+    );
+
+const toggle = () => screen.getByRole('button', { name: /Best available/ });
+
+describe('BestAvailableSheet', () => {
+    it('is collapsed by default', () => {
+        renderSheet();
+
+        expect(toggle()).toHaveAttribute('aria-expanded', 'false');
+        expect(screen.queryByText(FREE_AGENT.name)).toBeNull();
+    });
+
+    it('expands and collapses on click, tracked by aria-expanded', async () => {
+        const user = userEvent.setup();
+        renderSheet();
+
+        await user.click(toggle());
+        expect(toggle()).toHaveAttribute('aria-expanded', 'true');
+        expect(screen.getByText(FREE_AGENT.name)).toBeInTheDocument();
+
+        await user.click(toggle());
+        expect(toggle()).toHaveAttribute('aria-expanded', 'false');
+        expect(screen.queryByText(FREE_AGENT.name)).toBeNull();
+    });
+
+    it('lists players in ranking order', async () => {
+        const user = userEvent.setup();
+        renderSheet();
+        await user.click(toggle());
+
+        const names = screen.getAllByRole('listitem').map((item) => item.textContent);
+        expect(names[0]).toContain(FREE_AGENT.name);
+        expect(names[1]).toContain(OTHER_FREE_AGENT.name);
+    });
+
+    it('excludes a taken player while keeping an untaken one', async () => {
+        const user = userEvent.setup();
+        renderSheet();
+        await user.click(toggle());
+
+        expect(screen.getByText(FREE_AGENT.name)).toBeInTheDocument();
+        expect(screen.queryByText(TAKEN_BY_OTHERS.name)).toBeNull();
+        expect(screen.queryByText(TAKEN_BY_ME.name)).toBeNull();
+    });
+
+    it('reflects the filtered count, not the raw list, in the collapsed bar', () => {
+        renderSheet();
+
+        // Only the two free agents survive filtering out of the four pasted ranks.
+        expect(toggle()).toHaveTextContent('2 left');
+    });
+
+    it('renders an empty state when there is no rank list at all', () => {
+        renderSheet({ rankingPlayersIdsList: [] });
+
+        expect(screen.getByText(/No rank list yet/)).toBeInTheDocument();
+        expect(screen.getByText(/Ranks section/)).toBeInTheDocument();
+    });
+});

--- a/src/Panels/DraftPanel.jsx
+++ b/src/Panels/DraftPanel.jsx
@@ -3,6 +3,7 @@ import Button from '../Components/Button';
 import SegmentedControl from '../Components/SegmentedControl';
 import PickFeed from './PickFeed';
 import DraftGrid from './DraftGrid';
+import BestAvailableSheet from './BestAvailableSheet';
 import PickClock from '../Components/PickClock';
 import { SLEEPER_API_URLS } from '../urls';
 import { syncLiveDraft } from '../lib/liveDraft.js';
@@ -162,6 +163,11 @@ const DraftPanel = ({ leagueData, playerInfo, rosterInfo, rankingPlayersIdsList,
                                 onPickChange={handlePickChange}
                             />
                         )}
+                        <BestAvailableSheet
+                            rankingPlayersIdsList={rankingPlayersIdsList}
+                            playerInfo={playerInfo}
+                            rosterInfo={rosterInfo}
+                        />
                     </>
                 )}
             </div>

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -86,6 +86,16 @@
  * through arbitrary-value utilities (`w-[var(--cell-w)]` etc).
  */
 @layer components {
+    /*
+     * The bottom tab bar's height, shared by the bar itself and anything that
+     * has to sit clear of it - the best-available sheet, so far. It was a
+     * literal 56 in one file and a measured 46.5 in the other, which is a
+     * silent drift waiting to happen the first time the bar's padding changes.
+     */
+    :root {
+        --tab-bar-h: 56px;
+    }
+
     .draft-grid[data-zoom='overview'] {
         --cell-w: 23px;
         --cell-h: 23px;


### PR DESCRIPTION
The last piece of the Draft screen's first pass. At ≥768px the shell already renders Ranks beside the board, so this is **below-`md` only**: a collapsed bar showing how many of your ranked players are still available, expanding to the list without leaving the board.

The list is your pasted ranking order with **taken players filtered out** — that is what makes it answer "who's left that I wanted" rather than repeating the Ranks screen. An empty rank list gets its own message pointing at Ranks; that's the normal state for a signed-out user, not an edge case.

Tap to expand. **No swipe gestures, deliberately** — a drag handle is a lot of surface for something a button already does, and it isn't testable without synthesising pointer streams.

### The tab-bar height became a shared variable, and two bugs fell out of pinning it

It was a literal `56` in the sheet and a measured `46.5` in the bar — a drift waiting for the first padding change. Making both read `--tab-bar-h` surfaced:

1. **`min-height` is only a floor.** The bar rendered 59px tall, so the sheet sat ~3px underneath it.
2. **Nothing is `border-box` here** — preflight is not loaded, so the bar's 1px top border added to its declared height. The bar is `box-border` now, which makes `--tab-bar-h` its real, measurable height.

Measured after: bar top **756**, sheet bottom **756**, zero overlap, no horizontal page scroll, and four board rows still visible above the expanded sheet.

### Sabotage

| Sabotage | Result |
|---|---|
| stop filtering taken players | fails 3 (order, exclusion, and the collapsed count) |
| remove the empty state | fails 1 |
| ignore the expanded state | fails 3, including an unrelated App-level test that depended on the sheet staying shut |

The exclusion test uses the fixture's genuine free agent (`13307`) against players taken for real reasons (`13294` on roster 2, `13274` on roster 1) — a player excluded for an unrelated reason would make correct and incorrect exclusion indistinguishable.

Tests 255 → 261. All six gates clean including `npm ci`.

**Still open on this screen**, and worth your call rather than mine: tapping a grid cell currently opens the pick modal, the same as tapping a feed row. The design also describes the grid doubling as a round navigator — tap a cell, land on that pick in the feed. Both readings are defensible; I left the consistent one.