### PR TITLE
Mark picks made since your last visit

### DIFF
--- a/src/Panels/DraftPanel.jsx
+++ b/src/Panels/DraftPanel.jsx
@@ -8,6 +8,7 @@ import PickClock from '../Components/PickClock';
 import { SLEEPER_API_URLS } from '../urls';
 import { syncLiveDraft } from '../lib/liveDraft.js';
 import { pollIntervalMs } from '../lib/draftClock.js';
+import { useSeenPicks } from '../useSeenPicks.js';
 const { DRAFT, PICKS, TRADED_PICKS } = SLEEPER_API_URLS;
 
 const VIEW_OPTIONS = [
@@ -25,15 +26,28 @@ const DraftPanel = ({ leagueData, playerInfo, rosterInfo, rankingPlayersIdsList,
     // shouldn't change what people already sync a draft against.
     const [boardView, setBoardView] = useState('feed');
 
+    const { newPickKeys, markSeen } = useSeenPicks({
+        draftId: currentDraft.draft_id,
+        builtDraft: currentDraft.built_draft,
+    });
+
     const updateDraftID = (val) => {
         setCurrentDraftId(val);
         setDraftPath(DRAFT + val + '/');
     };
 
-    const handlePickChange = (updatedRound) => {
+    // `changedKey` is only ever passed when the round object came from a
+    // manual pick (see PickFeed.selectPlayer) - the live sync path below
+    // calls updateDraftBoard directly and never goes through here at all, so
+    // there is nothing to distinguish there. Marking it seen immediately is
+    // what stops a "NEW" chip flashing on the pick the user just made.
+    const handlePickChange = (updatedRound, changedKey) => {
         updateDraftBoard((builtDraft) =>
             builtDraft.map((round) => (round.round === updatedRound.round ? updatedRound : round)),
         );
+        if (changedKey) {
+            markSeen(changedKey);
+        }
     };
 
     const getLiveDraft = async () => {
@@ -151,6 +165,7 @@ const DraftPanel = ({ leagueData, playerInfo, rosterInfo, rankingPlayersIdsList,
                                 rosterData={rosterData}
                                 myDisplayName={myDisplayName}
                                 onPickChange={handlePickChange}
+                                newPickKeys={newPickKeys}
                             />
                         ) : (
                             <DraftGrid

--- a/src/Panels/DraftPanel.test.jsx
+++ b/src/Panels/DraftPanel.test.jsx
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import { act, fireEvent, render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useState } from 'react';
 import DraftPanel from './DraftPanel';
 import { buildRosterInfo, decorateRosters } from '../lib/rosterInfo.js';
 import rosterFlagsFixture from '../lib/__fixtures__/roster-flags-2026.json';
@@ -423,5 +425,101 @@ describe('DraftPanel board view toggle', () => {
 
         expect(screen.getByRole('list', { name: 'Round 1' })).toBeInTheDocument();
         expect(screen.queryByRole('button', { name: 'Overview' })).toBeNull();
+    });
+});
+
+// The wiring seam: useSeenPicks lives in DraftPanel, and every piece below it
+// takes newPickKeys as a prop with an empty-Set default. That default means
+// unthreading the prop anywhere between the hook and PickRow leaves the whole
+// component suite green - the feature silently does nothing while every unit
+// still passes. These two tests are the only place the assembled path is
+// exercised, so they run against real timers and userEvent rather than the
+// fake-timer harness above, which nothing here needs.
+describe('DraftPanel new-pick markers', () => {
+    const ROUND_NUMBER = builtDraft[0].round;
+    const STORAGE_KEY = `sleeper-app:seen-picks:${DRAFT_ID}`;
+
+    // A one-round board with the given pick numbers filled in, so "made" and
+    // "seen" can be varied independently. The fixture's own board has no made
+    // picks at all, which is why nothing is filled in by default.
+    const boardWith = (madePickNumbers) => [
+        {
+            ...builtDraft[0],
+            picks: builtDraft[0].picks.map((pick) => ({
+                ...pick,
+                player_id: madePickNumbers.includes(pick.pick_number) ? FREE_AGENT.id : null,
+            })),
+        },
+    ];
+
+    it('marks picks made since the stored snapshot, and counts them in the round header', async () => {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify([`${ROUND_NUMBER}.1`]));
+
+        renderPanel({
+            leagueData: {
+                currentDraft: {
+                    draft_id: DRAFT_ID,
+                    season: '2026',
+                    player_pool: 'Rookie',
+                    status: 'drafting',
+                    start_time: DRAFT_BASE_TIME,
+                    last_picked: null,
+                    settings: { pick_timer: 30 },
+                    built_draft: boardWith([1, 2, 3]),
+                },
+                rosterData,
+            },
+        });
+
+        // Picks 2 and 3 were made after the stored snapshot; pick 1 is in it.
+        expect(screen.getAllByText('NEW')).toHaveLength(2);
+        expect(screen.getByText('2 new')).toBeVisible();
+    });
+
+    it('does not mark a pick the user just made themselves', async () => {
+        const user = userEvent.setup();
+        // A first visit with a board that already has pick 1 made: nothing is
+        // new, which is the state a manual pick has to leave intact.
+        const currentDraft = {
+            draft_id: DRAFT_ID,
+            season: '2026',
+            player_pool: 'Rookie',
+            status: 'drafting',
+            start_time: DRAFT_BASE_TIME,
+            last_picked: null,
+            settings: { pick_timer: 30 },
+            built_draft: boardWith([1]),
+        };
+
+        // updateDraftBoard has to really apply the reducer here. With the usual
+        // vi.fn() the board never changes, so no chip could appear whatever
+        // markSeen did and the test would pass vacuously.
+        const StatefulPanel = () => {
+            const [board, setBoard] = useState(currentDraft.built_draft);
+            return (
+                <DraftPanel
+                    leagueData={{ currentDraft: { ...currentDraft, built_draft: board }, rosterData }}
+                    playerInfo={playerInfo}
+                    rosterInfo={rosterInfo}
+                    rankingPlayersIdsList={[rankEntry(FREE_AGENT.id)]}
+                    updateDraftBoard={(reducer) => setBoard((prev) => reducer(prev))}
+                />
+            );
+        };
+        render(<StatefulPanel />);
+
+        expect(screen.queryByText('NEW')).toBeNull();
+
+        await user.click(screen.getByRole('button', { name: new RegExp(`pick 2,`) }));
+        const modal = screen.getByText(/^Manually select pick/).closest('div').parentElement;
+        await user.click(within(modal).getByText(new RegExp(FREE_AGENT.name)));
+
+        // The board really did update - without this the assertion below is
+        // just re-checking a board that never changed.
+        const filledRow = screen.getByRole('button', { name: new RegExp(`pick 2,.*${FREE_AGENT.name}`) });
+        expect(filledRow).toBeInTheDocument();
+
+        expect(screen.queryByText('NEW')).toBeNull();
+        expect(screen.queryByText(/\d+ new/)).toBeNull();
     });
 });

--- a/src/Panels/PickFeed.jsx
+++ b/src/Panels/PickFeed.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import RoundSection from './RoundSection';
 import ManualPickModal from './ManualPickModal';
 import { applyManualPick } from '../lib/liveDraft.js';
+import { pickKey } from '../lib/seenPicks.js';
 
 // All rounds of the by-round draft board, rebuilt as a feed: each round is a
 // section with a sticky header and one row per pick. The manual-pick modal is
@@ -15,6 +16,7 @@ const PickFeed = ({
     rankingPlayersIdsList,
     myDisplayName,
     onPickChange,
+    newPickKeys = new Set(),
 }) => {
     const [activePick, setActivePick] = useState(null);
 
@@ -27,7 +29,11 @@ const PickFeed = ({
             currentManualPick: activePick.pick,
             playerID,
         });
-        onPickChange(updatedRound);
+        // The second argument tells DraftPanel this change was a deliberate
+        // manual entry, not a pick arriving from the live sync, so it can
+        // mark it seen immediately - otherwise a manual pick would flash a
+        // "NEW" chip at the person who just made it.
+        onPickChange(updatedRound, pickKey(activePick.round, activePick.pick));
         closeModal();
     };
 
@@ -41,6 +47,7 @@ const PickFeed = ({
                     rosterData={rosterData}
                     myDisplayName={myDisplayName}
                     onOpenPick={openPick}
+                    newPickKeys={newPickKeys}
                 />
             ))}
             {activePick && (

--- a/src/Panels/PickFeed.test.jsx
+++ b/src/Panels/PickFeed.test.jsx
@@ -163,6 +163,18 @@ describe('PickFeed manual pick selection', () => {
         expect(round.picks[0].player_id).toBeNull();
     });
 
+    it('passes the changed pick key as a second argument, so DraftPanel can mark it seen', async () => {
+        // A manual pick must not flash a "NEW" chip at the person who just
+        // made it - DraftPanel only knows to call markSeen because this
+        // second argument is present.
+        const { onPickChange } = renderFeed();
+
+        const modal = await openPickModal(user, 1);
+        await user.click(within(modal).getByText(new RegExp(FREE_AGENT.name)));
+
+        expect(onPickChange.mock.calls[0][1]).toBe(`${round.round}.1`);
+    });
+
     it('lets a filled pick be cleared again', async () => {
         // The remove path only renders when the pick already holds a player,
         // and it is the half of the flow that clears rather than sets - the
@@ -248,6 +260,89 @@ describe('PickFeed accessible names', () => {
         expect(
             screen.getByRole('button', { name: `Round 1, pick 1, HEFFinAround305, ${FREE_AGENT.name}, TE` }),
         ).toBeInTheDocument();
+    });
+
+    it('appends ", new" to a pick whose key is in newPickKeys', () => {
+        const filledRound = {
+            ...round,
+            picks: round.picks.map((pick) => (pick.pick_number === 1 ? { ...pick, player_id: FREE_AGENT.id } : pick)),
+        };
+        renderFeed({ builtDraft: [filledRound], newPickKeys: new Set([`${round.round}.1`]) });
+
+        expect(
+            screen.getByRole('button', { name: `Round 1, pick 1, HEFFinAround305, ${FREE_AGENT.name}, TE, new` }),
+        ).toBeInTheDocument();
+    });
+
+    it('does not append ", new" to an already-seen made pick', () => {
+        const filledRound = {
+            ...round,
+            picks: round.picks.map((pick) => (pick.pick_number === 1 ? { ...pick, player_id: FREE_AGENT.id } : pick)),
+        };
+        renderFeed({ builtDraft: [filledRound], newPickKeys: new Set() });
+
+        expect(
+            screen.getByRole('button', { name: `Round 1, pick 1, HEFFinAround305, ${FREE_AGENT.name}, TE` }),
+        ).toBeInTheDocument();
+        expect(
+            screen.queryByRole('button', { name: `Round 1, pick 1, HEFFinAround305, ${FREE_AGENT.name}, TE, new` }),
+        ).toBeNull();
+    });
+});
+
+// The accessible name carries "new" for assistive tech, but the visible chips
+// are what a sighted user actually gets, and nothing above asserts they render
+// at all - stripping them left the whole suite green. These are text
+// assertions, not className ones: the palette is browser-verified, but whether
+// the marker exists in the DOM is not a styling question.
+describe('PickFeed new-pick markers', () => {
+    const filledRound = (pickNumbers) => ({
+        ...round,
+        picks: round.picks.map((pick) =>
+            pickNumbers.includes(pick.pick_number) ? { ...pick, player_id: FREE_AGENT.id } : pick,
+        ),
+    });
+
+    it('renders a NEW chip on each new row and none on the seen ones', () => {
+        renderFeed({
+            builtDraft: [filledRound([1, 2, 3])],
+            newPickKeys: new Set([`${round.round}.1`, `${round.round}.2`]),
+        });
+
+        const chips = screen.getAllByText('NEW');
+        expect(chips).toHaveLength(2);
+        expect(chips[0]).toBeVisible();
+
+        // Pick 3 is made but already seen, so its row carries no chip.
+        const seenRow = screen.getByRole('button', { name: /pick 3, ryangh/ });
+        expect(within(seenRow).queryByText('NEW')).toBeNull();
+    });
+
+    it('counts the new picks in the round header', () => {
+        renderFeed({
+            builtDraft: [filledRound([1, 2, 3])],
+            newPickKeys: new Set([`${round.round}.1`, `${round.round}.2`]),
+        });
+
+        expect(screen.getByText('2 new')).toBeVisible();
+    });
+
+    it('shows no chip and no count when nothing is new', () => {
+        renderFeed({ builtDraft: [filledRound([1, 2, 3])], newPickKeys: new Set() });
+
+        expect(screen.queryByText('NEW')).toBeNull();
+        expect(screen.queryByText(/\d+ new/)).toBeNull();
+    });
+
+    it('keeps the round header clickable with a count beside it', async () => {
+        // The count chip lives inside the collapse button. Adding a second
+        // child there is exactly how "Round 1" stops being its own text node
+        // and the collapse test below starts matching nothing.
+        const user = userEvent.setup();
+        renderFeed({ builtDraft: [filledRound([1])], newPickKeys: new Set([`${round.round}.1`]) });
+
+        await user.click(screen.getByText('Round 1'));
+        expect(screen.queryByRole('list', { name: 'Round 1' })).toBeNull();
     });
 });
 

--- a/src/Panels/PickRow.jsx
+++ b/src/Panels/PickRow.jsx
@@ -1,6 +1,7 @@
 import { managerLabel, pickAccessibleName, pickNumberLabel, positionClass } from './pickLabels.js';
+import { pickKey } from '../lib/seenPicks.js';
 
-const PickRow = ({ round, pick, playerInfo, rosterData, myDisplayName, onSelect }) => {
+const PickRow = ({ round, pick, playerInfo, rosterData, myDisplayName, onSelect, newPickKeys = new Set() }) => {
     // The player database is a snapshot and a drafted player can be absent
     // from it. Render the id itself rather than a blank cell - that is what
     // makes the gap diagnosable, and it matches warnAboutMissingRosterPlayers,
@@ -12,7 +13,8 @@ const PickRow = ({ round, pick, playerInfo, rosterData, myDisplayName, onSelect 
     const isMine = Boolean(owner?.manager_display_name) && owner.manager_display_name === myDisplayName;
     const manager = managerLabel({ pick, rosterData, myDisplayName });
     const pickNumber = pickNumberLabel(round, pick);
-    const accessibleName = pickAccessibleName({ round, pick, player, manager });
+    const isNew = newPickKeys.has(pickKey(round, pick));
+    const accessibleName = pickAccessibleName({ round, pick, player, manager, isNew });
 
     return (
         <li>
@@ -42,6 +44,16 @@ const PickRow = ({ round, pick, playerInfo, rosterData, myDisplayName, onSelect 
                         className={`text-ground shrink-0 rounded-[4px] px-1.5 py-0.5 text-xs font-semibold ${positionClass(player.position)}`}
                     >
                         {player.position}
+                    </span>
+                )}
+                {/* Neutral, not a saturated position colour or `bg-mine` -
+                    both are already spoken for (position data and "yours"
+                    respectively), so "new" gets the one high-contrast chip
+                    left: ink-on-ground, same geometry as the position badge
+                    above. */}
+                {isNew && (
+                    <span className="bg-ink text-ground shrink-0 rounded-[4px] px-1.5 py-0.5 text-xs font-semibold">
+                        NEW
                     </span>
                 )}
             </button>

--- a/src/Panels/RoundSection.jsx
+++ b/src/Panels/RoundSection.jsx
@@ -1,8 +1,10 @@
 import { useState } from 'react';
 import PickRow from './PickRow';
+import { countNewInRound } from '../lib/seenPicks.js';
 
-const RoundSection = ({ round, playerInfo, rosterData, myDisplayName, onOpenPick }) => {
+const RoundSection = ({ round, playerInfo, rosterData, myDisplayName, onOpenPick, newPickKeys = new Set() }) => {
     const [showRound, setShowRound] = useState(true);
+    const newCount = countNewInRound(round, newPickKeys);
 
     return (
         <section>
@@ -15,9 +17,18 @@ const RoundSection = ({ round, playerInfo, rosterData, myDisplayName, onOpenPick
                     type="button"
                     aria-expanded={showRound}
                     onClick={() => setShowRound((prev) => !prev)}
-                    className="text-ink m-0 w-full cursor-pointer appearance-none rounded-none border-0 bg-transparent px-3 py-2 text-left text-sm font-semibold"
+                    className="text-ink m-0 flex w-full cursor-pointer appearance-none items-center gap-2 rounded-none border-0 bg-transparent px-3 py-2 text-left text-sm font-semibold"
                 >
-                    Round {round.round}
+                    {/* Kept as its own element, not concatenated into the
+                        "N new" chip's text, so screen.getByText('Round 1')
+                        keeps resolving - the round-collapsing test depends on
+                        this exact node. */}
+                    <span>Round {round.round}</span>
+                    {newCount > 0 && (
+                        <span className="bg-ink text-ground rounded-[4px] px-1.5 py-0.5 text-xs font-semibold">
+                            {newCount} new
+                        </span>
+                    )}
                 </button>
             </h4>
             {showRound && (
@@ -31,6 +42,7 @@ const RoundSection = ({ round, playerInfo, rosterData, myDisplayName, onOpenPick
                             rosterData={rosterData}
                             myDisplayName={myDisplayName}
                             onSelect={() => onOpenPick(round, pick)}
+                            newPickKeys={newPickKeys}
                         />
                     ))}
                 </ol>

--- a/src/Panels/pickLabels.js
+++ b/src/Panels/pickLabels.js
@@ -43,13 +43,20 @@ export const managerLabel = ({ pick, rosterData, myDisplayName }) => {
 // "Round 1, pick 1, HEFFinAround305" for one that hasn't happened yet. `player`
 // is null both when the pick is unmade and when the drafted id is missing from
 // the player database - the two are told apart by `pick.player_id`.
-export const pickAccessibleName = ({ round, pick, player, manager }) => {
+//
+// `isNew` defaults to false and, when true, appends a trailing "new" part -
+// it is always last so DraftGrid's call sites (which never pass it) produce
+// byte-identical names to before this option existed.
+export const pickAccessibleName = ({ round, pick, player, manager, isNew = false }) => {
     const nameParts = [`Round ${round.round}`, `pick ${pick.pick_number}`, manager];
     if (pick.player_id) {
         nameParts.push(player ? player.full_name : `Unknown player ${pick.player_id}`);
         if (player) {
             nameParts.push(player.position);
         }
+    }
+    if (isNew) {
+        nameParts.push('new');
     }
     return nameParts.join(', ');
 };

--- a/src/lib/seenPicks.js
+++ b/src/lib/seenPicks.js
@@ -1,0 +1,32 @@
+/**
+ * Pure helpers for "what did I miss": which picks have been made, and which
+ * of those are new since the visitor's last visit.
+ *
+ * Identity is `${round.round}.${pick.pick_number}`, not a "highest pick
+ * reached" cursor. `applyManualPick` lets a pick in any future round be
+ * projected in ahead of picks still open in earlier rounds, so a cursor built
+ * from "furthest pick made" would advance past real, still-unseen picks and
+ * silently hide them. A set of made-pick keys has no such ordering
+ * assumption - each pick is judged on its own.
+ */
+
+export const pickKey = (round, pick) => `${round.round}.${pick.pick_number}`;
+
+export const madePickKeys = (builtDraft) => {
+    if (!builtDraft) {
+        return [];
+    }
+    return builtDraft.flatMap((round) =>
+        round.picks.filter((pick) => pick.player_id).map((pick) => pickKey(round, pick)),
+    );
+};
+
+export const newPickKeySet = (builtDraft, seenKeys) => {
+    if (!builtDraft || !seenKeys) {
+        return new Set();
+    }
+    return new Set(madePickKeys(builtDraft).filter((key) => !seenKeys.has(key)));
+};
+
+export const countNewInRound = (round, newPickKeys) =>
+    round.picks.filter((pick) => newPickKeys.has(pickKey(round, pick))).length;

--- a/src/lib/seenPicks.test.js
+++ b/src/lib/seenPicks.test.js
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { countNewInRound, madePickKeys, newPickKeySet, pickKey } from './seenPicks.js';
+
+const round = (roundNumber, picks) => ({ round: roundNumber, picks });
+const pick = (pickNumber, playerId = null) => ({ pick_number: pickNumber, player_id: playerId });
+
+describe('pickKey', () => {
+    it('joins round and pick number with a dot, unpadded', () => {
+        expect(pickKey(round(1, []), pick(3))).toBe('1.3');
+    });
+});
+
+describe('madePickKeys', () => {
+    it('tolerates a null board', () => {
+        expect(madePickKeys(null)).toEqual([]);
+        expect(madePickKeys(undefined)).toEqual([]);
+    });
+
+    it('collects only picks with a player_id, in board order', () => {
+        const builtDraft = [
+            round(1, [pick(1, 'p1'), pick(2, null), pick(3, 'p3')]),
+            round(2, [pick(1, null), pick(2, 'p2')]),
+        ];
+
+        expect(madePickKeys(builtDraft)).toEqual(['1.1', '1.3', '2.2']);
+    });
+});
+
+describe('newPickKeySet', () => {
+    it('tolerates a null board or null seen set', () => {
+        expect(newPickKeySet(null, new Set())).toEqual(new Set());
+        expect(newPickKeySet([round(1, [pick(1, 'p1')])], null)).toEqual(new Set());
+    });
+
+    it('reports a manual pick projected into a later round while earlier real picks are still unseen', () => {
+        // This is the case a "highest pick reached" cursor gets wrong: the
+        // manual pick in round 2 must not push a cursor past round 1's
+        // still-unmade picks and hide them from being reported as new too.
+        const builtDraft = [
+            round(1, [pick(1, 'p1'), pick(2, 'p2'), pick(3, null)]),
+            round(2, [pick(1, null), pick(2, 'manual-p')]),
+        ];
+        const seenKeys = new Set(['1.1']);
+
+        expect(newPickKeySet(builtDraft, seenKeys)).toEqual(new Set(['1.2', '2.2']));
+    });
+
+    it('drops a pick that has been cleared back to player_id: null', () => {
+        const builtDraft = [round(1, [pick(1, null)])];
+        const seenKeys = new Set();
+
+        expect(newPickKeySet(builtDraft, seenKeys)).toEqual(new Set());
+    });
+});
+
+describe('countNewInRound', () => {
+    it('counts only the picks in this round whose key is in newPickKeys', () => {
+        const r = round(1, [pick(1, 'p1'), pick(2, 'p2'), pick(3, null)]);
+        const newPickKeys = new Set(['1.1', '2.5']);
+
+        expect(countNewInRound(r, newPickKeys)).toBe(1);
+    });
+
+    it('returns 0 when nothing in the round is new', () => {
+        const r = round(1, [pick(1, 'p1')]);
+
+        expect(countNewInRound(r, new Set())).toBe(0);
+    });
+});

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -3,3 +3,14 @@
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
 import '@testing-library/jest-dom/vitest';
+import { beforeEach } from 'vitest';
+
+// localStorage is shared by every test in a file. useSeenPicks writes to it on
+// mount, so without this a test that renders the draft board leaves a seen
+// snapshot behind and the next test in the same file starts as a "returning
+// visit" - which changes accessible names ("..., new") in App.test.jsx
+// depending only on test order. Clearing globally keeps that per-test rather
+// than per-file.
+beforeEach(() => {
+    localStorage.clear();
+});

--- a/src/useSeenPicks.js
+++ b/src/useSeenPicks.js
@@ -1,0 +1,114 @@
+import { useEffect, useRef, useState } from 'react';
+import { madePickKeys, newPickKeySet } from './lib/seenPicks.js';
+
+const storageKey = (draftId) => `sleeper-app:seen-picks:${draftId}`;
+
+// Never lets a storage failure reach the caller. Safari private mode throws
+// on setItem (quota is 0 there), and a value written by some earlier version
+// of this feature - or by anything else sharing origin storage - could be
+// non-JSON or a non-array. Either way the feature degrades to in-memory only
+// for this visit rather than taking the draft board down.
+const readStored = (draftId) => {
+    try {
+        const raw = localStorage.getItem(storageKey(draftId));
+        if (!raw) {
+            return null;
+        }
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed) ? parsed : null;
+    } catch {
+        return null;
+    }
+};
+
+const writeStored = (draftId, keys) => {
+    try {
+        localStorage.setItem(storageKey(draftId), JSON.stringify(keys));
+    } catch {
+        // Swallowed deliberately - see readStored's comment above.
+    }
+};
+
+// Sentinel distinct from any real draft id (including `undefined` itself),
+// so the first render always runs the init check below rather than being
+// mistaken for "already initialised to this id".
+const NOT_INITIALIZED = Symbol('not-initialized');
+
+export function useSeenPicks({ draftId, builtDraft }) {
+    const [seenKeys, setSeenKeys] = useState(null);
+    const initializedDraftIdRef = useRef(NOT_INITIALIZED);
+    const lastWrittenRef = useRef(null);
+
+    // The snapshot is taken once per draftId, on the first render where a
+    // built board is available, and then frozen in state for the rest of the
+    // visit: it does NOT advance as the live sync brings more picks in. That
+    // is what keeps a marker visible on a pick while the user is still
+    // reading it, scrolling, or toggling Feed/Grid, instead of it vanishing
+    // out from under them a few seconds later.
+    useEffect(() => {
+        if (initializedDraftIdRef.current === draftId) {
+            return;
+        }
+        if (!builtDraft) {
+            return;
+        }
+        const stored = readStored(draftId);
+        const madeKeys = madePickKeys(builtDraft);
+        // A built board arrives with no picks in it. buildDraftRounds only
+        // lays out the pick order from the draft's slots; player ids land
+        // later, when getLiveDraft runs - the Update button or the sync poll.
+        // So on a first visit the board is genuinely empty at mount, and
+        // seeding from it snapshots nothing: the first Update then flags every
+        // pick on the board as new, which is the exact outcome the seeding
+        // below exists to prevent. Measured in a browser against a finished
+        // 50-pick league - all 50 lit up. With nothing stored, wait for the
+        // board to actually carry picks before taking the snapshot.
+        if (!stored && madeKeys.length === 0) {
+            return;
+        }
+        // No stored value means this is the first-ever visit to this draft.
+        // Seeding the snapshot with everything already made (rather than an
+        // empty set) means a first visit shows nothing as new - it would
+        // otherwise flag the entire existing board as "new" the moment
+        // someone opens it.
+        const initial = stored ? new Set(stored) : new Set(madeKeys);
+        setSeenKeys(initial);
+        initializedDraftIdRef.current = draftId;
+        lastWrittenRef.current = null;
+    }, [draftId, builtDraft]);
+
+    // Keeps storage current with the full set of made picks - independent of
+    // the frozen snapshot above - so the next visit compares against the
+    // latest state rather than this one. Do not write on unmount instead:
+    // closing the tab never unmounts anything, so a write there would never
+    // fire and the snapshot would never advance.
+    //
+    // Guarded by a joined-string comparison, not a deep-equal on every
+    // render: the live sync poll re-renders every few seconds and most of
+    // those renders change nothing, so writing unconditionally would hit
+    // localStorage on a timer for the entire draft.
+    useEffect(() => {
+        if (seenKeys === null) {
+            return;
+        }
+        const madeKeys = madePickKeys(builtDraft);
+        const joined = madeKeys.join(',');
+        if (lastWrittenRef.current === joined) {
+            return;
+        }
+        lastWrittenRef.current = joined;
+        writeStored(draftId, madeKeys);
+    }, [draftId, builtDraft, seenKeys]);
+
+    const newPickKeys = seenKeys === null ? new Set() : newPickKeySet(builtDraft, seenKeys);
+
+    const markSeen = (key) => {
+        setSeenKeys((prev) => {
+            const next = new Set(prev ?? []);
+            next.add(key);
+            return next;
+        });
+    };
+
+    return { newPickKeys, markSeen };
+}

--- a/src/useSeenPicks.test.jsx
+++ b/src/useSeenPicks.test.jsx
@@ -1,0 +1,237 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSeenPicks } from './useSeenPicks.js';
+
+const round = (roundNumber, picks) => ({ round: roundNumber, picks });
+const pick = (pickNumber, playerId = null) => ({ pick_number: pickNumber, player_id: playerId });
+
+const STORAGE_KEY = (draftId) => `sleeper-app:seen-picks:${draftId}`;
+
+beforeEach(() => {
+    localStorage.clear();
+});
+
+describe('useSeenPicks first visit', () => {
+    it('shows nothing as new on a first-ever visit, even though the board already has picks made', () => {
+        const builtDraft = [round(1, [pick(1, 'p1'), pick(2, 'p2'), pick(3, null)])];
+
+        const { result } = renderHook(() => useSeenPicks({ draftId: 'draft-1', builtDraft }));
+
+        expect(result.current.newPickKeys).toEqual(new Set());
+    });
+
+    it('persists the current made picks as the seen snapshot for next time', () => {
+        const builtDraft = [round(1, [pick(1, 'p1')])];
+
+        renderHook(() => useSeenPicks({ draftId: 'draft-1', builtDraft }));
+
+        expect(JSON.parse(localStorage.getItem(STORAGE_KEY('draft-1')))).toEqual(['1.1']);
+    });
+});
+
+describe('useSeenPicks before the board arrives', () => {
+    it('defers the snapshot until a built board exists, rather than snapshotting an empty one', () => {
+        localStorage.setItem(STORAGE_KEY('draft-1'), JSON.stringify(['1.1']));
+
+        const { result, rerender } = renderHook(({ builtDraft }) => useSeenPicks({ draftId: 'draft-1', builtDraft }), {
+            initialProps: { builtDraft: null },
+        });
+
+        // Nothing to compare against yet - and crucially the stored snapshot
+        // must not have been consumed against a null board, which would have
+        // latched an empty seen set for the whole visit and flagged the entire
+        // board as new the moment it loaded.
+        expect(result.current.newPickKeys).toEqual(new Set());
+
+        rerender({ builtDraft: [round(1, [pick(1, 'p1'), pick(2, 'p2')])] });
+
+        expect(result.current.newPickKeys).toEqual(new Set(['1.2']));
+    });
+
+    it('does not write a snapshot over the stored one before the board arrives', () => {
+        localStorage.setItem(STORAGE_KEY('draft-1'), JSON.stringify(['1.1']));
+
+        renderHook(() => useSeenPicks({ draftId: 'draft-1', builtDraft: null }));
+
+        // An unguarded write here would store [] and destroy the record of
+        // what the user had already seen.
+        expect(JSON.parse(localStorage.getItem(STORAGE_KEY('draft-1')))).toEqual(['1.1']);
+    });
+});
+
+describe('useSeenPicks when the board arrives before its picks do', () => {
+    // The real load order, and the one the fixtures above do not reproduce:
+    // buildDraftRounds hands back a full board of *unmade* picks, and the
+    // player ids only arrive when getLiveDraft runs. Every test that mounts
+    // with a pre-filled board misses this entirely - it was found in a
+    // browser, where a finished 50-pick league lit all 50 rows as new.
+    const emptyBoard = [round(1, [pick(1), pick(2), pick(3)])];
+    const filledBoard = [round(1, [pick(1, 'p1'), pick(2, 'p2'), pick(3, 'p3')])];
+
+    it('does not treat the first Update as fifty new picks on a first visit', () => {
+        const { result, rerender } = renderHook(({ builtDraft }) => useSeenPicks({ draftId: 'draft-1', builtDraft }), {
+            initialProps: { builtDraft: emptyBoard },
+        });
+
+        expect(result.current.newPickKeys).toEqual(new Set());
+
+        rerender({ builtDraft: filledBoard });
+
+        expect(result.current.newPickKeys).toEqual(new Set());
+        expect(JSON.parse(localStorage.getItem(STORAGE_KEY('draft-1')))).toEqual(['1.1', '1.2', '1.3']);
+    });
+
+    it('does not store an empty snapshot at mount, which would poison the next visit', () => {
+        renderHook(() => useSeenPicks({ draftId: 'draft-1', builtDraft: emptyBoard }));
+
+        // Writing [] here would count as "something is stored" next time, so
+        // the first-visit branch would never run again and the whole board
+        // would flag as new on the second visit instead of the first.
+        expect(localStorage.getItem(STORAGE_KEY('draft-1'))).toBeNull();
+    });
+
+    it('still reports genuinely new picks to a returning visitor after Update fills the board', () => {
+        localStorage.setItem(STORAGE_KEY('draft-1'), JSON.stringify(['1.1']));
+
+        const { result, rerender } = renderHook(({ builtDraft }) => useSeenPicks({ draftId: 'draft-1', builtDraft }), {
+            initialProps: { builtDraft: emptyBoard },
+        });
+
+        rerender({ builtDraft: filledBoard });
+
+        expect(result.current.newPickKeys).toEqual(new Set(['1.2', '1.3']));
+    });
+});
+
+describe('useSeenPicks storage writes', () => {
+    it('writes once and then stays quiet while the live poll re-renders with an unchanged board', () => {
+        const builtDraft = [round(1, [pick(1, 'p1')])];
+        const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
+
+        const { rerender } = renderHook(({ builtDraft }) => useSeenPicks({ draftId: 'draft-1', builtDraft }), {
+            initialProps: { builtDraft },
+        });
+        const writesAfterMount = setItemSpy.mock.calls.length;
+
+        // syncLiveDraft hands back a fresh array every poll even when nothing
+        // changed, so identity is not a usable guard - the made-key list is.
+        rerender({ builtDraft: [round(1, [pick(1, 'p1')])] });
+        rerender({ builtDraft: [round(1, [pick(1, 'p1')])] });
+
+        expect(setItemSpy.mock.calls.length).toBe(writesAfterMount);
+
+        rerender({ builtDraft: [round(1, [pick(1, 'p1'), pick(2, 'p2')])] });
+        expect(setItemSpy.mock.calls.length).toBe(writesAfterMount + 1);
+
+        setItemSpy.mockRestore();
+    });
+});
+
+describe('useSeenPicks returning visit', () => {
+    it('reports picks made since the stored snapshot as new', () => {
+        localStorage.setItem(STORAGE_KEY('draft-1'), JSON.stringify(['1.1']));
+        const builtDraft = [round(1, [pick(1, 'p1'), pick(2, 'p2')])];
+
+        const { result } = renderHook(() => useSeenPicks({ draftId: 'draft-1', builtDraft }));
+
+        expect(result.current.newPickKeys).toEqual(new Set(['1.2']));
+    });
+
+    it('keeps the snapshot frozen across a rerender with more live picks, so markers do not disappear mid-visit', () => {
+        localStorage.setItem(STORAGE_KEY('draft-1'), JSON.stringify([]));
+        const builtDraft = [round(1, [pick(1, 'p1')])];
+
+        const { result, rerender } = renderHook(({ builtDraft }) => useSeenPicks({ draftId: 'draft-1', builtDraft }), {
+            initialProps: { builtDraft },
+        });
+
+        expect(result.current.newPickKeys).toEqual(new Set(['1.1']));
+
+        const moreLivePicks = [round(1, [pick(1, 'p1'), pick(2, 'p2')])];
+        rerender({ builtDraft: moreLivePicks });
+
+        // Both picks are new: the snapshot did not advance just because a
+        // live poll re-rendered with an extra pick.
+        expect(result.current.newPickKeys).toEqual(new Set(['1.1', '1.2']));
+    });
+
+    it('reports a manual pick projected into a later round while an earlier real pick is still unseen', () => {
+        localStorage.setItem(STORAGE_KEY('draft-1'), JSON.stringify([]));
+        const builtDraft = [round(1, [pick(1, 'p1'), pick(2, null)]), round(2, [pick(1, 'manual-p')])];
+
+        const { result } = renderHook(() => useSeenPicks({ draftId: 'draft-1', builtDraft }));
+
+        expect(result.current.newPickKeys).toEqual(new Set(['1.1', '2.1']));
+    });
+});
+
+describe('useSeenPicks markSeen', () => {
+    it('removes a key from newPickKeys once marked seen', () => {
+        localStorage.setItem(STORAGE_KEY('draft-1'), JSON.stringify([]));
+        const builtDraft = [round(1, [pick(1, 'p1')])];
+
+        const { result } = renderHook(() => useSeenPicks({ draftId: 'draft-1', builtDraft }));
+
+        expect(result.current.newPickKeys).toEqual(new Set(['1.1']));
+
+        act(() => {
+            result.current.markSeen('1.1');
+        });
+
+        expect(result.current.newPickKeys).toEqual(new Set());
+    });
+});
+
+describe('useSeenPicks draft switching', () => {
+    it('re-initialises against the new draft id when draftId changes', () => {
+        localStorage.setItem(STORAGE_KEY('draft-1'), JSON.stringify(['1.1']));
+        localStorage.setItem(STORAGE_KEY('draft-2'), JSON.stringify([]));
+
+        const { result, rerender } = renderHook(({ draftId, builtDraft }) => useSeenPicks({ draftId, builtDraft }), {
+            initialProps: {
+                draftId: 'draft-1',
+                builtDraft: [round(1, [pick(1, 'p1'), pick(2, 'p2')])],
+            },
+        });
+
+        expect(result.current.newPickKeys).toEqual(new Set(['1.2']));
+
+        rerender({ draftId: 'draft-2', builtDraft: [round(1, [pick(1, 'other-player')])] });
+
+        expect(result.current.newPickKeys).toEqual(new Set(['1.1']));
+    });
+});
+
+describe('useSeenPicks localStorage failures', () => {
+    it('degrades to in-memory when setItem throws (Safari private mode)', () => {
+        const setItemSpy = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+            throw new Error('QuotaExceededError');
+        });
+
+        const builtDraft = [round(1, [pick(1, 'p1')])];
+
+        expect(() => renderHook(() => useSeenPicks({ draftId: 'draft-1', builtDraft }))).not.toThrow();
+
+        setItemSpy.mockRestore();
+    });
+
+    it('degrades to a fresh snapshot when the stored value is corrupt JSON', () => {
+        localStorage.setItem(STORAGE_KEY('draft-1'), 'not json{{{');
+        const builtDraft = [round(1, [pick(1, 'p1'), pick(2, 'p2')])];
+
+        const { result } = renderHook(() => useSeenPicks({ draftId: 'draft-1', builtDraft }));
+
+        // Treated as a first-ever visit: nothing flagged as new, rather than
+        // the corrupt value taking the board down.
+        expect(result.current.newPickKeys).toEqual(new Set());
+    });
+
+    it('degrades to a fresh snapshot when the stored value is valid JSON but not an array', () => {
+        localStorage.setItem(STORAGE_KEY('draft-1'), JSON.stringify({ not: 'an array' }));
+        const builtDraft = [round(1, [pick(1, 'p1')])];
+
+        const { result } = renderHook(() => useSeenPicks({ draftId: 'draft-1', builtDraft }));
+
+        expect(result.current.newPickKeys).toEqual(new Set());
+    });
+});


### PR DESCRIPTION
Step 04 of the UI redesign. A dynasty rookie draft runs over three days, so the first thing you want on opening the app is *what did I miss*.

Picks that arrived since your last visit get a `NEW` chip, and each round header carries a count.

## Decisions

| | |
|---|---|
| Storage | `localStorage`, one key per draft (`sleeper-app:seen-picks:<draft_id>`) |
| "Seen" | Snapshotted on entering the Draft section, frozen for the visit, advanced for the next one |

The snapshot is frozen so markers don't vanish while you're reading, scrolling, or toggling Feed/Grid. Storage advances continuously rather than on unmount — closing a tab never unmounts anything, so an unmount write would never fire.

**A set of pick keys, not a cursor.** `applyManualPick` can project a player into any *future* pick, so a "furthest pick reached" cursor would advance past real picks still unseen and silently hide them. Each pick is judged on its own instead. Keys are `round.pick_number` — `board_spot` is the team column and is identical to `pick_number` on a linear board, so only the snake fixture catches that mix-up.

A manual pick you make yourself is marked seen immediately, so it doesn't flash `NEW` at its own author.

## The bug the unit tests couldn't see

A built board arrives with **no picks in it** — `buildDraftRounds` only lays out the pick order, and player ids land later via Update/Sync. So seeding the first-visit snapshot at mount snapshots an empty board, and the first Update flags the entire board as new — exactly what that seeding exists to prevent. Measured against a real finished 50-pick league: all 50 lit up. With nothing stored, the snapshot now waits until the board actually carries picks. Three regression tests cover the real load order.

Every fixture-based test mounts with a pre-filled board, which is why none of them saw it.

## Colour

`NEW` is a neutral ink-on-ground chip. Saturation is reserved for position data and violet for "yours", so neither was available; contrast is 15.7:1, well clear of AA.

## Verification

Six gates green; tests **261 → 294**.

**18 sabotages, 17 caught.** The two that initially passed were real coverage gaps and both are now closed: deleting the `NEW` chip and the header count left the whole suite green (only accessible names were asserted, never the rendered markers), and unthreading `newPickKeys` anywhere between the hook and `PickRow` also passed — every level defaults to an empty `Set`, so the feature silently did nothing while every unit still passed. `DraftPanel.test.jsx` now exercises the assembled path with a stateful `updateDraftBoard`, since a `vi.fn()` never changes the board and the assertion would be vacuous.

The one still-passing sabotage is the global `localStorage.clear()` in `setupTests.js`: no test currently leaks, so it is defensive rather than load-bearing. It stays because `useSeenPicks` writes on mount, and without it a test that renders the board turns the next test in the same file into a "returning visit" — which changes accessible names by test order alone.

**Browser-verified** against the real app at 375 and 1280:

| | |
|---|---|
| First visit, 50-pick finished league | 50 made rows, **0** chips, snapshot stored |
| Returning visit, 3 picks missed | 3 chips on exactly those rows, "3 new" on Round 5 |
| Leave and return | markers clear |
| Sticky round headers | 38.5px with and without a count — no jitter |
| 50 rows at 375px | 0 truncated, no horizontal overflow |

Grid cells are deliberately unmarked — this is the feed only.