### PR TITLE
Rebuild the weekly lineup as its own screen

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -18,9 +18,6 @@
         flex-direction: column;
     }
 
-    .roster-positions {
-        padding: 0 !important;
-    }
     .team {
         flex-direction: column;
     }
@@ -139,12 +136,6 @@
     height: 25px;
 }
 
-.roster-positions {
-    display: flex;
-    flex-direction: column;
-    padding: 5px 15px 15px 15px;
-}
-
 .input {
     margin-top: 8px;
     margin-right: 3px;
@@ -179,14 +170,6 @@
 
 .radioPad {
     display: none;
-}
-
-.lineup-position {
-    width: fit-content;
-    display: flex;
-    padding: 5px 5px 5px 5px;
-    border-radius: 10px;
-    margin-top: 3px;
 }
 
 .draft-pick {

--- a/src/Panels/LeaguePanel.jsx
+++ b/src/Panels/LeaguePanel.jsx
@@ -1,4 +1,5 @@
 import DraftPanel from './DraftPanel';
+import LineupPanel from './LineupPanel';
 import Spinner from '../Components/Spinner';
 
 const LeaguePanel = ({
@@ -20,77 +21,11 @@ const LeaguePanel = ({
             ) : (
                 <>
                     {view === 'weekly' && (
-                        <div className="roster-positions">
-                            {rosterSlots.map((slot, i) => {
-                                // A slot is occupied whenever it holds a player id, even if
-                                // that id is missing from the player database (a retired
-                                // player dropped from it). Keying the click off the id
-                                // rather than off the lookup means such a slot can still be
-                                // cleared - previously it rendered the raw id and could not
-                                // be emptied at all.
-                                const player = slot.playerId ? playerInfo[slot.playerId] : null;
-                                const occupantName = player ? player.full_name : slot.playerId;
-                                return (
-                                    <div
-                                        style={{ cursor: 'pointer' }}
-                                        className={`${player ? player.position : slot.label} lineup-position`}
-                                        key={`${slot.label}-${i}`}
-                                        onClick={() => (slot.playerId ? removeFromLineup(i) : null)}
-                                    >
-                                        <span className="full-text" style={{ marginRight: 0 }}>
-                                            <b>{slot.label}</b>
-                                            {slot.playerId ? ` ${occupantName}` : null}
-                                        </span>
-                                        <span className="abbr-text" style={{ marginRight: 0 }}>
-                                            <b>{slot.label}</b>
-                                            {slot.playerId
-                                                ? ` ${player ? `${player.first_name.split('')[0]}.${player.last_name}` : slot.playerId}`
-                                                : null}
-                                        </span>
-                                        {player ? (
-                                            <div
-                                                style={{
-                                                    marginBottom: -19 + 'px',
-                                                    marginLeft: 3 + 'px',
-                                                    position: 'relative',
-                                                    bottom: 3 + 'px',
-                                                }}
-                                            >
-                                                <div
-                                                    className="avatar-player"
-                                                    aria-label="nfl Player"
-                                                    style={{
-                                                        width: 22 + 'px',
-                                                        height: 22 + 'px',
-                                                        flex: '0 0 32 px',
-                                                        background: `url(https://sleepercdn.com/content/nfl/players/thumb/${player.player_id}.jpg) center center / cover rgb(239, 239, 239)`,
-                                                        borderRadius: 33 + '%',
-                                                        backgroundColor: 'transparent',
-                                                    }}
-                                                ></div>
-                                                <div
-                                                    className="avatar-player"
-                                                    aria-label="nfl Player"
-                                                    style={{
-                                                        width: 17 + 'px',
-                                                        height: 17 + 'px',
-                                                        flex: '0 0 32 px',
-                                                        background: `url(https://sleepercdn.com/images/team_logos/nfl/${
-                                                            player.team ? player.team.toLowerCase() : null
-                                                        }.png) center center / cover rgb(239, 239, 239)`,
-                                                        borderRadius: 33 + '%',
-                                                        position: 'relative',
-                                                        top: -12 + 'px',
-                                                        left: 10 + 'px',
-                                                        backgroundColor: 'transparent',
-                                                    }}
-                                                ></div>
-                                            </div>
-                                        ) : null}
-                                    </div>
-                                );
-                            })}
-                        </div>
+                        <LineupPanel
+                            playerInfo={playerInfo}
+                            rosterSlots={rosterSlots}
+                            removeFromLineup={removeFromLineup}
+                        />
                     )}
                     {view === 'draft' && (
                         <DraftPanel

--- a/src/Panels/LeaguePanel.test.jsx
+++ b/src/Panels/LeaguePanel.test.jsx
@@ -1,14 +1,13 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import LeaguePanel from './LeaguePanel';
 import { buildRosterInfo, decorateRosters } from '../lib/rosterInfo.js';
 import rosterFlagsFixture from '../lib/__fixtures__/roster-flags-2026.json';
 
 // LeaguePanel no longer owns which sub-panel is showing - a `view` prop
 // selects it, and AppShell (via App) is what changes that prop. The weekly
-// lineup is the only view rendered nowhere else, and App.test.jsx never
-// leaves the draft tab, so the weekly branch had no coverage at all.
+// lineup's own rendering is covered in LineupPanel.test.jsx; this file only
+// covers the loader and the view switch itself.
 
 const { rosterDataRaw, managerData, playerInfo, builtDraft } = rosterFlagsFixture;
 
@@ -19,17 +18,8 @@ const LEAGUE_ID = '1312088290526003200';
 const OTHER_LEAGUE_ID = '9999999999999999999';
 const STARTER = { id: '13274', name: 'Germie Bernard' };
 
-// The player database is used exactly as the fixture holds it - nothing is
-// decorated onto it any more. The slot label lives on the slot, which is the
-// whole point of the shape.
-const lineupPlayerInfo = playerInfo;
-
 // Index 1 is the only filled slot; the empty ones around it are what
 // distinguishes a real starter from an open position.
-// The filled slot is deliberately a FLX holding a WR: the label and the
-// occupant's position must differ, or rendering the position instead of the
-// label looks identical and the assertion proves nothing. A WR in a WR slot
-// hides exactly the bug this is here to catch.
 const ROSTER_SLOTS = [
     { label: 'QB', playerId: null },
     { label: 'FLX', playerId: STARTER.id },
@@ -54,7 +44,7 @@ function renderPanel(overrides = {}) {
             },
             rosterData,
         },
-        playerInfo: lineupPlayerInfo,
+        playerInfo,
         rosterInfo,
         rosterSlots: ROSTER_SLOTS,
         isLoading: false,
@@ -71,10 +61,7 @@ function renderPanel(overrides = {}) {
 const draftPanelShowing = () => screen.queryByRole('button', { name: 'Sync draft' }) !== null;
 
 describe('LeaguePanel', () => {
-    let user;
-
     beforeEach(() => {
-        user = userEvent.setup();
         global.fetch = vi.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve([]) }));
     });
 
@@ -98,42 +85,5 @@ describe('LeaguePanel', () => {
 
         expect(draftPanelShowing()).toBe(false);
         expect(screen.getAllByText(STARTER.name).length).toBeGreaterThan(0);
-    });
-
-    it('renders filled lineup slots as players and empty ones as bare position labels', () => {
-        const { container } = renderPanel({ view: 'weekly' });
-
-        const slots = [...container.querySelectorAll('.lineup-position')];
-        expect(slots).toHaveLength(ROSTER_SLOTS.length);
-
-        // Two different things are rendered from one filled slot, and they
-        // disagree here on purpose: the class comes from the occupant's
-        // position (that is what colours the row), while the visible label
-        // comes from the slot. A WR sitting in FLX must read FLX.
-        expect(slots[1].className).toContain(lineupPlayerInfo[STARTER.id].position);
-        expect(slots[1].textContent).toContain(STARTER.name);
-        expect(slots[1].textContent).toContain('FLX');
-        expect(slots[1].textContent).not.toContain('WR');
-        // Doubled because the slot renders a full-text and an abbr-text span,
-        // one of which CSS hides depending on viewport width.
-        expect(slots[0].textContent).toBe('QBQB');
-        expect(slots[2].textContent).toBe('WRWR');
-    });
-
-    it('removes a player from the lineup by slot index, and ignores clicks on empty slots', async () => {
-        const { removeFromLineup, container } = renderPanel({ view: 'weekly' });
-
-        const slots = [...container.querySelectorAll('.lineup-position')];
-
-        await user.click(slots[0]);
-        expect(removeFromLineup).not.toHaveBeenCalled();
-
-        await user.click(slots[1]);
-        // The index is which slot gets emptied, so passing the wrong one clears
-        // someone else's.
-        expect(removeFromLineup).toHaveBeenCalledTimes(1);
-        // The index alone identifies the slot now - the player id was only ever
-        // needed to look roster_text back off the player.
-        expect(removeFromLineup).toHaveBeenCalledWith(1);
     });
 });

--- a/src/Panels/LineupPanel.jsx
+++ b/src/Panels/LineupPanel.jsx
@@ -1,0 +1,29 @@
+import SlotRow from './SlotRow';
+
+const LineupPanel = ({ playerInfo, rosterSlots, removeFromLineup }) => {
+    const emptyCount = rosterSlots.filter((slot) => !slot.playerId).length;
+
+    return (
+        <div>
+            <h4 className="border-line bg-ground sticky top-0 z-10 m-0 flex items-center justify-between border-b border-solid px-3 py-2 text-sm font-semibold">
+                <span>Starters</span>
+                {/* Omitted entirely at zero rather than reading "0 empty" -
+                    a full lineup has nothing to draw attention to. */}
+                {emptyCount > 0 && <span className="text-ink-muted font-normal">{emptyCount} empty</span>}
+            </h4>
+            <ul className="m-0 flex list-none flex-col gap-1 p-0 py-1">
+                {rosterSlots.map((slot, i) => (
+                    <SlotRow
+                        key={`${slot.label}-${i}`}
+                        slot={slot}
+                        index={i}
+                        playerInfo={playerInfo}
+                        onRemove={removeFromLineup}
+                    />
+                ))}
+            </ul>
+        </div>
+    );
+};
+
+export default LineupPanel;

--- a/src/Panels/LineupPanel.test.jsx
+++ b/src/Panels/LineupPanel.test.jsx
@@ -1,0 +1,121 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import LineupPanel from './LineupPanel';
+
+const STARTER = {
+    player_id: '13274',
+    full_name: 'Germie Bernard',
+    first_name: 'Germie',
+    last_name: 'Bernard',
+    position: 'WR',
+    team: 'LV',
+};
+
+const PLAYER_INFO = { [STARTER.player_id]: STARTER };
+const MISSING_ID = '999999';
+
+// The filled slot is deliberately a FLX holding a WR: the label and the
+// occupant's position must differ, or rendering the position instead of the
+// label looks identical and the assertion proves nothing. A WR in a WR slot
+// hides exactly the bug this is here to catch.
+const ROSTER_SLOTS = [
+    { label: 'QB', playerId: null },
+    { label: 'FLX', playerId: STARTER.player_id },
+    { label: 'WR', playerId: null },
+];
+
+function renderLineup(overrides = {}) {
+    const removeFromLineup = vi.fn();
+    const { unmount } = render(
+        <LineupPanel
+            playerInfo={PLAYER_INFO}
+            rosterSlots={ROSTER_SLOTS}
+            removeFromLineup={removeFromLineup}
+            {...overrides}
+        />,
+    );
+    return { removeFromLineup, unmount };
+}
+
+describe('LineupPanel', () => {
+    it('labels a filled slot by the slot, not the occupant - a WR in FLX reads FLX', () => {
+        renderLineup();
+
+        // The label and the position chip disagree on purpose: a WR sitting
+        // in a FLX slot must read FLX, never WR.
+        expect(screen.getByRole('button', { name: 'FLX, Germie Bernard, WR' })).toBeTruthy();
+        expect(screen.queryByRole('button', { name: 'WR, Germie Bernard, WR' })).toBeNull();
+
+        // The rendered label, not just the accessible name. Swapping the
+        // visible label for the occupant's position left the name correct and
+        // every test green - the two are built from different expressions, so
+        // one of them passing says nothing about the other.
+        expect(screen.getByText('FLX')).toBeVisible();
+    });
+
+    it('renders empty slots as bare, non-interactive rows', () => {
+        renderLineup();
+
+        // Empty slots have no fill-from-slot action in this app, so they are
+        // not buttons at all - only filled slots get a role of button.
+        expect(screen.queryByRole('button', { name: 'QB, empty' })).toBeNull();
+        expect(screen.queryByRole('button', { name: 'WR, empty' })).toBeNull();
+        expect(screen.getByLabelText('QB, empty')).toBeTruthy();
+        expect(screen.getByLabelText('WR, empty')).toBeTruthy();
+    });
+
+    it('calls removeFromLineup with the slot index, and ignores clicks on empty slots', async () => {
+        const user = userEvent.setup();
+        const { removeFromLineup } = renderLineup();
+
+        // Empty slots are not buttons, so there is nothing to click - this
+        // just confirms no stray handler exists on them.
+        await user.click(screen.getByLabelText('QB, empty'));
+        expect(removeFromLineup).not.toHaveBeenCalled();
+
+        await user.click(screen.getByRole('button', { name: 'FLX, Germie Bernard, WR' }));
+        // The index is which slot gets emptied, so passing the wrong one
+        // clears someone else's.
+        expect(removeFromLineup).toHaveBeenCalledTimes(1);
+        expect(removeFromLineup).toHaveBeenCalledWith(1);
+    });
+
+    it('shows a muted count of unfilled slots, omitted entirely when zero', () => {
+        const { unmount } = renderLineup();
+        expect(screen.getByText('2 empty')).toBeTruthy();
+        unmount();
+
+        const fullSlots = [{ label: 'QB', playerId: STARTER.player_id }];
+        renderLineup({ rosterSlots: fullSlots });
+        expect(screen.queryByText(/empty$/)).toBeNull();
+    });
+
+    it('renders a slot holding an id missing from the player database, and keeps it removable', async () => {
+        const user = userEvent.setup();
+        const slots = [{ label: 'TE', playerId: MISSING_ID }];
+        const { removeFromLineup } = renderLineup({ rosterSlots: slots });
+
+        const row = screen.getByRole('button', { name: `TE, Unknown player ${MISSING_ID}` });
+        expect(row).toBeTruthy();
+
+        // Asserted on screen, not only in the accessible name: the two were
+        // built by separate expressions and disagreed here - the row showed a
+        // bare id while the name said "Unknown player <id>". Checking the name
+        // alone is what let that through.
+        expect(screen.getByText(`Unknown player ${MISSING_ID}`)).toBeVisible();
+
+        await user.click(row);
+        expect(removeFromLineup).toHaveBeenCalledWith(0);
+    });
+
+    it('shows the occupant name and team on screen, and Empty for an unfilled slot', () => {
+        renderLineup();
+
+        expect(screen.getByText(STARTER.full_name)).toBeVisible();
+        // The second line is the team alone - there is no schedule data in
+        // this app, so an opponent here would have to be invented.
+        expect(screen.getByText(STARTER.team)).toBeVisible();
+        expect(screen.getAllByText('Empty')).toHaveLength(2);
+    });
+});

--- a/src/Panels/SlotRow.jsx
+++ b/src/Panels/SlotRow.jsx
@@ -1,0 +1,86 @@
+import { positionClass } from './pickLabels.js';
+import { slotAccessibleName, slotOccupantLabel } from './lineupLabels.js';
+
+const SlotRow = ({ slot, index, playerInfo, onRemove }) => {
+    // A slot is occupied whenever it holds a player id, even if that id is
+    // missing from the player database (a retired player dropped from it).
+    // Keying the occupied state off the id rather than off the lookup means
+    // such a slot still renders as filled and removable - matching PickRow,
+    // which renders the raw id rather than a blank for the same case.
+    const player = slot.playerId ? playerInfo[slot.playerId] : null;
+    // Read off the same helper as the accessible name below. These were two
+    // separate expressions and disagreed for a missing player - the row read a
+    // bare id while the name said "Unknown player <id>", which is precisely the
+    // drift lineupLabels.js exists to prevent.
+    const occupantName = slotOccupantLabel({ slot, player });
+    const accessibleName = slotAccessibleName({ slot, player });
+
+    // Shared classes for the row geometry - copied from PickRow rather than
+    // reinvented, because Tailwind orders utilities by group, not by
+    // class-string order: a base border-solid here would beat a later
+    // border-dashed if both were left in the same string.
+    // `box-border` is load-bearing, not tidiness. Preflight is not loaded, so
+    // a <button> keeps the UA's border-box while a <div> stays content-box -
+    // and a filled slot is a button while an empty one is a div. Measured in a
+    // browser, that alone made empty rows 62px against a filled row's 54, so
+    // the list jogged 8px at every gap. min-h-14 rather than min-h-11 because
+    // the filled row's two stacked lines already exceed 44px: with both rows
+    // border-box the floor is what makes them agree instead of merely being
+    // above the 44px touch minimum.
+    const rowClasses =
+        'm-0 box-border flex min-h-14 w-full items-center gap-3 rounded-[5px] border bg-transparent px-3 py-2 text-left';
+
+    const content = (
+        <>
+            <span className="text-ink-muted w-12 shrink-0 text-sm">{slot.label}</span>
+            {slot.playerId ? (
+                <span className="flex min-w-0 flex-1 flex-col leading-tight">
+                    <span className="text-ink truncate text-sm">{occupantName}</span>
+                    {/* No opponent/schedule data is available here, so only the
+                        team renders on the second line - inventing an opponent
+                        would be worse than leaving the line short. */}
+                    {player?.team && <span className="text-ink-muted truncate text-xs">{player.team}</span>}
+                </span>
+            ) : (
+                <span className="text-ink-muted flex min-w-0 flex-1 flex-col text-sm">Empty</span>
+            )}
+            {player && (
+                <span
+                    className={`text-ground shrink-0 rounded-[4px] px-1.5 py-0.5 text-xs font-semibold ${positionClass(player.position)}`}
+                >
+                    {player.position}
+                </span>
+            )}
+        </>
+    );
+
+    // Filled slots remove on click; empty slots have nothing to do. The
+    // design captions empty slots "Tap to fill", but no fill-from-slot action
+    // exists in this app - filling happens from the Ranks panel's Add button.
+    // A control that does nothing is worse than none, so an empty slot is a
+    // plain non-interactive row rather than a button with no effect.
+    if (!slot.playerId) {
+        return (
+            <li>
+                <div aria-label={accessibleName} className={`${rowClasses} border-line border-dashed`}>
+                    {content}
+                </div>
+            </li>
+        );
+    }
+
+    return (
+        <li>
+            <button
+                type="button"
+                aria-label={accessibleName}
+                onClick={() => onRemove(index)}
+                className={`${rowClasses} border-line appearance-none border-solid`}
+            >
+                {content}
+            </button>
+        </li>
+    );
+};
+
+export default SlotRow;

--- a/src/Panels/lineupLabels.js
+++ b/src/Panels/lineupLabels.js
@@ -1,0 +1,22 @@
+// Builds the accessible name shared by SlotRow's filled and empty renders, so
+// the visible text and the name cannot drift the way pickLabels.js does for
+// the feed: "FLX, Colston Loveland, WR" for a filled slot, "WR, empty" for an
+// empty one. The slot's own label always leads - see slotAccessibleName's
+// callers in SlotRow for why the occupant's position is never substituted.
+
+// The occupant's visible name. A slot can hold an id that is absent from the
+// player database (a retired player dropped from it), and the raw id alone
+// renders as a bare number that reads like a bug rather than a diagnosable
+// gap - PickRow spells the same case out, so this matches it.
+export const slotOccupantLabel = ({ slot, player }) => (player ? player.full_name : `Unknown player ${slot.playerId}`);
+
+export const slotAccessibleName = ({ slot, player }) => {
+    if (!slot.playerId) {
+        return `${slot.label}, empty`;
+    }
+    const nameParts = [slot.label, slotOccupantLabel({ slot, player })];
+    if (player) {
+        nameParts.push(player.position);
+    }
+    return nameParts.join(', ');
+};

--- a/src/styles/legacy-css.test.js
+++ b/src/styles/legacy-css.test.js
@@ -33,7 +33,13 @@ const APP_CSS = resolve(process.cwd(), 'src/App.css');
 // and moved in here rather than being converted or dropped. This is rules
 // relocating out of a deleted stylesheet, not new styling - the ratchet
 // still only trends toward zero across the two files combined.
-const MAX_LINES = 341;
+//
+// 324 once the weekly lineup moved onto Tailwind as LineupPanel: both
+// `.roster-positions` rules (the base one and the one inside the phone
+// media query) and `.lineup-position` are gone. `.abbr-text`, `.full-text`,
+// and `.avatar-player` stay - PlayerInfoItem still uses them and is not
+// part of this migration.
+const MAX_LINES = 324;
 
 const CONVERTED = ['error-banner', 'warning-banner', 'main-container', 'latest-update', '.title {'];
 


### PR DESCRIPTION
Step 05, part 1. The weekly lineup was still original markup living inside `LeaguePanel`: `full-text`/`abbr-text` spans, six inline `style={{}}` objects, and two `sleepercdn` avatar divs. It moves out to `LineupPanel` + `SlotRow` on Tailwind.

Rows now match the pick feed — same geometry, same position chip, same stacked two-line treatment — per the design doc's Lineup screen:

| | |
|---|---|
| Slot label | Always the **slot's** label. A WR in a FLX slot reads `FLX`, never `WR` |
| Occupant | Name over team. There is no schedule data in this app, so the design's `WAS · vs ARI` second line is the team alone — the opponent is not invented |
| Empty slot | Dashed border, muted `Empty`, counted as `N empty` in the header (omitted at zero) |
| Missing player | Renders `Unknown player <id>` and stays removable, matching `PickRow` |

**Empty slots are not buttons.** The design captions them "Tap to fill", but no fill-from-slot action exists — filling happens from the Ranks panel's Add button. A control that does nothing is worse than none, so they render inert. Worth its own decision if you want the fill interaction.

The two avatars are dropped: the design's lineup rows carry none, and they were four of the six inline styles.

`App.css` **341 → 324** (`.roster-positions` ×2 including the one inside the phone media query, and `.lineup-position`). `.abbr-text`, `.full-text`, `.avatar-player` and the position classes stay — `PlayerInfoItem` still uses all of them and is next.

## The bug the tests couldn't see

A filled row is a `<button>`, an empty row is a `<div>`. Preflight is not loaded, so the button keeps the UA's `border-box` while the div stays `content-box` — the same `min-h-11 px-3 py-2 border` produced **54px filled and 62px empty**, so the list jogged 8px at every gap. Fixed with an explicit `box-border` and a `min-h-14` floor; all nine rows now measure 56px in a browser.

## Verification

Six gates green; tests **294 → 298**. No test in a touched file uses `container.querySelector`, `closest('.class')` or a `className` assertion — the old lineup tests used all three.

**15 sabotages, 13 caught.** Two passed and both are the expected kind:
- Swapping the empty row's dashed border for solid — jsdom applies no stylesheet, so this is a browser check by nature, and it is measured below.
- Raising the `App.css` ratchet to 999 — a ceiling only fails when exceeded. Inherent to a ratchet, not a gap to fill.

One sabotage caught a real gap mid-run: replacing the **visible** slot label with the occupant's position left every test green, because only the accessible name was asserted. The two are built from different expressions, so one passing said nothing about the other. Same shape as the missing-player case, where the row showed a bare id while the name said `Unknown player <id>` — that drift was live in the first draft of this change and is now fixed by both reading one helper.

**Browser-verified** at 375 and 1280: nine rows uniform at 56px, all `border-box`, dashed borders 1px on all four edges (no medium-width leak), TE chip in position orange on dark ink, no horizontal overflow, clean console.