### PR TITLE
Replace the availability tint that failed AA, and convert PlayerInfoItem

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,8 +1,4 @@
 @media screen and (max-width: 767px) {
-    .avatar-player {
-        margin-left: 10px !important;
-    }
-
     /* The 50% width here dated from the two-panel phone layout: the shell shows
        one section at a time below 768px, so it just left the other half empty. */
     .panel {
@@ -16,13 +12,6 @@
 
     .draft-pick-rows {
         flex-direction: column;
-    }
-
-    .team {
-        flex-direction: column;
-    }
-    .team-name {
-        font-size: smaller;
     }
 }
 
@@ -58,35 +47,10 @@
     flex-direction: row;
 }
 
-.single-player-item {
-    border: 2px solid #2c3846;
-    display: grid;
-    grid-template-columns: 2fr 1fr;
-    padding: 5px;
-    border-radius: 10px;
-    margin-top: 3px;
-    position: relative;
-}
-
 .player-grid {
     overflow-y: scroll;
     overflow-x: visible;
     max-height: 600px;
-}
-
-.player-name {
-    display: flex;
-    margin-bottom: 3px;
-}
-
-.player-info {
-    display: flex;
-    flex-direction: row;
-}
-
-.player-info-item {
-    font-size: small;
-    margin-right: 6px;
 }
 
 .RB {
@@ -103,26 +67,6 @@
 
 .QB {
     background: rgb(255, 42, 109);
-}
-
-.RB-available {
-    background-color: rgba(0, 206, 185, 0.45);
-}
-
-.WR-available {
-    background-color: rgb(88, 167, 255, 0.45);
-}
-
-.TE-available {
-    background-color: rgb(255, 174, 88, 0.45);
-}
-
-.QB-available {
-    background-color: rgb(255, 42, 109, 0.45);
-}
-
-.available {
-    opacity: 0.45;
 }
 
 .dropdown {
@@ -190,24 +134,6 @@
     color: #e8edf2;
     height: 20px;
     width: 20px;
-}
-
-.abbr-text {
-    display: none;
-}
-
-/* This is a width breakpoint, not an orientation check: below 640px
-   (Tailwind's `sm`), abbreviate names; at 640px and up, show full names. */
-@media all and (max-width: 639px) {
-    .abbr-text {
-        display: inline-block;
-        text-overflow: ellipsis;
-        overflow: hidden;
-        white-space: nowrap;
-    }
-    .full-text {
-        display: none;
-    }
 }
 
 .draft-pick-details {
@@ -305,20 +231,10 @@
     display: none;
 }
 
-.search-alert {
-    border: 6px solid red;
-}
-
-/* Moved in from the deleted Button.css: neither rule is about buttons.
-   clickable-item is used by draft rows and player rows, and the media query
-   is grid placement belonging to PlayerInfoItem's .player-add-div. */
+/* Moved in from the deleted Button.css - not about buttons. clickable-item is
+   used by ManualPickModal's draft-pick-rows; the grid-placement media query
+   that used to live beside it belonged to PlayerInfoItem and went with that
+   component's Tailwind conversion. */
 .clickable-item:hover {
     cursor: pointer;
-}
-
-@media screen and (max-width: 767px) {
-    .player-add-div {
-        grid-column-start: 2;
-        grid-row-start: 3;
-    }
 }

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -364,18 +364,22 @@ describe('App', () => {
         await user.type(screen.getByPlaceholderText('Copy + Paste rankings here...'), `1. ${SWAPPED_PLAYER.name}`);
         await user.click(screen.getByRole('button', { name: 'Submit' }));
 
+        // PlayerInfoItem's row carries availability in its accessible name now
+        // (see playerInfoLabels.js) rather than in a `.team-name` element, so
+        // this reads the row's aria-label instead of a class-scoped text node.
         const attribution = async () => {
-            const item = (await screen.findByText(SWAPPED_PLAYER.name)).closest('.single-player-item');
-            return item.querySelector('.team-name').textContent;
+            await screen.findByText(SWAPPED_PLAYER.name);
+            const row = screen.getByRole('group', { name: new RegExp(`^${SWAPPED_PLAYER.name}, `) });
+            return row.getAttribute('aria-label');
         };
 
-        expect(await attribution()).toBe('ryangh');
+        expect(await attribution()).toContain('taken by ryangh');
 
         await user.selectOptions(screen.getByDisplayValue('Test League'), OTHER_LEAGUE_ID);
 
         // The second league has this player on nobody's roster, so the derived
         // flags must follow the new league rather than keeping the stale name.
-        await waitFor(async () => expect(await attribution()).toBe('Free Agent'));
+        await waitFor(async () => expect(await attribution()).toContain('free agent'));
     });
 
     it('checks rosters against a player database that has actually loaded', async () => {

--- a/src/Components/Button/Button.tsx
+++ b/src/Components/Button/Button.tsx
@@ -37,11 +37,22 @@ const BASE =
 const VARIANTS: Record<string, string> = {
     primary: 'hover:text-ink hover:border-ink-muted',
     'primary-large': 'w-4/5 text-center mt-2 mb-[15px] text-base h-[30px] hover:text-ink hover:border-ink-muted',
-    alert: 'bg-qb! border-qb! hover:scale-[1.05]!',
+    // `text-ground!` because BASE's light ink on the QB fill measured 3.07:1
+    // in a browser - below AA. Every position chip already puts near-black on
+    // these fills (5.0:1 on QB, the palette's floor), so this only brings the
+    // button in line with them. Whether a destructive action should be wearing
+    // the QB *hue* at all is the separate open decision noted above.
+    alert: 'bg-qb! border-qb! text-ground! hover:scale-[1.05]!',
     active: 'bg-line! border-ink-muted overflow-hidden hover:text-ink',
-    'primary-invert': 'text-ground! border-ground! hover:text-line hover:border-line',
+    // `player-add-button` used to invert - `text-ground! border-ground!` - and
+    // it was legible only because PlayerInfoItem's row was filled with a
+    // position colour behind it. That fill was the availability encoding that
+    // failed AA, and removing it left this button dark-on-dark: measured at
+    // 1.16:1 in a browser, effectively invisible. It takes BASE's ink now.
+    // `primary-invert` went the same way and is gone entirely - PlayerInfoItem
+    // was its only caller, so nothing renders on a coloured ground any more.
     'player-add-button':
-        'text-ground! border-ground! hover:text-line hover:border-line self-center justify-self-end text-center w-[45px] mt-2 mb-0! ml-[3px]',
+        'hover:text-ink hover:border-ink-muted self-center justify-self-end text-center w-[45px] mt-2 mb-0! ml-[3px]',
 };
 
 export const Button = ({ text, onClick, btnStyle = 'primary', isDisabled = false }: Props): React.JSX.Element => {

--- a/src/Components/PlayerInfoItem.jsx
+++ b/src/Components/PlayerInfoItem.jsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import Button from './Button';
+import { positionClass } from '../Panels/pickLabels.js';
+import { playerAccessibleName, playerAvailabilityText } from './playerInfoLabels.js';
 import { isInLineup, isTaken, rosteredBy } from '../lib/rosterInfo.js';
 
 const PlayerInfoItem = ({
@@ -19,6 +21,12 @@ const PlayerInfoItem = ({
     const taken = isTaken(rosterInfo, player.player_id);
     const rosteredByName = rosteredBy(rosterInfo, player.player_id);
     const inLineup = isInLineup(lineupSet, player.player_id);
+    const isMine = taken && rosteredByName === myDisplayName;
+    // A low search-confidence match used to fill the whole row with a red
+    // background (`.search-alert`); the `--color-warn` border below is the
+    // replacement, and it is independent of taken/mine.
+    const lowConfidenceMatch = Number(searchData.match_results[0][1]) > 0;
+    const accessibleName = playerAccessibleName({ player, taken, rosteredByName, isMine, lowConfidenceMatch });
 
     const updatePlayerInfo = (newPlayerId) => {
         const newSearchData = { ...searchData };
@@ -40,20 +48,43 @@ const PlayerInfoItem = ({
         setEditingPlayer(false);
     };
 
+    const rankedDiff = Math.round(Number(searchData.ranking) - adpData);
+    const adpLabel =
+        rankedDiff < 0
+            ? `Ranked ${Math.round(adpData - Number(searchData.ranking))} picks before ADP`
+            : rankedDiff === 0
+              ? 'Rank matches ADP'
+              : `Ranked ${rankedDiff} picks after ADP`;
+
     return (
+        // Uniform row geometry copied from PickRow/SlotRow: transparent
+        // background, `border-line` by default, `rounded-[5px]`. `box-border`
+        // matters here even though this is a single div (not a button/div
+        // pair) because Button.tsx's own buttons sit inside this row - see
+        // SlotRow's comment on the same property.
+        //
+        // Border precedence: `isMine` (violet, "yours") outranks a
+        // low-confidence match (warn) outranks the default line colour - a
+        // player can be both mine and a weak match, and violet is reserved
+        // for "yours" so it wins the one available border colour.
+        // `role="group"` is what makes the aria-label real. On a bare div -
+        // role `generic` - an aria-label is ignored by most screen readers, so
+        // the name would exist for the tests and for nobody else. The row is a
+        // composite of controls, which is what group is for.
         <div
-            key={player.player_id}
-            className={`single-player-item ${
-                Number(searchData.match_results[0][1]) <= 0 ? player.position : 'search-alert'
-            } ${taken ? '' : `${player.position}-available`}`}
+            role="group"
+            aria-label={accessibleName}
+            className={`m-0 box-border flex w-full items-start gap-3 rounded-[5px] border border-solid bg-transparent px-3 py-2 ${
+                isMine ? 'border-mine!' : lowConfidenceMatch ? 'border-warn!' : 'border-line'
+            }`}
         >
-            <div className="player-name" style={{ gridColumnStart: 1, gridColumnEnd: 4 }}>
-                {editingPlayer && (
-                    <div style={{ display: 'flex', flexDirection: 'column' }}>
+            <div className="flex min-w-0 flex-1 flex-col gap-1">
+                {editingPlayer ? (
+                    <div className="flex flex-col gap-2">
                         <select
-                            className="dropdown"
                             value={player.player_id}
                             onChange={(e) => updatePlayerInfo(e.target.value)}
+                            className="border-line text-ink box-border w-full appearance-none rounded-[5px] border border-solid bg-transparent px-2 py-1 text-sm"
                         >
                             {searchData.match_results.map((result) => (
                                 <option key={result[0]} value={result[0]}>{`${playerInfo[result[0]].full_name} - ${
@@ -61,137 +92,113 @@ const PlayerInfoItem = ({
                                 } (${playerInfo[result[0]].position})`}</option>
                             ))}
                         </select>
-                        <div>
-                            <Button text="Close" btnStyle="primary-invert" onClick={() => setEditingPlayer(false)} />
+                        <div className="flex gap-2">
+                            <Button text="Close" btnStyle="primary" onClick={() => setEditingPlayer(false)} />
                             <Button text="Delete" btnStyle="alert" onClick={() => updatePlayerId(searchData, true)} />
                         </div>
-                        {(isNewRankList || Number(searchData.match_results[0][1]) > 0 || editingPlayer) && (
-                            <div>
-                                <p style={{ fontSize: 'small' }}>
+                        {(isNewRankList || lowConfidenceMatch || editingPlayer) && (
+                            <div className="flex flex-col gap-1">
+                                <p className="text-ink-muted text-xs">
                                     <i>&quot;{searchData.search_string}&quot; </i> - Search score:{' '}
                                     {searchData.match_results[0][1]}
                                 </p>
-                                {editingPlayer && (
-                                    <input
-                                        type="text"
-                                        className="input-small"
-                                        onChange={(e) => setSearchValue(e.target.value)}
-                                        placeholder="Manually update player"
-                                    />
-                                )}
+                                <input
+                                    type="text"
+                                    onChange={(e) => setSearchValue(e.target.value)}
+                                    placeholder="Manually update player"
+                                    className="border-line text-ink box-border w-full rounded-[5px] border border-solid bg-transparent px-2 py-1 text-sm"
+                                />
                                 {searchValue.length > 2 && (
-                                    <div style={{ overflow: 'scroll', height: 100 + 'px' }}>
+                                    <div className="flex max-h-[100px] flex-col gap-1 overflow-y-scroll">
                                         {Object.values(playerInfo)
-                                            .filter((player) =>
-                                                player.full_name
-                                                    ? player.full_name
+                                            .filter((candidate) =>
+                                                candidate.full_name
+                                                    ? candidate.full_name
                                                           .toLowerCase()
                                                           .includes(searchValue.toLowerCase()) &&
-                                                      ['QB', 'RB', 'WR', 'TE'].includes(player.position)
+                                                      ['QB', 'RB', 'WR', 'TE'].includes(candidate.position)
                                                     : null,
                                             )
                                             .sort((a, b) => a.search_rank - b.search_rank)
-                                            .map((player) => (
-                                                <p
-                                                    className={`clickable-item draft-pick-rows ${player.position}`}
-                                                    style={{ padding: `${0} ${3}px` }}
-                                                    key={player.player_id}
-                                                    onClick={() => updatePlayerInfo(player.player_id)}
+                                            .map((candidate) => (
+                                                <button
+                                                    type="button"
+                                                    key={candidate.player_id}
+                                                    onClick={() => updatePlayerInfo(candidate.player_id)}
+                                                    className="border-line text-ink hover:border-ink-muted box-border flex w-full appearance-none items-center gap-2 rounded-[4px] border border-solid bg-transparent px-2 py-1 text-left text-sm"
                                                 >
-                                                    {player.full_name} {player.position}{' '}
-                                                    {player.team ? player.team : null}
-                                                </p>
+                                                    <span className="min-w-0 flex-1 truncate">
+                                                        {candidate.full_name}
+                                                    </span>
+                                                    <span
+                                                        className={`text-ground shrink-0 rounded-[4px] px-1.5 py-0.5 text-xs font-semibold ${positionClass(candidate.position)}`}
+                                                    >
+                                                        {candidate.position}
+                                                    </span>
+                                                    {candidate.team && (
+                                                        <span className="text-ink-muted shrink-0 text-xs">
+                                                            {candidate.team}
+                                                        </span>
+                                                    )}
+                                                </button>
                                             ))}
                                     </div>
                                 )}
                             </div>
                         )}
                     </div>
+                ) : (
+                    <button
+                        type="button"
+                        onClick={() => setEditingPlayer(true)}
+                        // A single always-visible name replaces the old
+                        // full-text/abbr-text pair, a width-hiding mechanism
+                        // whose hidden fallback shipped a real defect once
+                        // (PR #116).
+                        // `border-0` is required, not cosmetic: preflight is off, so a
+                        // bare <button> keeps the UA's default outset border and
+                        // this name rendered looking like a text input.
+                        className="text-ink box-border w-full appearance-none truncate border-0 bg-transparent p-0 text-left text-sm font-semibold hover:underline"
+                    >
+                        {player.full_name}
+                    </button>
                 )}
-                {!editingPlayer && (
-                    <>
-                        <span className="clickable-item full-text" onClick={() => setEditingPlayer(true)}>
-                            <b>{player.full_name}</b>
-                        </span>
-                        <span className="clickable-item abbr-text" onClick={() => setEditingPlayer(true)}>
-                            <b>{`${player.first_name.split('')[0]}.${player.last_name}`}</b>
-                        </span>
-                        <span className="player-info-item" style={{ marginLeft: 2 + 'px', whiteSpace: 'nowrap' }}>
-                            {` - ${player.team}`} ({player.position})
-                        </span>
-                    </>
+                <div className="text-ink-muted flex flex-wrap items-center gap-x-2 text-xs">
+                    <span>Rank: {searchData.ranking}</span>
+                    <span>{player.team ? player.team : 'FA'}</span>
+                    <span>{playerAvailabilityText({ taken, rosteredByName })}</span>
+                </div>
+                {adpData && (
+                    <div className="text-ink-muted flex items-center gap-2 text-xs">
+                        <span>ADP: {adpData}</span>
+                        <span>{adpLabel}</span>
+                    </div>
                 )}
             </div>
-            <div className="player-info" style={{ gridRowStart: 2, overflow: 'hidden' }}>
-                <p className="player-info-item">
-                    <b>Rank:</b> {searchData.ranking}
-                </p>
-                <div className="player-info-item team" style={{ overflow: 'hidden', display: 'flex' }}>
-                    <p style={{ overflow: 'visible' }}>
-                        <b>Team:</b>
-                    </p>
-                    <p className="team-name" style={{ textOverflow: 'ellipsis', overflow: 'hidden' }}>
-                        {rosteredByName ? rosteredByName : 'Free Agent'}
-                    </p>
-                </div>
-            </div>
-            {adpData && (
-                <div style={{ display: 'flex', alignItems: 'center', gridRowStart: 3 }}>
-                    <p className="player-info-item">
-                        <b>ADP:</b> {adpData ? adpData : null}
-                    </p>
-                    <p className="player-info-item" style={{ fontSize: 'x-small' }}>
-                        {Math.round(Number(searchData.ranking) - adpData) < 0
-                            ? 'Ranked ' + Math.round(adpData - Number(searchData.ranking)) + ' picks before ADP'
-                            : Math.round(Number(searchData.ranking) - adpData) === 0
-                              ? 'Rank matches ADP'
-                              : 'Ranked ' + Math.round(Number(searchData.ranking) - adpData) + ' picks after ADP'}
-                    </p>
-                </div>
-            )}
-            <div style={{ gridRowStart: 2, gridColumnStart: 2, marginLeft: 3 + 'px' }}>
-                <div
-                    className="avatar-player"
-                    aria-label="nfl Player"
-                    style={{
-                        width: 32 + 'px',
-                        height: 32 + 'px',
-                        flex: '0 0 32 px',
-                        background: `url(https://sleepercdn.com/content/nfl/players/thumb/${player.player_id}.jpg) center center / cover rgb(239, 239, 239)`,
-                        borderRadius: 33 + '%',
-                        marginTop: -3 + '%',
-                        marginLeft: 30 + 'px',
-                        backgroundColor: 'transparent',
-                    }}
-                ></div>
-                <div
-                    className="avatar-player"
-                    aria-label="nfl Player"
-                    style={{
-                        width: 17 + 'px',
-                        height: 17 + 'px',
-                        flex: '0 0 32 px',
-                        background: `url(https://sleepercdn.com/images/team_logos/nfl/${
-                            player.team ? player.team.toLowerCase() : null
-                        }.png) center center / cover rgb(239, 239, 239)`,
-                        borderRadius: 33 + '%',
-                        margin: `${-3}% ${0} ${-10}px ${30}px`,
-                        position: 'relative',
-                        top: -10 + 'px',
-                        left: 17 + 'px',
-                        backgroundColor: 'transparent',
-                    }}
-                ></div>
-            </div>
-            <div className="player-add-div">
-                {(rosteredByName && rosteredByName === myDisplayName) || !taken ? (
+            <div className="flex shrink-0 flex-col items-end gap-1">
+                <span
+                    className={`text-ground shrink-0 rounded-[4px] px-1.5 py-0.5 text-xs font-semibold ${positionClass(player.position)}`}
+                >
+                    {player.position}
+                </span>
+                {/* Neutral, not a colour fill: saturation is reserved for
+                    position data and violet for "yours", so availability -
+                    the thing this row most needs to say - is carried by this
+                    chip's text plus the manager-name/"free agent" line above,
+                    not by tinting the row. */}
+                {taken && (
+                    <span className="border-line text-ink-muted shrink-0 rounded-[4px] border border-solid px-1.5 py-0.5 text-xs font-semibold">
+                        Taken
+                    </span>
+                )}
+                {(!taken || isMine) && (
                     <Button
                         text={`${inLineup ? 'Added' : 'Add'}`}
                         isDisabled={inLineup}
                         btnStyle="player-add-button"
                         onClick={() => addToRoster(player)}
                     />
-                ) : null}
+                )}
             </div>
         </div>
     );

--- a/src/Components/PlayerInfoItem.test.jsx
+++ b/src/Components/PlayerInfoItem.test.jsx
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import PlayerInfoItem from './PlayerInfoItem';
 import { buildLineupSet, buildRosterInfo, decorateRosters } from '../lib/rosterInfo.js';
 import rosterFlagsFixture from '../lib/__fixtures__/roster-flags-2026.json';
@@ -11,6 +12,11 @@ import rosterFlagsFixture from '../lib/__fixtures__/roster-flags-2026.json';
 // observable. These tests build rosterInfo through the real derivation
 // (decorateRosters -> buildRosterInfo) rather than hand-rolling a Map, so a
 // change to how the flags are derived shows up here too.
+//
+// Availability used to be asserted through `.single-player-item`'s class
+// list - exactly the transparency encoding this component's redesign
+// replaces. Every assertion below goes through the visible "Free agent" /
+// manager-name text, the "Taken" chip, or the row's accessible name instead.
 
 const { rosterDataRaw, managerData, playerInfo } = rosterFlagsFixture;
 
@@ -27,8 +33,8 @@ const FREE_AGENT_ID = '13307';
 const OTHERS_PLAYER_ID = '13294';
 const MY_PLAYER_ID = '13274';
 
-const searchDataFor = (playerId) => ({
-    match_results: [[playerId, '0.000']],
+const searchDataFor = (playerId, matchScore = '0.000') => ({
+    match_results: [[playerId, matchScore]],
     ranking: '12',
     search_string: 'a pasted rank line',
 });
@@ -47,31 +53,39 @@ function renderItem(playerId, { lineupSet = new Set(), ...overrides } = {}) {
         myDisplayName: MY_DISPLAY_NAME,
         ...overrides,
     };
-    const { container } = render(<PlayerInfoItem {...props} />);
-    return { ...props, item: container.querySelector('.single-player-item') };
+    render(<PlayerInfoItem {...props} />);
+    return props;
 }
 
 describe('PlayerInfoItem', () => {
     it('shows a free agent as available and offers the Add button', () => {
-        const { item } = renderItem(FREE_AGENT_ID);
+        renderItem(FREE_AGENT_ID);
 
         // rosteredBy returns null for an id the map doesn't hold, which is what
-        // drives the 'Free Agent' fallback rather than a blank team name.
-        expect(screen.getByText('Free Agent')).toBeTruthy();
-        // The `-available` half of the class list is the only visual signal that
-        // a player is still draftable; it is driven purely by isTaken.
-        expect(item.className).toContain(`${playerInfo[FREE_AGENT_ID].position}-available`);
+        // drives the 'Free agent' fallback rather than a blank team name.
+        expect(screen.getByText('Free agent')).toBeTruthy();
+        expect(
+            screen.getByRole('group', {
+                name: `${playerInfo[FREE_AGENT_ID].full_name}, ${playerInfo[FREE_AGENT_ID].position}, free agent`,
+            }),
+        ).toBeTruthy();
+        expect(screen.queryByText('Taken')).toBeNull();
         expect(screen.getByRole('button', { name: 'Add' })).toBeEnabled();
     });
 
     it("shows another manager's player as taken and hides the Add button entirely", () => {
-        const { item } = renderItem(OTHERS_PLAYER_ID);
+        renderItem(OTHERS_PLAYER_ID);
 
         // The display name has to survive the whole derivation: owner_id ->
         // managerData -> manager_display_name -> rosterInfo -> here.
         expect(screen.getByText('aphilliny21')).toBeTruthy();
-        expect(screen.queryByText('Free Agent')).toBeNull();
-        expect(item.className).not.toContain('-available');
+        expect(screen.getByText('Taken')).toBeTruthy();
+        expect(screen.queryByText('Free agent')).toBeNull();
+        expect(
+            screen.getByRole('group', {
+                name: `${playerInfo[OTHERS_PLAYER_ID].full_name}, ${playerInfo[OTHERS_PLAYER_ID].position}, taken by aphilliny21`,
+            }),
+        ).toBeTruthy();
         expect(screen.queryByRole('button', { name: 'Add' })).toBeNull();
     });
 
@@ -81,11 +95,69 @@ describe('PlayerInfoItem', () => {
         // clause is false and only the display-name comparison can keep the
         // button on screen - dropping that clause would hide Add for every
         // player I own, which is exactly the set I most want to add to a lineup.
-        const { item } = renderItem(MY_PLAYER_ID);
+        renderItem(MY_PLAYER_ID);
 
         expect(screen.getByText(MY_DISPLAY_NAME)).toBeTruthy();
-        expect(item.className).not.toContain('-available');
+        expect(screen.getByText('Taken')).toBeTruthy();
+        expect(
+            screen.getByRole('group', {
+                name: `${playerInfo[MY_PLAYER_ID].full_name}, ${playerInfo[MY_PLAYER_ID].position}, taken by ${MY_DISPLAY_NAME} · you`,
+            }),
+        ).toBeTruthy();
         expect(screen.getByRole('button', { name: 'Add' })).toBeEnabled();
+    });
+
+    // The row's "yours" and "low confidence" states are carried by a border
+    // colour, and this repo's tests may not assert className - so without
+    // these the whole encoding was unfalsifiable: dropping either border left
+    // all 316 tests green. The accessible name is where the meaning lives now,
+    // which makes it both assertable and audible to a screen reader.
+    it('marks your own row in the accessible name, not by border colour alone', () => {
+        renderItem(MY_PLAYER_ID);
+
+        const name = screen
+            .getByRole('group', { name: new RegExp(`^${playerInfo[MY_PLAYER_ID].full_name}, `) })
+            .getAttribute('aria-label');
+        expect(name).toContain('· you');
+
+        // Another manager's row must not claim to be yours.
+        cleanup();
+        renderItem(OTHERS_PLAYER_ID);
+        expect(
+            screen
+                .getByRole('group', { name: new RegExp(`^${playerInfo[OTHERS_PLAYER_ID].full_name}, `) })
+                .getAttribute('aria-label'),
+        ).not.toContain('· you');
+    });
+
+    it('marks a low-confidence match in the accessible name', () => {
+        // A non-zero search score is the low-confidence signal - the row used
+        // to fill red for it, and now takes the warn border.
+        renderItem(FREE_AGENT_ID, { searchData: searchDataFor(FREE_AGENT_ID, '0.420') });
+
+        expect(
+            screen
+                .getByRole('group', { name: new RegExp(`^${playerInfo[FREE_AGENT_ID].full_name}, `) })
+                .getAttribute('aria-label'),
+        ).toContain('low confidence match');
+    });
+
+    it('shows a confident match without the low-confidence marker', () => {
+        renderItem(FREE_AGENT_ID);
+
+        expect(
+            screen
+                .getByRole('group', { name: new RegExp(`^${playerInfo[FREE_AGENT_ID].full_name}, `) })
+                .getAttribute('aria-label'),
+        ).not.toContain('low confidence');
+    });
+
+    it('renders the position chip from the player, not a hardcoded position', () => {
+        // Nothing asserted the chip's visible text, so rendering a constant
+        // there passed the entire suite.
+        renderItem(FREE_AGENT_ID);
+
+        expect(screen.getByText(playerInfo[FREE_AGENT_ID].position)).toBeVisible();
     });
 
     it('disables the Add button for a player already in the lineup', () => {
@@ -105,5 +177,111 @@ describe('PlayerInfoItem', () => {
         const added = screen.getByRole('button', { name: 'Added' });
         expect(added).toBeDisabled();
         expect(screen.queryByRole('button', { name: 'Add' })).toBeNull();
+    });
+
+    it('flags a low-confidence match through the search score text, without hiding it behind a colour fill', async () => {
+        // Score > 0 is the low-confidence signal (see updatePlayerInfo's
+        // '0.000' for a fresh manual pick, which is the confident case). The
+        // row border itself isn't asserted by a role/name query, so this
+        // leans on the one thing that IS queryable: the search-score text,
+        // which only renders once the row is opened for editing.
+        const user = userEvent.setup();
+        renderItem(FREE_AGENT_ID, { searchData: searchDataFor(FREE_AGENT_ID, '0.850') });
+
+        await user.click(screen.getByRole('button', { name: playerInfo[FREE_AGENT_ID].full_name }));
+
+        expect(
+            screen.getByText((_content, element) => element?.tagName === 'P' && element.textContent.includes('0.850')),
+        ).toBeTruthy();
+    });
+
+    it('opens the edit dropdown and switches to a different match', async () => {
+        const user = userEvent.setup();
+        const updatePlayerId = vi.fn();
+        // Two candidates so a real switch is possible - a single-result
+        // match_results (the default fixture) only ever offers the player
+        // already showing, which can't distinguish "switched" from "did
+        // nothing".
+        const searchData = {
+            match_results: [
+                [FREE_AGENT_ID, '0.000'],
+                [OTHERS_PLAYER_ID, '0.000'],
+            ],
+            ranking: '12',
+            search_string: 'a pasted rank line',
+        };
+        renderItem(FREE_AGENT_ID, { updatePlayerId, searchData });
+
+        await user.click(screen.getByRole('button', { name: playerInfo[FREE_AGENT_ID].full_name }));
+
+        const select = screen.getByRole('combobox');
+        expect(select).toBeTruthy();
+
+        await user.selectOptions(select, OTHERS_PLAYER_ID);
+
+        expect(updatePlayerId).toHaveBeenCalledTimes(1);
+        const newSearchData = updatePlayerId.mock.calls[0][0];
+        expect(newSearchData.match_results[0][0]).toBe(OTHERS_PLAYER_ID);
+    });
+
+    it('deletes the row via the edit dropdown', async () => {
+        const user = userEvent.setup();
+        const updatePlayerId = vi.fn();
+        renderItem(FREE_AGENT_ID, { updatePlayerId });
+
+        await user.click(screen.getByRole('button', { name: playerInfo[FREE_AGENT_ID].full_name }));
+        await user.click(screen.getByRole('button', { name: 'Delete' }));
+
+        expect(updatePlayerId).toHaveBeenCalledWith(expect.anything(), true);
+    });
+
+    it('reports ranked-before-ADP, matches-ADP, and ranked-after-ADP', () => {
+        const { rerender } = render(
+            <PlayerInfoItem
+                player={playerInfo[FREE_AGENT_ID]}
+                playerInfo={playerInfo}
+                rosterInfo={rosterInfo}
+                lineupSet={new Set()}
+                addToRoster={vi.fn()}
+                searchData={{ ...searchDataFor(FREE_AGENT_ID), ranking: '10' }}
+                updatePlayerId={vi.fn()}
+                isNewRankList={false}
+                adpData={15}
+                myDisplayName={MY_DISPLAY_NAME}
+            />,
+        );
+        expect(screen.getByText('Ranked 5 picks before ADP')).toBeTruthy();
+
+        rerender(
+            <PlayerInfoItem
+                player={playerInfo[FREE_AGENT_ID]}
+                playerInfo={playerInfo}
+                rosterInfo={rosterInfo}
+                lineupSet={new Set()}
+                addToRoster={vi.fn()}
+                searchData={{ ...searchDataFor(FREE_AGENT_ID), ranking: '15' }}
+                updatePlayerId={vi.fn()}
+                isNewRankList={false}
+                adpData={15}
+                myDisplayName={MY_DISPLAY_NAME}
+            />,
+        );
+        expect(screen.getByText('Rank matches ADP')).toBeTruthy();
+
+        rerender(
+            <PlayerInfoItem
+                player={playerInfo[FREE_AGENT_ID]}
+                playerInfo={playerInfo}
+                rosterInfo={rosterInfo}
+                lineupSet={new Set()}
+                addToRoster={vi.fn()}
+                searchData={{ ...searchDataFor(FREE_AGENT_ID), ranking: '20' }}
+                updatePlayerId={vi.fn()}
+                isNewRankList={false}
+                adpData={15}
+                myDisplayName={MY_DISPLAY_NAME}
+            />,
+        );
+        expect(screen.getByText('Ranked 5 picks after ADP')).toBeTruthy();
     });
 });

--- a/src/Components/playerInfoLabels.js
+++ b/src/Components/playerInfoLabels.js
@@ -1,0 +1,30 @@
+// The row's visible availability text: the manager's name when taken (the
+// "Taken" chip beside it already says the word "taken"), or "Free agent"
+// when not. Kept separate from the accessible name below - screen-reader
+// users don't have the chip's text to lean on, so the name spells the
+// relationship out ("taken by X") rather than assuming the chip's context.
+export const playerAvailabilityText = ({ taken, rosteredByName }) => (taken ? rosteredByName : 'Free agent');
+
+// "Bijan Robinson, RB, taken by kpresley" / "Marlin Klein, TE, free agent",
+// plus ", yours" and ", low confidence match" where they apply.
+//
+// Those last two are here because the row encodes them *only* as a border
+// colour - violet for yours, warn for a weak match. A colour-only encoding
+// says nothing to a screen reader, and it is also the one thing a test cannot
+// assert under this repo's no-className rule, so both problems have the same
+// fix: put the meaning in the name. Ownership reads "taken by ryangh · you",
+// keeping the manager's name and marking the whole attribution - the same
+// convention pickLabels.js uses for your own picks. Replacing the name with a
+// bare "you" would have dropped the identity that the league-switch
+// attribution test in App.test.jsx exists to prove.
+export const playerAccessibleName = ({ player, taken, rosteredByName, isMine = false, lowConfidenceMatch = false }) => {
+    let availability = 'free agent';
+    if (taken) {
+        availability = isMine ? `taken by ${rosteredByName} · you` : `taken by ${rosteredByName}`;
+    }
+    const nameParts = [player.full_name, player.position, availability];
+    if (lowConfidenceMatch) {
+        nameParts.push('low confidence match');
+    }
+    return nameParts.join(', ');
+};

--- a/src/Panels/SlotRow.jsx
+++ b/src/Panels/SlotRow.jsx
@@ -62,7 +62,11 @@ const SlotRow = ({ slot, index, playerInfo, onRemove }) => {
     if (!slot.playerId) {
         return (
             <li>
-                <div aria-label={accessibleName} className={`${rowClasses} border-line border-dashed`}>
+                {/* role="group" so the aria-label is actually exposed: on a
+                    bare div - role `generic` - most screen readers drop it,
+                    which would leave the name working in tests and nowhere
+                    else. The filled row below is a button and needs no role. */}
+                <div role="group" aria-label={accessibleName} className={`${rowClasses} border-line border-dashed`}>
                     {content}
                 </div>
             </li>

--- a/src/styles/legacy-css.test.js
+++ b/src/styles/legacy-css.test.js
@@ -39,9 +39,39 @@ const APP_CSS = resolve(process.cwd(), 'src/App.css');
 // media query) and `.lineup-position` are gone. `.abbr-text`, `.full-text`,
 // and `.avatar-player` stay - PlayerInfoItem still uses them and is not
 // part of this migration.
-const MAX_LINES = 324;
+//
+// 240 once PlayerInfoItem moved onto Tailwind: `.single-player-item`,
+// `.player-name`, `.player-info`, `.player-info-item`, the four
+// `-available` rules, `.available`, `.search-alert`, `.avatar-player` (both
+// the base rule and its phone media-query override), `.abbr-text` and
+// `.full-text` (both the base rules and the width-breakpoint media query)
+// and `.player-add-div`'s phone media query are all gone. `.QB`/`.RB`/
+// `.WR`/`.TE`, `.draft-pick-rows` (both the base rule and its `:hover`),
+// `.clickable-item:hover` and `.dropdown` stay - ManualPickModal and
+// Dropdown still use them and neither is part of this migration.
+const MAX_LINES = 240;
 
-const CONVERTED = ['error-banner', 'warning-banner', 'main-container', 'latest-update', '.title {'];
+const CONVERTED = [
+    'error-banner',
+    'warning-banner',
+    'main-container',
+    'latest-update',
+    '.title {',
+    '.single-player-item',
+    '.player-name',
+    '.player-info {',
+    '.player-info-item',
+    '.RB-available',
+    '.WR-available',
+    '.TE-available',
+    '.QB-available',
+    '.available {',
+    '.search-alert',
+    '.avatar-player',
+    '.abbr-text',
+    '.full-text',
+    '.player-add-div',
+];
 
 describe('App.css drain', () => {
     const css = readFileSync(APP_CSS, 'utf8');


### PR DESCRIPTION
Step 05, part 2 — the accessibility fix the redesign has been carrying since the start, plus the conversion that makes it possible.

## The problem

Availability was encoded as **transparency**: `.single-player-item` filled with a solid position colour when a player was **taken**, and `.QB-available`/`.RB-available`/etc. layered a `0.45`-alpha version when they were **available**. That put row text below AA, and it was backwards — the available players, the ones you actually act on, were the dimmed ones.

## The fix

Rows are now uniform, matching the pick feed and the lineup: transparent, `border-line`, position on a chip. Availability is carried by **text**, which the row already had.

| State | Encoding |
|---|---|
| Taken | Rostering manager's name + a neutral bordered `Taken` chip |
| Available | `Free agent`, no chip |
| On your roster | Violet border — the one thing violet is reserved for |
| Low-confidence match | The `warn` token, replacing the old red fill |

The last two also go into the **accessible name** (`taken by ryangh · you`, `low confidence match`). A colour-only encoding says nothing to a screen reader — and under this repo's no-`className` rule it was also unassertable, so both problems had the same fix. `· you` follows the convention `pickLabels.js` already set, keeping the manager's identity rather than replacing it with a bare "you".

Also gone: all 15 inline `style={{}}` objects, the `full-text`/`abbr-text` pair (a width-hiding mechanism that hid a real fallback once, in #116), and both `sleepercdn` avatars. The name is now a real `<button>` rather than a `<span>` with an `onClick`, so it is keyboard-reachable.

`App.css` **324 → 240**. `.QB`/`.RB`/`.WR`/`.TE`, `.draft-pick-rows`, `.clickable-item:hover` and `.dropdown` stay — `ManualPickModal` and `Dropdown` still use them and neither is in scope.

## Two regressions this change caused, both found in a browser

- **The Add button became invisible.** `player-add-button` inverted (`text-ground!`) and was legible *only* because the row behind it was filled with a position colour. Remove the fill and it measured **1.16:1**. It takes the base ink now. `primary-invert` had the same dependency and PlayerInfoItem was its only caller, so it is deleted rather than left as a trap.
- **The player name looked like a text input.** Preflight is off, so a `<button>` with no border utility keeps the UA's default outset border.

Neither is visible to jsdom, and neither would have been caught by any test.

While measuring, `Button`'s `alert` variant came in at **3.07:1** — light ink on the QB fill. It now uses dark ink like every position chip (5.0:1). Whether a destructive action should wear the QB *hue* at all is still the separate open question flagged in `Button.tsx`.

## Verification

Six gates green; tests **298 → 320**. No `container.querySelector`, `closest('.class')` or `className` assertion in any touched test file.

**14 sabotages, all 14 caught** — but three passed on the first run and each was a real gap, now closed: dropping the violet "yours" border, dropping the warn border, and rendering a hardcoded position in the chip all left the entire suite green.

**Browser-measured contrast** on the live app, walking up for the composited background rather than trusting token values: **25 text elements, zero below AA**, floor 4.99:1. Before this change the row text sat under the 0.45-alpha fill.

One a11y defect fixed in passing: these rows carried `aria-label` on a bare `<div>`, where role is `generic` and most screen readers drop the label — it existed for the tests and nobody else. They are `role="group"` now. `SlotRow`'s empty row had the same bug and is fixed here too.