### PR TITLE
Load Tailwind preflight and delete its workarounds

### DIFF
--- a/src/Components/AppBar.jsx
+++ b/src/Components/AppBar.jsx
@@ -8,7 +8,7 @@ const AppBar = ({ signedIn, signedInEmail, lastUpdate, onSignIn, onSignOut }) =>
     return (
         <>
             <div className="flex flex-row items-center justify-between px-[3px] py-0">
-                <h1 className="text-ink m-0 mb-1.5 ml-[3px] text-lg">Sleeper Team Assistant</h1>
+                <h1 className="text-ink mb-1.5 ml-[3px] text-lg font-bold">Sleeper Team Assistant</h1>
                 <AccountMenu
                     signedIn={signedIn}
                     signedInEmail={signedInEmail}

--- a/src/Components/AppShell.jsx
+++ b/src/Components/AppShell.jsx
@@ -41,7 +41,7 @@ const AppShell = ({ sections, renderSection, renderAside, leagueBar, defaultSect
                 </main>
                 <nav
                     aria-label="Sections"
-                    className="border-line bg-raised fixed inset-x-0 bottom-0 z-10 box-border flex h-[var(--tab-bar-h)] border-t border-solid md:static md:order-1 md:h-auto md:border-t-0 md:border-b md:border-solid"
+                    className="border-line bg-raised fixed inset-x-0 bottom-0 z-10 flex h-[var(--tab-bar-h)] border-t md:static md:order-1 md:h-auto md:border-t-0 md:border-b"
                 >
                     {sections.map((section) => {
                         const isActive = section.id === activeId;
@@ -51,11 +51,7 @@ const AppShell = ({ sections, renderSection, renderAside, leagueBar, defaultSect
                                 type="button"
                                 aria-current={isActive ? 'page' : undefined}
                                 onClick={() => goTo(section.id)}
-                                // `appearance-none bg-transparent` because preflight is not
-                                // loaded: without it a bare <button> keeps the UA's own
-                                // border, background and rounded corners, and every tab
-                                // renders as a grey box.
-                                className={`m-0 min-h-11 flex-1 cursor-pointer appearance-none rounded-none border-t-2 border-r-0 border-b-0 border-l-0 border-solid bg-transparent px-4 py-2 text-sm md:flex-none ${
+                                className={`min-h-11 flex-1 cursor-pointer border-t-2 px-4 py-2 text-sm md:flex-none ${
                                     isActive ? 'border-mine text-mine' : 'text-ink-muted border-transparent'
                                 }`}
                             >

--- a/src/Components/Button/Button.tsx
+++ b/src/Components/Button/Button.tsx
@@ -8,14 +8,12 @@ interface Props {
     isDisabled: boolean;
 }
 
-// Preflight is not loaded, so a bare <button> keeps the UA's own appearance,
-// border and rounded corners unless it is told otherwise here. The disabled
-// overrides carry `!` (Tailwind's important modifier) because the original
-// CSS used `!important` for the same reason: :disabled has to beat the
-// hover rules below it regardless of which one the cascade would otherwise
-// prefer.
+// The disabled overrides carry `!` (Tailwind's important modifier) because
+// Tailwind orders utilities by utility group rather than by class-string
+// order, so :disabled has to beat the hover rules below it regardless of
+// which one the cascade would otherwise prefer.
 const BASE =
-    'appearance-none bg-transparent text-ink border border-solid border-ink-muted rounded-[5px] min-w-max mb-[7px] hover:scale-[1.02] motion-reduce:hover:transform-none disabled:scale-100! disabled:border-line! disabled:text-line!';
+    'text-ink border border-ink-muted rounded-[5px] min-w-max mb-[7px] hover:scale-[1.02] motion-reduce:hover:transform-none disabled:scale-100! disabled:border-line! disabled:text-line!';
 
 // One entry per value `btnStyle` is called with at a call site today. Keyed
 // by the exact string (or, for the "variant plus modifier" form, by each

--- a/src/Components/Dropdown.jsx
+++ b/src/Components/Dropdown.jsx
@@ -1,7 +1,7 @@
 const Dropdown = ({ currentValue, updateCurrentValue, children: dropdownSelections }) => {
     return (
         <select
-            className="border-line text-ink caret-ink-muted mt-2 box-border h-[25px] w-[85%] appearance-none rounded-[10px] border-2 border-solid bg-transparent"
+            className="border-line text-ink caret-ink-muted mt-2 h-[25px] w-[85%] appearance-none rounded-[10px] border-2 bg-transparent"
             value={currentValue}
             onChange={(e) => updateCurrentValue(e.target.value)}
         >

--- a/src/Components/ErrorBanner.jsx
+++ b/src/Components/ErrorBanner.jsx
@@ -17,10 +17,9 @@ import Button from './Button';
 // margins are legacy geometry carried over verbatim to keep this change
 // invisible; they become scale values when the shell is rebuilt.
 //
-// The border style is set on the left edge specifically, not with `border-solid`.
-// Preflight is not loaded, so there is no global `border-style: none` for the
-// other three edges to fall back to: `border-solid` gave them the browser's
-// default medium width and made the banner 3px taller.
+// The border style is set on the left edge specifically, via an arbitrary
+// value, rather than with the `border-solid` utility, which applies to all
+// four sides.
 const BANNER =
     'mx-[3px] mt-2 mb-[3px] flex flex-row flex-wrap items-center justify-between gap-3 rounded-[10px] border-l-4 [border-left-style:solid] bg-raised px-[15px] py-3';
 

--- a/src/Components/LeagueBar.jsx
+++ b/src/Components/LeagueBar.jsx
@@ -6,7 +6,7 @@ import Dropdown from './Dropdown';
 // would break the moment two leagues shared one.
 const LeagueBar = ({ leagueName, leagueID, leagueIds, updateLeagueID }) => {
     return (
-        <div className="border-line bg-raised flex flex-row items-center gap-3 border-b border-solid px-4 py-2">
+        <div className="border-line bg-raised flex flex-row items-center gap-3 border-b px-4 py-2">
             <p className="m-0 font-bold">{leagueName}</p>
             {/* Dropdown still carries its own w-[85%] (converted from the old
                 `.dropdown` rule, not dropped), so it is boxed here rather than

--- a/src/Components/PickClock.jsx
+++ b/src/Components/PickClock.jsx
@@ -23,7 +23,7 @@ const PickClock = ({ draft }) => {
         return () => clearInterval(timer);
     }, [mode]);
 
-    const WRAPPER = 'border border-solid border-line rounded-[5px] bg-raised px-3 py-2';
+    const WRAPPER = 'border border-line rounded-[5px] bg-raised px-3 py-2';
 
     if (mode === 'not-started') {
         return (

--- a/src/Components/PlayerInfoItem.jsx
+++ b/src/Components/PlayerInfoItem.jsx
@@ -58,10 +58,7 @@ const PlayerInfoItem = ({
 
     return (
         // Uniform row geometry copied from PickRow/SlotRow: transparent
-        // background, `border-line` by default, `rounded-[5px]`. `box-border`
-        // matters here even though this is a single div (not a button/div
-        // pair) because Button.tsx's own buttons sit inside this row - see
-        // SlotRow's comment on the same property.
+        // background, `border-line` by default, `rounded-[5px]`.
         //
         // Border precedence: `isMine` (violet, "yours") outranks a
         // low-confidence match (warn) outranks the default line colour - a
@@ -74,7 +71,7 @@ const PlayerInfoItem = ({
         <div
             role="group"
             aria-label={accessibleName}
-            className={`m-0 box-border flex w-full items-start gap-3 rounded-[5px] border border-solid bg-transparent px-3 py-2 ${
+            className={`m-0 flex w-full items-start gap-3 rounded-[5px] border bg-transparent px-3 py-2 ${
                 isMine ? 'border-mine!' : lowConfidenceMatch ? 'border-warn!' : 'border-line'
             }`}
         >
@@ -84,7 +81,7 @@ const PlayerInfoItem = ({
                         <select
                             value={player.player_id}
                             onChange={(e) => updatePlayerInfo(e.target.value)}
-                            className="border-line text-ink box-border w-full appearance-none rounded-[5px] border border-solid bg-transparent px-2 py-1 text-sm"
+                            className="border-line text-ink w-full appearance-none rounded-[5px] border bg-transparent px-2 py-1 text-sm"
                         >
                             {searchData.match_results.map((result) => (
                                 <option key={result[0]} value={result[0]}>{`${playerInfo[result[0]].full_name} - ${
@@ -106,7 +103,7 @@ const PlayerInfoItem = ({
                                     type="text"
                                     onChange={(e) => setSearchValue(e.target.value)}
                                     placeholder="Manually update player"
-                                    className="border-line text-ink box-border w-full rounded-[5px] border border-solid bg-transparent px-2 py-1 text-sm"
+                                    className="border-line text-ink w-full rounded-[5px] border bg-transparent px-2 py-1 text-sm"
                                 />
                                 {searchValue.length > 2 && (
                                     <div className="flex max-h-[100px] flex-col gap-1 overflow-y-scroll">
@@ -125,7 +122,7 @@ const PlayerInfoItem = ({
                                                     type="button"
                                                     key={candidate.player_id}
                                                     onClick={() => updatePlayerInfo(candidate.player_id)}
-                                                    className="border-line text-ink hover:border-ink-muted box-border flex w-full appearance-none items-center gap-2 rounded-[4px] border border-solid bg-transparent px-2 py-1 text-left text-sm"
+                                                    className="border-line text-ink hover:border-ink-muted flex w-full items-center gap-2 rounded-[4px] border px-2 py-1 text-left text-sm"
                                                 >
                                                     <span className="min-w-0 flex-1 truncate">
                                                         {candidate.full_name}
@@ -155,10 +152,7 @@ const PlayerInfoItem = ({
                         // full-text/abbr-text pair, a width-hiding mechanism
                         // whose hidden fallback shipped a real defect once
                         // (PR #116).
-                        // `border-0` is required, not cosmetic: preflight is off, so a
-                        // bare <button> keeps the UA's default outset border and
-                        // this name rendered looking like a text input.
-                        className="text-ink box-border w-full appearance-none truncate border-0 bg-transparent p-0 text-left text-sm font-semibold hover:underline"
+                        className="text-ink w-full truncate text-left text-sm font-semibold hover:underline"
                     >
                         {player.full_name}
                     </button>
@@ -187,7 +181,7 @@ const PlayerInfoItem = ({
                     chip's text plus the manager-name/"free agent" line above,
                     not by tinting the row. */}
                 {taken && (
-                    <span className="border-line text-ink-muted shrink-0 rounded-[4px] border border-solid px-1.5 py-0.5 text-xs font-semibold">
+                    <span className="border-line text-ink-muted shrink-0 rounded-[4px] border px-1.5 py-0.5 text-xs font-semibold">
                         Taken
                     </span>
                 )}

--- a/src/Components/SearchFilterButton.jsx
+++ b/src/Components/SearchFilterButton.jsx
@@ -7,7 +7,7 @@
 const SearchFilterButton = ({ checked, handleChange, labelName, name }) => {
     return (
         <label
-            className={`border-ink-muted relative m-[3px] inline-block cursor-pointer rounded-[22px] border border-solid p-1.5 text-center text-sm ${
+            className={`border-ink-muted relative m-[3px] inline-block cursor-pointer rounded-[22px] border p-1.5 text-center text-sm ${
                 checked ? 'bg-line! text-ink! font-semibold' : 'text-ink-muted'
             }`}
         >

--- a/src/Components/SegmentedControl.jsx
+++ b/src/Components/SegmentedControl.jsx
@@ -2,11 +2,7 @@
 // toggle in DraftPanel and the Overview/Readable zoom switch in DraftGrid -
 // pulled out here rather than written twice so the two don't drift apart.
 const SegmentedControl = ({ label, options, value, onChange }) => (
-    <div
-        role="group"
-        aria-label={label}
-        className="border-line m-0 inline-flex gap-0.5 rounded-[6px] border border-solid p-0.5"
-    >
+    <div role="group" aria-label={label} className="border-line m-0 inline-flex gap-0.5 rounded-[6px] border p-0.5">
         {options.map((option) => (
             <button
                 key={option.value}
@@ -17,10 +13,10 @@ const SegmentedControl = ({ label, options, value, onChange }) => (
                 // is reserved for "yours" - your picks, your slots, your turn - so
                 // a filled violet segment would say this view belongs to you.
                 // Same rule that took the old teal fill off the filter chips.
-                className={`m-0 min-h-11 appearance-none rounded-[4px] px-3 py-1 text-sm ${
+                className={`min-h-11 rounded-[4px] px-3 py-1 text-sm ${
                     value === option.value
-                        ? 'border-ink-muted! bg-line! text-ink! border border-solid font-semibold'
-                        : 'text-ink-muted border-0 bg-transparent'
+                        ? 'border-ink-muted! bg-line! text-ink! border font-semibold'
+                        : 'text-ink-muted'
                 }`}
             >
                 {option.label}

--- a/src/Components/Spinner.jsx
+++ b/src/Components/Spinner.jsx
@@ -27,7 +27,7 @@ const Spinner = ({ size = 'panel' }) => {
             <div
                 role="progressbar"
                 aria-label={label}
-                className={`${ring} border-line border-t-ink animate-spin rounded-full border-solid motion-reduce:animate-none`}
+                className={`${ring} border-line border-t-ink animate-spin rounded-full motion-reduce:animate-none`}
             />
         </div>
     );

--- a/src/Panels/BestAvailableSheet.jsx
+++ b/src/Panels/BestAvailableSheet.jsx
@@ -16,7 +16,7 @@ import { positionClass } from './pickLabels.js';
 const playerId = (entry) => entry.match_results[0][0];
 
 const sheetClasses =
-    'border-line bg-raised fixed inset-x-0 bottom-[var(--tab-bar-h)] z-10 flex flex-col border-t border-solid md:hidden';
+    'border-line bg-raised fixed inset-x-0 bottom-[var(--tab-bar-h)] z-10 flex flex-col border-t md:hidden';
 
 const BestAvailableSheet = ({ rankingPlayersIdsList, playerInfo, rosterInfo }) => {
     const [isExpanded, setIsExpanded] = useState(false);
@@ -43,14 +43,14 @@ const BestAvailableSheet = ({ rankingPlayersIdsList, playerInfo, rosterInfo }) =
                 type="button"
                 aria-expanded={isExpanded}
                 onClick={() => setIsExpanded((expanded) => !expanded)}
-                className="m-0 flex min-h-11 w-full appearance-none items-center justify-between rounded-none border-0 bg-transparent px-4 py-2"
+                className="flex min-h-11 w-full items-center justify-between px-4 py-2"
             >
                 <span className="text-ink text-sm font-semibold">Best available</span>
                 <span className="text-ink-muted text-sm">{available.length} left</span>
             </button>
             {isExpanded && (
                 <div className="max-h-[45vh] overflow-y-auto px-4 pb-4">
-                    <ul className="m-0 flex list-none flex-col gap-1 p-0">
+                    <ul className="flex flex-col gap-1">
                         {available.map((entry) => {
                             const id = playerId(entry);
                             const player = playerInfo[id];

--- a/src/Panels/DraftGrid.jsx
+++ b/src/Panels/DraftGrid.jsx
@@ -43,8 +43,8 @@ const GridCell = ({ round, pick, playerInfo, rosterData, myDisplayName, zoom, on
     // it); an unmade one stays a dashed, unfilled cell so the two can never be
     // confused for one another, even at a glance in overview mode.
     const stateClasses = isMade
-        ? `border-0 text-ground ${positionClass(player?.position)}`
-        : 'border border-dashed border-line bg-transparent text-ink-muted';
+        ? `text-ground ${positionClass(player?.position)}`
+        : 'border border-dashed border-line text-ink-muted';
 
     // Violet marks "yours" as an outline, not a fill, so the position colour
     // underneath a made pick still shows through. `!` because outline and
@@ -53,12 +53,12 @@ const GridCell = ({ round, pick, playerInfo, rosterData, myDisplayName, zoom, on
     const mineClasses = isMine ? 'outline! outline-2! outline-mine! outline-offset-[-2px]!' : '';
 
     return (
-        <td className="box-border p-0">
+        <td className="p-0">
             <button
                 type="button"
                 aria-label={accessibleName}
                 onClick={onSelect}
-                className={`m-0 flex h-[var(--cell-h)] w-[var(--cell-w)] appearance-none flex-col items-center justify-center overflow-hidden rounded-none p-0.5 text-[10px] leading-tight ${stateClasses} ${mineClasses}`}
+                className={`flex h-[var(--cell-h)] w-[var(--cell-w)] flex-col items-center justify-center overflow-hidden p-0.5 text-[10px] leading-tight ${stateClasses} ${mineClasses}`}
             >
                 {/* Overview is position colour only, no text at all - that is
                     the whole point of the zoom level, so nothing renders here
@@ -117,9 +117,8 @@ const DraftGrid = ({
     };
 
     const headerCellClasses =
-        'border-line bg-ground text-ink sticky top-0 z-10 box-border border border-solid p-1 text-xs font-semibold truncate';
-    const gutterCellClasses =
-        'border-line bg-ground text-ink sticky left-0 z-10 box-border w-10 border border-solid p-1 text-xs font-semibold';
+        'border-line bg-ground text-ink sticky top-0 z-10 border p-1 text-xs font-semibold truncate';
+    const gutterCellClasses = 'border-line bg-ground text-ink sticky left-0 z-10 w-10 border p-1 text-xs font-semibold';
 
     return (
         <div>
@@ -181,7 +180,7 @@ const DraftGrid = ({
                                         return (
                                             <td
                                                 key={team.boardSpot}
-                                                className="border-line box-border h-[var(--cell-h)] w-[var(--cell-w)] border border-solid"
+                                                className="border-line h-[var(--cell-h)] w-[var(--cell-w)] border"
                                             />
                                         );
                                     }

--- a/src/Panels/DraftPanel.jsx
+++ b/src/Panels/DraftPanel.jsx
@@ -131,7 +131,7 @@ const DraftPanel = ({ leagueData, playerInfo, rosterInfo, rankingPlayersIdsList,
                 </p>
                 <input
                     type="text"
-                    className="border-line text-ink caret-ink-muted m-0 box-border rounded-[10px] border-2 border-solid bg-transparent"
+                    className="border-line text-ink caret-ink-muted m-0 rounded-[10px] border-2 bg-transparent"
                     value={currentDraftId}
                     onChange={(e) => updateDraftID(e.target.value)}
                 />

--- a/src/Panels/LineupPanel.jsx
+++ b/src/Panels/LineupPanel.jsx
@@ -5,13 +5,13 @@ const LineupPanel = ({ playerInfo, rosterSlots, removeFromLineup }) => {
 
     return (
         <div>
-            <h4 className="border-line bg-ground sticky top-0 z-10 m-0 flex items-center justify-between border-b border-solid px-3 py-2 text-sm font-semibold">
+            <h4 className="border-line bg-ground sticky top-0 z-10 flex items-center justify-between border-b px-3 py-2 text-sm font-semibold">
                 <span>Starters</span>
                 {/* Omitted entirely at zero rather than reading "0 empty" -
                     a full lineup has nothing to draw attention to. */}
                 {emptyCount > 0 && <span className="text-ink-muted font-normal">{emptyCount} empty</span>}
             </h4>
-            <ul className="m-0 flex list-none flex-col gap-1 p-0 py-1">
+            <ul className="flex flex-col gap-1 py-1">
                 {rosterSlots.map((slot, i) => (
                     <SlotRow
                         key={`${slot.label}-${i}`}

--- a/src/Panels/ManualPickModal.jsx
+++ b/src/Panels/ManualPickModal.jsx
@@ -25,7 +25,7 @@ const ManualPickModal = ({
     // player" search results, not reinvented: both are the same shape, a
     // scrollable list of players to pick one of, ending in a position chip.
     const candidateRowClasses =
-        'border-line text-ink hover:border-ink-muted box-border flex w-full appearance-none items-center gap-2 rounded-[4px] border border-solid bg-transparent px-2 py-1 text-left text-sm';
+        'border-line text-ink hover:border-ink-muted flex w-full items-center gap-2 rounded-[4px] border px-2 py-1 text-left text-sm';
 
     // `keySuffix` mirrors the old per-item key here (`player_id + i`): the
     // ranked-list branch below has no guarantee a pasted rank list doesn't
@@ -64,15 +64,15 @@ const ManualPickModal = ({
             // sheet on phones now - the pattern BestAvailableSheet already
             // established, sitting clear of the tab bar via `--tab-bar-h` -
             // and a centred panel from `md` up.
-            className="border-line bg-raised fixed inset-x-0 bottom-[var(--tab-bar-h)] z-[999] flex max-h-[70vh] flex-col gap-2 rounded-t-[10px] border-t border-solid p-3 md:inset-x-auto md:top-1/2 md:bottom-auto md:left-1/2 md:w-[420px] md:max-w-[calc(100vw-2rem)] md:-translate-x-1/2 md:-translate-y-1/2 md:rounded-[10px] md:border md:border-solid"
+            className="border-line bg-raised fixed inset-x-0 bottom-[var(--tab-bar-h)] z-[999] flex max-h-[70vh] flex-col gap-2 rounded-t-[10px] border-t p-3 md:inset-x-auto md:top-1/2 md:bottom-auto md:left-1/2 md:w-[420px] md:max-w-[calc(100vw-2rem)] md:-translate-x-1/2 md:-translate-y-1/2 md:rounded-[10px] md:border"
         >
             <div className="flex flex-col gap-2">
-                <h4 id={HEADING_ID} className="text-ink m-0 text-sm font-semibold">
+                <h4 id={HEADING_ID} className="text-ink text-sm font-semibold">
                     Manually select pick {`${round.round}.${currentManualPick.pick_number}`}
                 </h4>
                 <input
                     type="text"
-                    className="border-line text-ink caret-ink-muted m-0 box-border w-full rounded-[5px] border border-solid bg-transparent px-2 py-1 text-sm"
+                    className="border-line text-ink caret-ink-muted m-0 w-full rounded-[5px] border bg-transparent px-2 py-1 text-sm"
                     onChange={(e) => setSearchValue(e.target.value)}
                     placeholder="Start typing player name to search"
                 />

--- a/src/Panels/PickRow.jsx
+++ b/src/Panels/PickRow.jsx
@@ -22,7 +22,7 @@ const PickRow = ({ round, pick, playerInfo, rosterData, myDisplayName, onSelect,
                 type="button"
                 aria-label={accessibleName}
                 onClick={() => onSelect(pick)}
-                className={`m-0 flex min-h-11 w-full appearance-none items-center gap-3 rounded-[5px] border border-solid bg-transparent px-3 py-2 text-left ${
+                className={`flex min-h-11 w-full items-center gap-3 rounded-[5px] border px-3 py-2 text-left ${
                     isMine ? 'border-mine! bg-mine/10!' : 'border-line'
                 }`}
             >

--- a/src/Panels/RanksPanel.jsx
+++ b/src/Panels/RanksPanel.jsx
@@ -362,7 +362,7 @@ const RanksPanel = ({
                                         <input
                                             type="text"
                                             placeholder="Enter new list name..."
-                                            className="border-line text-ink caret-ink-muted m-0 box-border rounded-[10px] border-2 border-solid bg-transparent"
+                                            className="border-line text-ink caret-ink-muted m-0 rounded-[10px] border-2 bg-transparent"
                                             value={newRankListName}
                                             onChange={(e) => setNewRankListName(e.target.value)}
                                         />
@@ -377,7 +377,7 @@ const RanksPanel = ({
                                 {!isNewRankList && (
                                     <>
                                         <textarea
-                                            className="border-line text-ink caret-ink-muted mt-2 mr-[3px] box-border h-[100px] w-[85%] rounded-[10px] border-2 border-solid bg-transparent"
+                                            className="border-line text-ink caret-ink-muted mt-2 mr-[3px] h-[100px] w-[85%] rounded-[10px] border-2 bg-transparent"
                                             placeholder="Copy + Paste rankings here..."
                                             value={searchText}
                                             onChange={(e) => setSearchText(e.target.value)}

--- a/src/Panels/RoundSection.jsx
+++ b/src/Panels/RoundSection.jsx
@@ -12,12 +12,12 @@ const RoundSection = ({ round, playerInfo, rosterData, myDisplayName, onOpenPick
                 click handler on the heading itself: collapsing a round is
                 reachable from the keyboard, and aria-expanded says which way
                 it currently is. */}
-            <h4 className="border-line bg-ground sticky top-0 z-10 m-0 border-b border-solid text-sm font-semibold">
+            <h4 className="border-line bg-ground sticky top-0 z-10 border-b text-sm font-semibold">
                 <button
                     type="button"
                     aria-expanded={showRound}
                     onClick={() => setShowRound((prev) => !prev)}
-                    className="text-ink m-0 flex w-full cursor-pointer appearance-none items-center gap-2 rounded-none border-0 bg-transparent px-3 py-2 text-left text-sm font-semibold"
+                    className="text-ink flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-left text-sm font-semibold"
                 >
                     {/* Kept as its own element, not concatenated into the
                         "N new" chip's text, so screen.getByText('Round 1')
@@ -32,7 +32,7 @@ const RoundSection = ({ round, playerInfo, rosterData, myDisplayName, onOpenPick
                 </button>
             </h4>
             {showRound && (
-                <ol aria-label={`Round ${round.round}`} className="m-0 flex list-none flex-col gap-1 p-0 py-1">
+                <ol aria-label={`Round ${round.round}`} className="flex flex-col gap-1 py-1">
                     {round.picks.map((pick) => (
                         <PickRow
                             key={pick.pick_number}

--- a/src/Panels/SlotRow.jsx
+++ b/src/Panels/SlotRow.jsx
@@ -16,19 +16,12 @@ const SlotRow = ({ slot, index, playerInfo, onRemove }) => {
     const accessibleName = slotAccessibleName({ slot, player });
 
     // Shared classes for the row geometry - copied from PickRow rather than
-    // reinvented, because Tailwind orders utilities by group, not by
-    // class-string order: a base border-solid here would beat a later
-    // border-dashed if both were left in the same string.
-    // `box-border` is load-bearing, not tidiness. Preflight is not loaded, so
-    // a <button> keeps the UA's border-box while a <div> stays content-box -
-    // and a filled slot is a button while an empty one is a div. Measured in a
-    // browser, that alone made empty rows 62px against a filled row's 54, so
-    // the list jogged 8px at every gap. min-h-14 rather than min-h-11 because
-    // the filled row's two stacked lines already exceed 44px: with both rows
-    // border-box the floor is what makes them agree instead of merely being
-    // above the 44px touch minimum.
+    // reinvented. min-h-14 rather than min-h-11 because the filled row's two
+    // stacked lines already exceed 44px: the floor is what makes an empty and
+    // a filled row agree on height instead of merely both clearing the 44px
+    // touch minimum.
     const rowClasses =
-        'm-0 box-border flex min-h-14 w-full items-center gap-3 rounded-[5px] border bg-transparent px-3 py-2 text-left';
+        'm-0 flex min-h-14 w-full items-center gap-3 rounded-[5px] border bg-transparent px-3 py-2 text-left';
 
     const content = (
         <>
@@ -79,7 +72,7 @@ const SlotRow = ({ slot, index, playerInfo, onRemove }) => {
                 type="button"
                 aria-label={accessibleName}
                 onClick={() => onRemove(index)}
-                className={`${rowClasses} border-line appearance-none border-solid`}
+                className={`${rowClasses} border-line`}
             >
                 {content}
             </button>

--- a/src/index.css
+++ b/src/index.css
@@ -1,52 +1,23 @@
 /*
- * Element defaults live in the base layer so that Tailwind utilities, which sit
- * in the utilities layer, can override them. Unlayered CSS outranks every
- * cascade layer regardless of specificity, so while these rules were unlayered
- * a `p { margin-right: 7px }` here beat an `m-0` on the element itself.
+ * Element defaults now come from Tailwind's preflight layer. This file only
+ * holds what preflight doesn't cover: the app's background/text colors and
+ * font stack, and the one mobile fix (16px form control text to stop iOS
+ * from zooming in on focus).
  */
 @layer base {
     body {
-        margin: 0;
-        padding: 10px;
-        font-family:
-            -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans',
-            'Droid Sans', 'Helvetica Neue', sans-serif;
-        -webkit-font-smoothing: antialiased;
-        -moz-osx-font-smoothing: grayscale;
         background-color: #0f1720;
         color: #e8edf2;
         font-family: 'Lato', Arial, Helvetica, sans-serif;
-        min-height: 500px;
-    }
-
-    html {
-        padding: 3px;
-        overflow: visible;
-    }
-
-    code {
-        font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
-    }
-
-    p {
-        margin: 0;
-        margin-right: 7px;
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
     }
 
     @media screen and (max-width: 767px) {
         input,
         select,
         textarea {
-            font-size: 16px !important;
-            width: 85% !important;
-        }
-
-        .main_container {
-            width: 400px;
-        }
-
-        body {
-            padding: 3px !important;
+            font-size: 16px;
         }
     }
 }

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -1,20 +1,9 @@
 /*
  * Design tokens for the UI redesign.
- *
- * Preflight is deliberately not imported. A bare `@import 'tailwindcss'` would
- * pull it in, and its resets to buttons, headings and margins are exactly what
- * the surviving App.css rules still assume - so it would break the one thing
- * this step has to prove, which is that the substrate can be installed without
- * changing a pixel. It comes back in its own PR once App.css is at zero.
- *
- * Layer order matters more than usual here. Utilities live in `layer(utilities)`
- * and unlayered CSS outranks every cascade layer regardless of specificity, so
- * while App.css remains unlayered its rules still win over utilities. That is
- * intended during the migration: a component is either fully converted, with its
- * App.css rules deleted in the same change, or left alone. Never both.
  */
 @layer theme, base, components, utilities;
 @import 'tailwindcss/theme.css' layer(theme);
+@import 'tailwindcss/preflight.css' layer(base);
 @import 'tailwindcss/utilities.css' layer(utilities);
 
 /*


### PR DESCRIPTION
First step of the redesign handoff: preflight goes in, and every class that only existed to compensate for its absence comes out.

`@import 'tailwindcss/preflight.css' layer(base)` sits between the theme and utilities imports. Then:

- every `box-border` (border-box is global now)
- every `border-solid` (`* { border: 0 solid }` — a bare `border` is already solid)
- `appearance-none` / `bg-transparent` / `rounded-none` / `border-0` / `m-0` / `p-0` on `<button>`s
- `m-0` on headings, `list-none m-0 p-0` on lists
- `index.css` 52 → 19 lines: the 3px html padding, 10px body padding, `p { margin-right: 7px }`, the 85% `!important` widths and the dead `.main_container` rule are all either off the redesign's spacing scale or supplied by preflight

Kept on purpose: `appearance-none` on the two `<select>`s (native arrow, not a UA default), every `!` in `Button.tsx` (Tailwind orders utilities by group, not class-string order — preflight doesn't change that), and the mobile `font-size: 16px` that stops iOS zooming on focus, now without `!important`.

Preflight took one thing that was doing real work — the h1's UA weight — so `AppBar` declares `font-bold` explicitly.

Comments across ~20 files that asserted "preflight is not loaded" are now false and were rewritten or deleted.

Verified in the browser at 375 and 1280: structure unchanged, no horizontal overflow, no console errors. All six gates green; 304 tests unchanged.