### PR TITLE
Build ListRow and PositionTag, and convert the three row types

### DIFF
--- a/src/Components/ListRow.jsx
+++ b/src/Components/ListRow.jsx
@@ -1,0 +1,106 @@
+// The shared list row: transparent on ground, no border, no card - the
+// blockiness the redesign removes. Three call sites (PickRow, SlotRow,
+// PlayerInfoItem's display state) all render this same shape with different
+// content, so the geometry lives here once.
+//
+// `as="div"` rows carry role="group" so the aria-label is actually exposed -
+// on a bare div (role `generic`) most screen readers drop it, which would
+// leave the name working in tests and nowhere else.
+const NAME_TONE = {
+    default: 'text-ink',
+    muted: 'text-ink-muted',
+    dim: 'text-ink-dim',
+};
+
+const FLAG_TONE = {
+    mine: 'text-mine',
+    live: 'text-live',
+};
+
+const ROW_TONE = {
+    mine: 'bg-mine-row',
+    empty: 'bg-empty',
+};
+
+const DOT_TONE = {
+    warn: 'bg-warn',
+};
+
+const ListRow = ({
+    as = 'button',
+    label,
+    onClick,
+    disabled = false,
+    ordinal,
+    ordinalWidth,
+    // The base treatment matches PickRow's pick number (mono 12px,
+    // text-ink-dim). SlotRow's slot label and PlayerInfoItem's rank numeral
+    // each use a distinct size/weight/tracking/colour and a right-aligned
+    // column, so they pass their own override here rather than ListRow
+    // hardcoding one typography for every caller.
+    ordinalClassName = 'text-[12px] text-ink-dim',
+    name,
+    nameTone = 'default',
+    flag,
+    leadingDot,
+    meta,
+    tone,
+    trailing,
+}) => {
+    // The design's row heights are 46px single-line and 56px two-line, and
+    // both fall out of this once the line-heights are pinned: preflight puts
+    // `line-height: 1.5` on the root, which made a 15px name 22.5px and an
+    // 11px meta 16.5px and the two-line row 61px. `leading-5` + `leading-[14px]`
+    // give 11 + 20 + 14 + 11 = 56. A single-line row is then 42, which is both
+    // under the design's 46 and under the 44px touch minimum, so the floor
+    // brings it back up - it is doing real work, not tidiness.
+    const geometry = `flex min-h-[46px] w-full items-center gap-3 rounded-row px-2.5 py-[11px] text-left ${tone ? ROW_TONE[tone] : ''}`;
+
+    const content = (
+        <>
+            {ordinal !== undefined && (
+                <span
+                    className={`shrink-0 font-mono tabular-nums ${ordinalClassName}`}
+                    style={ordinalWidth ? { width: ordinalWidth } : undefined}
+                >
+                    {ordinal}
+                </span>
+            )}
+            <span className="flex min-w-0 flex-1 flex-col">
+                <span className="flex min-w-0 items-center gap-2">
+                    {leadingDot && <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${DOT_TONE[leadingDot]}`} />}
+                    <span
+                        className={`min-w-0 truncate font-sans text-[15px] leading-5 font-semibold tracking-[-0.01em] ${NAME_TONE[nameTone]}`}
+                    >
+                        {name}
+                    </span>
+                    {flag && (
+                        <span
+                            className={`shrink-0 font-mono text-[9px] font-semibold tracking-[.1em] ${FLAG_TONE[flag.tone]}`}
+                        >
+                            {flag.text}
+                        </span>
+                    )}
+                </span>
+                {meta && <span className="text-ink-dim truncate font-mono text-[11px] leading-[14px]">{meta}</span>}
+            </span>
+            {trailing && <span className="flex shrink-0 items-center gap-2">{trailing}</span>}
+        </>
+    );
+
+    if (as === 'div') {
+        return (
+            <div role="group" aria-label={label} className={geometry}>
+                {content}
+            </div>
+        );
+    }
+
+    return (
+        <button type="button" aria-label={label} onClick={onClick} disabled={disabled} className={geometry}>
+            {content}
+        </button>
+    );
+};
+
+export default ListRow;

--- a/src/Components/PlayerInfoItem.jsx
+++ b/src/Components/PlayerInfoItem.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import Button from './Button';
-import { positionClass } from '../Panels/pickLabels.js';
+import ListRow from './ListRow';
+import PositionTag from './PositionTag';
 import { playerAccessibleName, playerAvailabilityText } from './playerInfoLabels.js';
 import { isInLineup, isTaken, rosteredBy } from '../lib/rosterInfo.js';
 
@@ -56,27 +57,20 @@ const PlayerInfoItem = ({
               ? 'Rank matches ADP'
               : `Ranked ${rankedDiff} picks after ADP`;
 
-    return (
-        // Uniform row geometry copied from PickRow/SlotRow: transparent
-        // background, `border-line` by default, `rounded-[5px]`.
-        //
-        // Border precedence: `isMine` (violet, "yours") outranks a
-        // low-confidence match (warn) outranks the default line colour - a
-        // player can be both mine and a weak match, and violet is reserved
-        // for "yours" so it wins the one available border colour.
-        // `role="group"` is what makes the aria-label real. On a bare div -
-        // role `generic` - an aria-label is ignored by most screen readers, so
-        // the name would exist for the tests and for nobody else. The row is a
-        // composite of controls, which is what group is for.
-        <div
-            role="group"
-            aria-label={accessibleName}
-            className={`m-0 flex w-full items-start gap-3 rounded-[5px] border bg-transparent px-3 py-2 ${
-                isMine ? 'border-mine!' : lowConfidenceMatch ? 'border-warn!' : 'border-line'
-            }`}
-        >
-            <div className="flex min-w-0 flex-1 flex-col gap-1">
-                {editingPlayer ? (
+    // Editing branch is left exactly as it was before this redesign pass -
+    // only its two position badges swap to the shared PositionTag. The
+    // display (non-editing) branch below is the one this step converts onto
+    // ListRow; the Ranks controls stack that surrounds both is a later step.
+    if (editingPlayer) {
+        return (
+            <div
+                role="group"
+                aria-label={accessibleName}
+                className={`m-0 flex w-full items-start gap-3 rounded-[5px] border bg-transparent px-3 py-2 ${
+                    isMine ? 'border-mine!' : lowConfidenceMatch ? 'border-warn!' : 'border-line'
+                }`}
+            >
+                <div className="flex min-w-0 flex-1 flex-col gap-1">
                     <div className="flex flex-col gap-2">
                         <select
                             value={player.player_id}
@@ -127,11 +121,7 @@ const PlayerInfoItem = ({
                                                     <span className="min-w-0 flex-1 truncate">
                                                         {candidate.full_name}
                                                     </span>
-                                                    <span
-                                                        className={`shrink-0 rounded-[4px] px-1.5 py-0.5 text-xs font-semibold ${positionClass(candidate.position)}`}
-                                                    >
-                                                        {candidate.position}
-                                                    </span>
+                                                    <PositionTag position={candidate.position} />
                                                     {candidate.team && (
                                                         <span className="text-ink-muted shrink-0 text-xs">
                                                             {candidate.team}
@@ -144,57 +134,111 @@ const PlayerInfoItem = ({
                             </div>
                         )}
                     </div>
-                ) : (
-                    <button
-                        type="button"
-                        onClick={() => setEditingPlayer(true)}
-                        // A single always-visible name replaces the old
-                        // full-text/abbr-text pair, a width-hiding mechanism
-                        // whose hidden fallback shipped a real defect once
-                        // (PR #116).
-                        className="text-ink w-full truncate text-left text-sm font-semibold hover:underline"
-                    >
-                        {player.full_name}
-                    </button>
-                )}
-                <div className="text-ink-muted flex flex-wrap items-center gap-x-2 text-xs">
-                    <span>Rank: {searchData.ranking}</span>
-                    <span>{player.team ? player.team : 'FA'}</span>
-                    <span>{playerAvailabilityText({ taken, rosteredByName })}</span>
-                </div>
-                {adpData && (
-                    <div className="text-ink-muted flex items-center gap-2 text-xs">
-                        <span>ADP: {adpData}</span>
-                        <span>{adpLabel}</span>
+                    <div className="text-ink-muted flex flex-wrap items-center gap-x-2 text-xs">
+                        <span>Rank: {searchData.ranking}</span>
+                        <span>{player.team ? player.team : 'FA'}</span>
+                        <span>{playerAvailabilityText({ taken, rosteredByName })}</span>
                     </div>
-                )}
+                    {adpData && (
+                        <div className="text-ink-muted flex items-center gap-2 text-xs">
+                            <span>ADP: {adpData}</span>
+                            <span>{adpLabel}</span>
+                        </div>
+                    )}
+                </div>
+                <div className="flex shrink-0 flex-col items-end gap-1">
+                    <PositionTag position={player.position} />
+                    {/* Neutral, not a colour fill: saturation is reserved for
+                        position data and violet for "yours", so availability -
+                        the thing this row most needs to say - is carried by this
+                        chip's text plus the manager-name/"free agent" line above,
+                        not by tinting the row. */}
+                    {taken && (
+                        <span className="border-line text-ink-muted shrink-0 rounded-[4px] border px-1.5 py-0.5 text-xs font-semibold">
+                            Taken
+                        </span>
+                    )}
+                    {(!taken || isMine) && (
+                        <Button
+                            text={`${inLineup ? 'Added' : 'Add'}`}
+                            isDisabled={inLineup}
+                            btnStyle="player-add-button"
+                            onClick={() => addToRoster(player)}
+                        />
+                    )}
+                </div>
             </div>
-            <div className="flex shrink-0 flex-col items-end gap-1">
-                <span
-                    className={`shrink-0 rounded-[4px] px-1.5 py-0.5 text-xs font-semibold ${positionClass(player.position)}`}
+        );
+    }
+
+    // The ADP delta replaces the old two-line "ADP: 3.1" / "Ranked N picks
+    // before ADP" prose. Sign convention: negative (ranked ahead of ADP) is
+    // `text-live`, positive (ranked behind ADP) is `text-warn`, zero is
+    // `text-ink-dim`. Omitted entirely when there is no ADP data.
+    const adpDeltaTone = rankedDiff < 0 ? 'text-live' : rankedDiff > 0 ? 'text-warn' : 'text-ink-dim';
+    const adpDeltaText = rankedDiff > 0 ? `+${rankedDiff}` : `${rankedDiff}`;
+
+    return (
+        <ListRow
+            as="div"
+            label={accessibleName}
+            ordinal={searchData.ranking}
+            ordinalWidth="22px"
+            ordinalClassName="text-right text-[12px] font-medium text-ink-muted"
+            // A single always-visible name replaces the old full-text/abbr-text
+            // pair, a width-hiding mechanism whose hidden fallback shipped a
+            // real defect once (PR #116). It stays a nested button so clicking
+            // the name opens the edit form, same as before.
+            name={
+                <button
+                    type="button"
+                    onClick={() => setEditingPlayer(true)}
+                    className="min-w-0 truncate text-left hover:underline"
                 >
-                    {player.position}
-                </span>
-                {/* Neutral, not a colour fill: saturation is reserved for
-                    position data and violet for "yours", so availability -
-                    the thing this row most needs to say - is carried by this
-                    chip's text plus the manager-name/"free agent" line above,
-                    not by tinting the row. */}
-                {taken && (
-                    <span className="border-line text-ink-muted shrink-0 rounded-[4px] border px-1.5 py-0.5 text-xs font-semibold">
-                        Taken
-                    </span>
-                )}
-                {(!taken || isMine) && (
-                    <Button
-                        text={`${inLineup ? 'Added' : 'Add'}`}
-                        isDisabled={inLineup}
-                        btnStyle="player-add-button"
-                        onClick={() => addToRoster(player)}
-                    />
-                )}
-            </div>
-        </div>
+                    {player.full_name}
+                </button>
+            }
+            nameTone={taken ? 'muted' : 'default'}
+            flag={isMine ? { text: 'YOU', tone: 'mine' } : undefined}
+            leadingDot={lowConfidenceMatch ? 'warn' : undefined}
+            meta={
+                <>
+                    <span>{player.team ? player.team : 'FA'}</span>
+                    <span> · </span>
+                    <span>{playerAvailabilityText({ taken, rosteredByName })}</span>
+                </>
+            }
+            trailing={
+                <>
+                    {adpData && (
+                        <span
+                            data-testid="adp-delta"
+                            className={`w-[34px] shrink-0 text-right font-mono text-[11px] ${adpDeltaTone}`}
+                        >
+                            {adpDeltaText}
+                        </span>
+                    )}
+                    <PositionTag position={player.position} />
+                    {/* Neutral, not a colour fill: saturation is reserved for
+                        position data and violet for "yours", so availability -
+                        the thing this row most needs to say - is carried by the
+                        meta line above, not by tinting the row. */}
+                    {taken && !isMine && (
+                        <span className="text-ink-quiet shrink-0 text-[11px] font-semibold">Taken</span>
+                    )}
+                    {(!taken || isMine) && (
+                        <button
+                            type="button"
+                            disabled={inLineup}
+                            onClick={() => addToRoster(player)}
+                            className="bg-mine-chip text-mine shrink-0 rounded-full px-[11px] py-1.5 text-[11px] font-semibold disabled:opacity-50"
+                        >
+                            {inLineup ? 'Added' : 'Add'}
+                        </button>
+                    )}
+                </>
+            }
+        />
     );
 };
 

--- a/src/Components/PlayerInfoItem.test.jsx
+++ b/src/Components/PlayerInfoItem.test.jsx
@@ -98,7 +98,9 @@ describe('PlayerInfoItem', () => {
         renderItem(MY_PLAYER_ID);
 
         expect(screen.getByText(MY_DISPLAY_NAME)).toBeTruthy();
-        expect(screen.getByText('Taken')).toBeTruthy();
+        // The "Taken" label is only for someone else's player now - your own
+        // taken player still gets the Add/Added pill instead, not both.
+        expect(screen.queryByText('Taken')).toBeNull();
         expect(
             screen.getByRole('group', {
                 name: `${playerInfo[MY_PLAYER_ID].full_name}, ${playerInfo[MY_PLAYER_ID].position}, taken by ${MY_DISPLAY_NAME} · you`,
@@ -235,7 +237,12 @@ describe('PlayerInfoItem', () => {
         expect(updatePlayerId).toHaveBeenCalledWith(expect.anything(), true);
     });
 
-    it('reports ranked-before-ADP, matches-ADP, and ranked-after-ADP', () => {
+    // The old two-line "ADP: 15" / "Ranked N picks before ADP" prose is gone
+    // from the display state - it is a single signed delta now (see
+    // ListRow's `trailing` in PlayerInfoItem): negative (ranked ahead of ADP)
+    // in text-live, positive (ranked behind) in text-warn, zero in
+    // text-ink-dim.
+    it('renders the ADP delta signed, coloured by direction: ahead, matching, and behind', () => {
         const { rerender } = render(
             <PlayerInfoItem
                 player={playerInfo[FREE_AGENT_ID]}
@@ -250,7 +257,7 @@ describe('PlayerInfoItem', () => {
                 myDisplayName={MY_DISPLAY_NAME}
             />,
         );
-        expect(screen.getByText('Ranked 5 picks before ADP')).toBeTruthy();
+        expect(screen.getByText('-5')).toHaveClass('text-live');
 
         rerender(
             <PlayerInfoItem
@@ -266,7 +273,7 @@ describe('PlayerInfoItem', () => {
                 myDisplayName={MY_DISPLAY_NAME}
             />,
         );
-        expect(screen.getByText('Rank matches ADP')).toBeTruthy();
+        expect(screen.getByText('0')).toHaveClass('text-ink-dim');
 
         rerender(
             <PlayerInfoItem
@@ -282,6 +289,12 @@ describe('PlayerInfoItem', () => {
                 myDisplayName={MY_DISPLAY_NAME}
             />,
         );
-        expect(screen.getByText('Ranked 5 picks after ADP')).toBeTruthy();
+        expect(screen.getByText('+5')).toHaveClass('text-warn');
+    });
+
+    it('omits the ADP delta column entirely when there is no ADP data', () => {
+        renderItem(FREE_AGENT_ID, { adpData: null });
+
+        expect(screen.queryByTestId('adp-delta')).toBeNull();
     });
 });

--- a/src/Components/PositionTag.jsx
+++ b/src/Components/PositionTag.jsx
@@ -1,0 +1,15 @@
+import { positionClass } from '../Panels/pickLabels.js';
+
+// The shared position badge: a tint plus a light ink, never a solid fill.
+// `positionClass` already resolves the tint/ink pair (and the K/DEF neutral
+// fallback) - this component is only the markup six call sites used to
+// duplicate.
+const PositionTag = ({ position }) => (
+    <span
+        className={`rounded-tag shrink-0 px-[7px] py-1 font-mono text-[10px] font-semibold tracking-[.08em] ${positionClass(position)}`}
+    >
+        {position}
+    </span>
+);
+
+export default PositionTag;

--- a/src/Panels/BestAvailableSheet.jsx
+++ b/src/Panels/BestAvailableSheet.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { isTaken } from '../lib/rosterInfo.js';
-import { positionClass } from './pickLabels.js';
+import PositionTag from '../Components/PositionTag';
 
 // Mobile-only companion to the Ranks column that already sits beside the
 // board at md+ (see AppShell's SECTIONS_WITH_ASIDE). Below that width there is
@@ -67,11 +67,7 @@ const BestAvailableSheet = ({ rankingPlayersIdsList, playerInfo, rosterInfo }) =
                                     </span>
                                     <span className="text-ink min-w-0 flex-1 truncate text-sm">{player.full_name}</span>
                                     <span className="text-ink-muted shrink-0 text-xs">{player.team}</span>
-                                    <span
-                                        className={`shrink-0 rounded-[4px] px-1.5 py-0.5 text-[10px] font-semibold ${positionClass(player.position)}`}
-                                    >
-                                        {player.position}
-                                    </span>
+                                    <PositionTag position={player.position} />
                                 </li>
                             );
                         })}

--- a/src/Panels/LineupPanel.jsx
+++ b/src/Panels/LineupPanel.jsx
@@ -5,13 +5,27 @@ const LineupPanel = ({ playerInfo, rosterSlots, removeFromLineup }) => {
 
     return (
         <div>
-            <h4 className="border-line bg-ground sticky top-0 z-10 flex items-center justify-between border-b px-3 py-2 text-sm font-semibold">
-                <span>Starters</span>
+            {/* The app has no week number and no bye-week source in the
+                Sleeper bundle, so the subhead reads just "{n} slots" rather
+                than inventing "Week 1". */}
+            <h4 className="border-line bg-ground sticky top-0 z-10 flex items-center justify-between border-b px-3.5 py-2">
+                <span className="flex flex-col">
+                    <span className="text-ink text-xl font-bold tracking-[-0.02em]">Starters</span>
+                    <span className="text-ink-quiet font-mono text-[11px]">{rosterSlots.length} slots</span>
+                </span>
                 {/* Omitted entirely at zero rather than reading "0 empty" -
-                    a full lineup has nothing to draw attention to. */}
-                {emptyCount > 0 && <span className="text-ink-muted font-normal">{emptyCount} empty</span>}
+                    a full lineup has nothing to draw attention to. Text
+                    content stays lowercase ("N empty") so the existing
+                    getByText('2 empty') query keeps resolving; uppercase is
+                    applied only visually via CSS, the same trick RoundSection
+                    uses for "Round 1". */}
+                {emptyCount > 0 && (
+                    <span className="bg-warn-tint text-warn rounded-tag px-2.5 py-[5px] font-mono text-[11px] font-semibold tracking-[.08em] uppercase">
+                        {emptyCount} empty
+                    </span>
+                )}
             </h4>
-            <ul className="flex flex-col gap-1 py-1">
+            <ul className="flex flex-col gap-0.5 px-2 py-1">
                 {rosterSlots.map((slot, i) => (
                     <SlotRow
                         key={`${slot.label}-${i}`}

--- a/src/Panels/LineupPanel.test.jsx
+++ b/src/Panels/LineupPanel.test.jsx
@@ -109,13 +109,17 @@ describe('LineupPanel', () => {
         expect(removeFromLineup).toHaveBeenCalledWith(0);
     });
 
-    it('shows the occupant name and team on screen, and Empty for an unfilled slot', () => {
+    it('shows the occupant name and team on screen, and a placeholder for an unfilled slot', () => {
         renderLineup();
 
         expect(screen.getByText(STARTER.full_name)).toBeVisible();
         // The second line is the team alone - there is no schedule data in
         // this app, so an opponent here would have to be invented.
         expect(screen.getByText(STARTER.team)).toBeVisible();
-        expect(screen.getAllByText('Empty')).toHaveLength(2);
+        // An empty slot reads "Add player" / "Empty slot" rather than a
+        // dashed box - the dashed border was exactly the blockiness this
+        // redesign removes.
+        expect(screen.getAllByText('Add player')).toHaveLength(2);
+        expect(screen.getAllByText('Empty slot')).toHaveLength(2);
     });
 });

--- a/src/Panels/ManualPickModal.jsx
+++ b/src/Panels/ManualPickModal.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import Button from '../Components/Button';
-import { positionClass } from './pickLabels.js';
+import PositionTag from '../Components/PositionTag';
 import { isTaken } from '../lib/rosterInfo.js';
 
 const HEADING_ID = 'manual-pick-modal-heading';
@@ -40,11 +40,7 @@ const ManualPickModal = ({
             <span className="min-w-0 flex-1 truncate">
                 {player.full_name} {player.team ? player.team : null}
             </span>
-            <span
-                className={`shrink-0 rounded-[4px] px-1.5 py-0.5 text-xs font-semibold ${positionClass(player.position)}`}
-            >
-                {player.position}
-            </span>
+            <PositionTag position={player.position} />
         </button>
     );
 

--- a/src/Panels/PickFeed.test.jsx
+++ b/src/Panels/PickFeed.test.jsx
@@ -223,7 +223,12 @@ describe('PickFeed manual pick selection', () => {
         // the "you" suffix and the "via" attribution both land on the same row.
         // "you" marks the whole attribution and so comes last: the pick is
         // yours, acquired via aphilliny21.
-        expect(screen.getByText('ryangh via aphilliny21 · you')).toBeTruthy();
+        //
+        // That suffix now lives in the accessible name only. On screen the row
+        // says "yours" twice already - the violet tint and the YOU flag - so
+        // the visible attribution is the plain one.
+        expect(screen.getByRole('button', { name: 'Round 1, pick 1, ryangh via aphilliny21 · you' })).toBeTruthy();
+        expect(screen.getByText('ryangh via aphilliny21')).toBeTruthy();
     });
 });
 
@@ -237,25 +242,34 @@ describe('PickFeed pick numbering', () => {
 });
 
 describe('PickFeed your-pick styling', () => {
-    it('marks the pick belonging to myDisplayName with the accent border, and no one else', () => {
+    it('marks the pick belonging to myDisplayName with the row tint, and no one else', () => {
         renderFeed();
 
         // Board spot 3 in round 1 is roster 1, "ryangh", in this fixture.
-        // Board spot 1 is roster 5, "HEFFinAround305" - not me.
+        // Board spot 1 is roster 5, "HEFFinAround305" - not me. The design
+        // marks "yours" with a row background tint, not a border - see
+        // ListRow's `tone="mine"`.
         const myRow = screen.getByRole('button', { name: /pick 3, ryangh/ });
-        expect(myRow.className).toMatch(/border-mine/);
+        expect(myRow.className).toMatch(/bg-mine-row/);
 
         const someoneElsesRow = screen.getByRole('button', { name: /pick 1, HEFFinAround305/ });
-        expect(someoneElsesRow.className).not.toMatch(/border-mine/);
+        expect(someoneElsesRow.className).not.toMatch(/bg-mine-row/);
     });
 
-    it('labels my own pick "ryangh · you" and leaves everyone else plain', () => {
+    it('keeps "· you" in my pick\'s accessible name but not in its visible text', () => {
         renderFeed();
 
-        expect(screen.getByText('ryangh · you')).toBeInTheDocument();
-        // Pick 1 belongs to roster 5, not me.
+        // The suffix is what a screen reader has instead of the row tint and
+        // the YOU flag, so it stays in the name. Visually it would be the
+        // third time the same row said "yours", so it is not rendered.
+        const myRow = screen.getByRole('button', { name: 'Round 1, pick 3, ryangh · you' });
+        expect(within(myRow).queryByText(/· you/)).toBeNull();
+        expect(within(myRow).getByText('YOU')).toBeInTheDocument();
+
+        // Pick 1 belongs to roster 5, not me - no suffix and no flag.
         const otherRow = screen.getByRole('button', { name: /pick 1,/ });
         expect(within(otherRow).queryByText(/· you/)).toBeNull();
+        expect(within(otherRow).queryByText('YOU')).toBeNull();
     });
 });
 

--- a/src/Panels/PickRow.jsx
+++ b/src/Panels/PickRow.jsx
@@ -1,5 +1,7 @@
-import { managerLabel, pickAccessibleName, pickNumberLabel, positionClass } from './pickLabels.js';
+import { managerLabel, pickAccessibleName, pickNumberLabel } from './pickLabels.js';
 import { pickKey } from '../lib/seenPicks.js';
+import ListRow from '../Components/ListRow';
+import PositionTag from '../Components/PositionTag';
 
 const PickRow = ({ round, pick, playerInfo, rosterData, myDisplayName, onSelect, newPickKeys = new Set() }) => {
     // The player database is a snapshot and a drafted player can be absent
@@ -16,47 +18,43 @@ const PickRow = ({ round, pick, playerInfo, rosterData, myDisplayName, onSelect,
     const isNew = newPickKeys.has(pickKey(round, pick));
     const accessibleName = pickAccessibleName({ round, pick, player, manager, isNew });
 
+    // The visible attribution drops the "· you" the accessible name keeps: on
+    // screen the row already says it twice, with the violet tint and the YOU
+    // flag, and "WR · ATL · ryangh · you" would be a third.
+    const visibleManager = managerLabel({ pick, rosterData, myDisplayName, markYours: false });
+
+    // Manager used to sit above the player name to stop a long attribution
+    // ("CHood20 via kpresley") from truncating the name. It moves into the
+    // mono meta line instead - the meta line already truncates independently
+    // of the name, which is the actual fix for the same problem.
+    const meta = player ? [player.position, player.team, visibleManager].filter(Boolean).join(' · ') : visibleManager;
+
+    // One flag slot, and a pick can be both yours and unseen. NEW wins:
+    // ownership is already carried by the row's violet tint, so spending the
+    // flag on YOU would say that twice and leave "new" - which nothing else on
+    // the row encodes, and which stops being true on the next visit - unsaid.
+    let flag;
+    if (isNew) {
+        flag = { text: 'NEW', tone: 'live' };
+    } else if (isMine) {
+        flag = { text: 'YOU', tone: 'mine' };
+    }
+
     return (
         <li>
-            <button
-                type="button"
-                aria-label={accessibleName}
+            <ListRow
+                label={accessibleName}
                 onClick={() => onSelect(pick)}
-                className={`flex min-h-11 w-full items-center gap-3 rounded-[5px] border px-3 py-2 text-left ${
-                    isMine ? 'border-mine! bg-mine/10!' : 'border-line'
-                }`}
-            >
-                <span className="text-ink-muted w-12 shrink-0 text-sm tabular-nums">{pickNumber}</span>
-                {/* Manager above player rather than beside it. Sharing one line
-                    meant a long attribution ate the name: "CHood20 via kpresley"
-                    truncated "KC Concepcion" on a 375px screen. Stacked, each
-                    gets the full width of the row. */}
-                <span className="flex min-w-0 flex-1 flex-col leading-tight">
-                    <span className="text-ink-muted truncate text-xs">{manager}</span>
-                    {pick.player_id && (
-                        <span className="text-ink truncate text-sm">
-                            {player ? player.full_name : `Unknown player ${pick.player_id}`}
-                        </span>
-                    )}
-                </span>
-                {player && (
-                    <span
-                        className={`shrink-0 rounded-[4px] px-1.5 py-0.5 text-xs font-semibold ${positionClass(player.position)}`}
-                    >
-                        {player.position}
-                    </span>
-                )}
-                {/* Neutral, not a saturated position colour or `bg-mine` -
-                    both are already spoken for (position data and "yours"
-                    respectively), so "new" gets the one high-contrast chip
-                    left: ink-on-ground, same geometry as the position badge
-                    above. */}
-                {isNew && (
-                    <span className="bg-ink text-ground shrink-0 rounded-[4px] px-1.5 py-0.5 text-xs font-semibold">
-                        NEW
-                    </span>
-                )}
-            </button>
+                ordinal={pickNumber}
+                ordinalWidth="34px"
+                name={
+                    pick.player_id ? (player ? player.full_name : `Unknown player ${pick.player_id}`) : visibleManager
+                }
+                flag={flag}
+                meta={pick.player_id ? meta : undefined}
+                tone={isMine ? 'mine' : undefined}
+                trailing={player && <PositionTag position={player.position} />}
+            />
         </li>
     );
 };

--- a/src/Panels/RanksPanel.jsx
+++ b/src/Panels/RanksPanel.jsx
@@ -393,7 +393,7 @@ const RanksPanel = ({
                             </>
                         )}
                     </div>
-                    <div className="max-h-[600px] overflow-x-visible overflow-y-scroll">
+                    <div className="flex max-h-[600px] flex-col gap-0.5 overflow-x-visible overflow-y-scroll px-2">
                         {rankingPlayersIdsList
                             .filter(filterPlayers)
                             .filter((results) =>

--- a/src/Panels/RoundSection.jsx
+++ b/src/Panels/RoundSection.jsx
@@ -5,6 +5,7 @@ import { countNewInRound } from '../lib/seenPicks.js';
 const RoundSection = ({ round, playerInfo, rosterData, myDisplayName, onOpenPick, newPickKeys = new Set() }) => {
     const [showRound, setShowRound] = useState(true);
     const newCount = countNewInRound(round, newPickKeys);
+    const madeCount = round.picks.filter((pick) => pick.player_id).length;
 
     return (
         <section>
@@ -12,27 +13,33 @@ const RoundSection = ({ round, playerInfo, rosterData, myDisplayName, onOpenPick
                 click handler on the heading itself: collapsing a round is
                 reachable from the keyboard, and aria-expanded says which way
                 it currently is. */}
-            <h4 className="border-line bg-ground sticky top-0 z-10 border-b text-sm font-semibold">
+            <h4 className="border-line-quiet bg-ground sticky top-0 z-10 border-b px-3.5 py-2">
                 <button
                     type="button"
                     aria-expanded={showRound}
                     onClick={() => setShowRound((prev) => !prev)}
-                    className="text-ink flex w-full cursor-pointer items-center gap-2 px-3 py-2 text-left text-sm font-semibold"
+                    className="flex w-full cursor-pointer items-center gap-2 text-left"
                 >
                     {/* Kept as its own element, not concatenated into the
                         "N new" chip's text, so screen.getByText('Round 1')
                         keeps resolving - the round-collapsing test depends on
-                        this exact node. */}
-                    <span>Round {round.round}</span>
+                        this exact node. Uppercased via CSS rather than a
+                        literal "ROUND 1" so that text query still matches. */}
+                    <span className="text-ink font-mono text-[11px] font-semibold tracking-[.12em] uppercase">
+                        Round {round.round}
+                    </span>
+                    <span className="text-ink-dim font-mono text-[11px]">
+                        {madeCount} / {round.picks.length}
+                    </span>
                     {newCount > 0 && (
-                        <span className="bg-ink text-ground rounded-[4px] px-1.5 py-0.5 text-xs font-semibold">
+                        <span className="text-live ml-auto font-mono text-[10px] font-semibold tracking-[.1em] uppercase">
                             {newCount} new
                         </span>
                     )}
                 </button>
             </h4>
             {showRound && (
-                <ol aria-label={`Round ${round.round}`} className="flex flex-col gap-1 py-1">
+                <ol aria-label={`Round ${round.round}`} className="flex flex-col gap-0.5 px-2 py-1">
                     {round.picks.map((pick) => (
                         <PickRow
                             key={pick.pick_number}

--- a/src/Panels/SlotRow.jsx
+++ b/src/Panels/SlotRow.jsx
@@ -1,5 +1,6 @@
-import { positionClass } from './pickLabels.js';
 import { slotAccessibleName, slotOccupantLabel } from './lineupLabels.js';
+import ListRow from '../Components/ListRow';
+import PositionTag from '../Components/PositionTag';
 
 const SlotRow = ({ slot, index, playerInfo, onRemove }) => {
     // A slot is occupied whenever it holds a player id, even if that id is
@@ -15,38 +16,6 @@ const SlotRow = ({ slot, index, playerInfo, onRemove }) => {
     const occupantName = slotOccupantLabel({ slot, player });
     const accessibleName = slotAccessibleName({ slot, player });
 
-    // Shared classes for the row geometry - copied from PickRow rather than
-    // reinvented. min-h-14 rather than min-h-11 because the filled row's two
-    // stacked lines already exceed 44px: the floor is what makes an empty and
-    // a filled row agree on height instead of merely both clearing the 44px
-    // touch minimum.
-    const rowClasses =
-        'm-0 flex min-h-14 w-full items-center gap-3 rounded-[5px] border bg-transparent px-3 py-2 text-left';
-
-    const content = (
-        <>
-            <span className="text-ink-muted w-12 shrink-0 text-sm">{slot.label}</span>
-            {slot.playerId ? (
-                <span className="flex min-w-0 flex-1 flex-col leading-tight">
-                    <span className="text-ink truncate text-sm">{occupantName}</span>
-                    {/* No opponent/schedule data is available here, so only the
-                        team renders on the second line - inventing an opponent
-                        would be worse than leaving the line short. */}
-                    {player?.team && <span className="text-ink-muted truncate text-xs">{player.team}</span>}
-                </span>
-            ) : (
-                <span className="text-ink-muted flex min-w-0 flex-1 flex-col text-sm">Empty</span>
-            )}
-            {player && (
-                <span
-                    className={`shrink-0 rounded-[4px] px-1.5 py-0.5 text-xs font-semibold ${positionClass(player.position)}`}
-                >
-                    {player.position}
-                </span>
-            )}
-        </>
-    );
-
     // Filled slots remove on click; empty slots have nothing to do. The
     // design captions empty slots "Tap to fill", but no fill-from-slot action
     // exists in this app - filling happens from the Ranks panel's Add button.
@@ -55,27 +24,36 @@ const SlotRow = ({ slot, index, playerInfo, onRemove }) => {
     if (!slot.playerId) {
         return (
             <li>
-                {/* role="group" so the aria-label is actually exposed: on a
-                    bare div - role `generic` - most screen readers drop it,
-                    which would leave the name working in tests and nowhere
-                    else. The filled row below is a button and needs no role. */}
-                <div role="group" aria-label={accessibleName} className={`${rowClasses} border-line border-dashed`}>
-                    {content}
-                </div>
+                <ListRow
+                    as="div"
+                    label={accessibleName}
+                    ordinal={slot.label}
+                    ordinalWidth="44px"
+                    ordinalClassName="text-[10px] font-semibold tracking-[.08em] text-ink-muted"
+                    name="Add player"
+                    nameTone="dim"
+                    meta="Empty slot"
+                    tone="empty"
+                />
             </li>
         );
     }
 
     return (
         <li>
-            <button
-                type="button"
-                aria-label={accessibleName}
+            <ListRow
+                label={accessibleName}
                 onClick={() => onRemove(index)}
-                className={`${rowClasses} border-line`}
-            >
-                {content}
-            </button>
+                ordinal={slot.label}
+                ordinalWidth="44px"
+                ordinalClassName="text-[10px] font-semibold tracking-[.08em] text-ink-muted"
+                name={occupantName}
+                // No opponent/schedule data is available here, so only the
+                // team renders on the meta line - inventing an opponent would
+                // be worse than leaving the line short.
+                meta={player?.team}
+                trailing={player && <PositionTag position={player.position} />}
+            />
         </li>
     );
 };

--- a/src/Panels/pickLabels.js
+++ b/src/Panels/pickLabels.js
@@ -39,7 +39,12 @@ export const pickNumberLabel = (round, pick) => `${round.round}.${String(pick.pi
 // Builds the manager attribution text once so the visible label and the
 // button's accessible name can't drift apart - both read off this same
 // string.
-export const managerLabel = ({ pick, rosterData, myDisplayName }) => {
+// `markYours` exists for the redesigned row, which shows ownership twice
+// otherwise: the row wears the violet "yours" tint and a `YOU` flag beside the
+// name, so a meta line reading "WR · ATL · ryangh · you" says it a third time.
+// It defaults to true, so the accessible name - which has no tint and no flag
+// to lean on, and which every pick test asserts on - is unchanged.
+export const managerLabel = ({ pick, rosterData, myDisplayName, markYours = true }) => {
     const owner = pick.owner_id ? rosterData.find((roster) => roster.roster_id === pick.owner_id) : null;
     if (!owner?.manager_display_name) {
         return 'Pick owner missing';
@@ -51,7 +56,7 @@ export const managerLabel = ({ pick, rosterData, myDisplayName }) => {
     }
     // "you" marks the whole attribution, so it goes last: a traded pick of
     // yours reads "ryangh via crbiehl · you", not "ryangh · you via crbiehl".
-    return owner.manager_display_name === myDisplayName ? `${label} · you` : label;
+    return markYours && owner.manager_display_name === myDisplayName ? `${label} · you` : label;
 };
 
 // Builds the accessible name shared by the feed's rows and the grid's cells:


### PR DESCRIPTION
Step 4. This is the one where the app stops looking like a stack of bordered boxes.

`ListRow` is transparent on the ground plane — 10px radius, `11px 10px` padding, 12px gap, **no border, no card**. Lists are flex columns with a 2px gap and no margins on rows. `PositionTag` replaces six duplicated copies of the same badge markup.

**Row heights hit the design's 46px / 56px, but only after pinning line-heights.** Preflight puts `line-height: 1.5` on the root, which made a two-line row 61px. `leading-5` on the 15px name and `leading-[14px]` on the 11px meta give exactly 56; a `min-h-[46px]` floor brings the single-line row back up from 42, which was both under the design's 46 *and* under the 44px touch minimum. Measured in the browser, not computed: 50 pick rows at 46px, 13 slot rows at 56px, no truncation overflow, no horizontal scroll at 375.

**`PickRow` inverts its stacking.** The manager moves off the line above the name and into the mono meta line (`WR · ATL · ryangh`), where it truncates without eating the player name — which is the actual fix for the problem the old stacking worked around.

**Two things the design left ambiguous, and how I called them:**

1. A pick can be both yours *and* unseen, and there's one flag slot. **NEW wins** — ownership is already carried by the row's violet tint, so spending the flag on `YOU` would say that twice and leave "new", which nothing else on the row encodes, unsaid.
2. `managerLabel` gains an optional `markYours: false` for the **visible** attribution only. The row was otherwise saying "yours" three times: the tint, the `YOU` flag, and `· you` in the meta line. The accessible name — which has neither tint nor flag to lean on, and which every pick test asserts on — is unchanged by default.

**Empty slots** lose the dashed border for a faint fill and read `Add player` / `Empty slot`. They stay non-interactive; no fill-from-slot action exists yet, and the shared sheet wires that up next.

**Rank rows** get the ADP delta (signed, `live` ahead / `warn` behind / `ink-dim` at zero) in place of the two-line prose, and a low-confidence match moves from a `warn` row border to a `warn` dot before the name.

Two test assertions changed, both to match deliberate design changes rather than to weaken them: the `· you` suffix is now asserted on the accessible name plus the visible `YOU` flag, and the empty-slot text is `Add player` / `Empty slot`. Verified against a real rank list pasted into the running app: `2 · Travis Hunter · YOU · JAX · ryangh · WR · Add`, 56px.

All six gates green; 321 tests.