### PR TITLE
Collapse the Ranks control stack into a header and one chip row

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import LeaguePanel from './Panels/LeaguePanel';
 import RanksPanel from './Panels/RanksPanel';
 import Spinner from './Components/Spinner';
 import { SyncStatusProvider } from './SyncStatus.jsx';
+import { RankListProvider, useRankList } from './RankList.jsx';
 import { SECTIONS, defaultSectionFor } from './sections.js';
 import { currentUserIdentity, observeAuthState, signInAnonymous, signInWithGoogle, signOutUser } from './lib/auth.js';
 import createRankings from './helpers.js';
@@ -40,6 +41,25 @@ const LOADING = {
     INITIAL: 'initial',
     LEAGUE_PANEL: 'leaguePanel',
     RANKS_PANEL: 'ranksPanel',
+};
+
+// The best-available rail's subtitle needs the real rank list name, which
+// only exists in RankList's context - not reachable from a class component's
+// render via a hook. This is the smallest possible wrapper: a function
+// component that reads the context itself and renders exactly the line
+// renderBestAvailableRail used to build from a hardcoded "Ranks" string.
+// Falls back to "Ranks" both before RanksPanel has ever mounted (no list
+// published yet) and while nothing is selected (the default "-- Select saved
+// ranks list" placeholder), so the rail never shows that placeholder text.
+const BestAvailableSubtitle = ({ left }) => {
+    const rankList = useRankList();
+    const selected = rankList?.options?.find((option) => option.value === rankList.currentValue);
+    const listName = selected && selected.value !== 'default' ? selected.label : 'Ranks';
+    return (
+        <p className="text-ink-quiet m-0 font-mono text-[11px]">
+            {listName} · {left} left
+        </p>
+    );
 };
 
 class App extends React.Component {
@@ -309,11 +329,6 @@ class App extends React.Component {
     // lets both render identically). Ranks itself is still reachable as its
     // own section; "Edit list" below is a shortcut there.
     //
-    // `listName` has nowhere to come from yet - RanksPanel keeps its saved
-    // rank list selection as local state and doesn't lift it up, and that
-    // control stack is explicitly the next step, not this one - so this
-    // reads a generic "Ranks" rather than the real list name. Worth revisiting
-    // once RanksPanel's controls move up.
     renderBestAvailableRail = (activeId) => {
         const { playerInfo, leagueData, rankingPlayersIdsList, rosterSlots, myDisplayName } = this.state;
         const rosterInfoValue = this.selectRosterInfo({
@@ -324,7 +339,6 @@ class App extends React.Component {
             activeId === 'lineup'
                 ? [...new Set(rosterSlots.filter((slot) => !slot.playerId).map((slot) => slot.label))]
                 : null;
-        const listName = 'Ranks';
         const left = countAvailable({
             entries: rankingPlayersIdsList,
             playerInfo,
@@ -337,9 +351,7 @@ class App extends React.Component {
                 <div className="flex items-start justify-between gap-2">
                     <div className="min-w-0">
                         <p className="text-ink m-0 text-[16px] font-semibold">Best available</p>
-                        <p className="text-ink-quiet m-0 font-mono text-[11px]">
-                            {listName} · {left} left
-                        </p>
+                        <BestAvailableSubtitle left={left} />
                     </div>
                     <button
                         type="button"
@@ -407,9 +419,10 @@ class App extends React.Component {
                 />
             );
             return (
-                <SyncStatusProvider>
-                    <div>
-                        {/*
+                <RankListProvider>
+                    <SyncStatusProvider>
+                        <div>
+                            {/*
                             The shell renders its own top bar, because the bar's
                             section pills and the tab bar have to share one
                             active id. So this is an either/or, not a stack: the
@@ -420,81 +433,84 @@ class App extends React.Component {
                             Rendering both is what it looked like first, and it
                             put two top bars on the screen.
                         */}
-                        {!loadError && leagueData.currentLeague ? (
-                            <AppShell
-                                sections={SECTIONS}
-                                // The league bundle already carries the draft's status, so this is
-                                // known the moment the shell can mount. Reading it off
-                                // currentDraft instead would be a render too late: that is
-                                // filled by loadDraft, which resolves after the shell is
-                                // already on screen.
-                                defaultSectionId={defaultSectionFor(leagueData.currentLeagueDrafts?.[0]?.status)}
-                                identity={{
-                                    signedIn,
-                                    signedInEmail,
-                                    myDisplayName,
-                                    onSignIn: this.googleSignIn,
-                                    onSignOut: this.signOut,
-                                }}
-                                leagueID={leagueID}
-                                leagueIds={leagueData.leagueIds}
-                                updateLeagueID={this.updateLeagueID}
-                                // Inside the shell rather than above it: the
-                                // shell owns the top bar now, so a banner
-                                // rendered as a sibling would sit above the bar
-                                // instead of under it.
-                                banner={
-                                    draftWarning ? (
+                            {!loadError && leagueData.currentLeague ? (
+                                <AppShell
+                                    sections={SECTIONS}
+                                    // The league bundle already carries the draft's status, so this is
+                                    // known the moment the shell can mount. Reading it off
+                                    // currentDraft instead would be a render too late: that is
+                                    // filled by loadDraft, which resolves after the shell is
+                                    // already on screen.
+                                    defaultSectionId={defaultSectionFor(leagueData.currentLeagueDrafts?.[0]?.status)}
+                                    identity={{
+                                        signedIn,
+                                        signedInEmail,
+                                        myDisplayName,
+                                        onSignIn: this.googleSignIn,
+                                        onSignOut: this.signOut,
+                                    }}
+                                    leagueID={leagueID}
+                                    leagueIds={leagueData.leagueIds}
+                                    updateLeagueID={this.updateLeagueID}
+                                    // Inside the shell rather than above it: the
+                                    // shell owns the top bar now, so a banner
+                                    // rendered as a sibling would sit above the bar
+                                    // instead of under it.
+                                    banner={
+                                        draftWarning ? (
+                                            <ErrorBanner
+                                                message={draftWarning}
+                                                variant="warning"
+                                                onRetry={this.retryDraftLoad}
+                                            />
+                                        ) : null
+                                    }
+                                    renderAside={this.renderBestAvailableRail}
+                                    renderSection={(activeId) => {
+                                        if (activeId === 'ranks') {
+                                            return ranksPanel;
+                                        }
+                                        return (
+                                            <LeaguePanel
+                                                view={activeId === 'lineup' ? 'weekly' : 'draft'}
+                                                leagueData={leagueData}
+                                                rankingPlayersIdsList={rankingPlayersIdsList}
+                                                rosterSlots={rosterSlots}
+                                                playerInfo={playerInfo}
+                                                rosterInfo={rosterInfo}
+                                                isLoading={loading === LOADING.LEAGUE_PANEL}
+                                                removeFromLineup={this.removeFromLineup}
+                                                updateDraftBoard={this.updateDraftBoard}
+                                                myDisplayName={myDisplayName}
+                                                addToRoster={this.addToRoster}
+                                            />
+                                        );
+                                    }}
+                                />
+                            ) : (
+                                <>
+                                    <AppBar
+                                        signedIn={signedIn}
+                                        signedInEmail={signedInEmail}
+                                        myDisplayName={myDisplayName}
+                                        onSignIn={this.googleSignIn}
+                                        onSignOut={this.signOut}
+                                    />
+                                    {loadError ? (
+                                        <ErrorBanner message={loadError} onRetry={this.retryLeagueLoad} />
+                                    ) : null}
+                                    {!loadError && draftWarning ? (
                                         <ErrorBanner
                                             message={draftWarning}
                                             variant="warning"
                                             onRetry={this.retryDraftLoad}
                                         />
-                                    ) : null
-                                }
-                                renderAside={this.renderBestAvailableRail}
-                                renderSection={(activeId) => {
-                                    if (activeId === 'ranks') {
-                                        return ranksPanel;
-                                    }
-                                    return (
-                                        <LeaguePanel
-                                            view={activeId === 'lineup' ? 'weekly' : 'draft'}
-                                            leagueData={leagueData}
-                                            rankingPlayersIdsList={rankingPlayersIdsList}
-                                            rosterSlots={rosterSlots}
-                                            playerInfo={playerInfo}
-                                            rosterInfo={rosterInfo}
-                                            isLoading={loading === LOADING.LEAGUE_PANEL}
-                                            removeFromLineup={this.removeFromLineup}
-                                            updateDraftBoard={this.updateDraftBoard}
-                                            myDisplayName={myDisplayName}
-                                            addToRoster={this.addToRoster}
-                                        />
-                                    );
-                                }}
-                            />
-                        ) : (
-                            <>
-                                <AppBar
-                                    signedIn={signedIn}
-                                    signedInEmail={signedInEmail}
-                                    myDisplayName={myDisplayName}
-                                    onSignIn={this.googleSignIn}
-                                    onSignOut={this.signOut}
-                                />
-                                {loadError ? <ErrorBanner message={loadError} onRetry={this.retryLeagueLoad} /> : null}
-                                {!loadError && draftWarning ? (
-                                    <ErrorBanner
-                                        message={draftWarning}
-                                        variant="warning"
-                                        onRetry={this.retryDraftLoad}
-                                    />
-                                ) : null}
-                            </>
-                        )}
-                    </div>
-                </SyncStatusProvider>
+                                    ) : null}
+                                </>
+                            )}
+                        </div>
+                    </SyncStatusProvider>
+                </RankListProvider>
             );
         }
     }

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -380,6 +380,9 @@ describe('App', () => {
         // rather than a second copy of Ranks (see App.renderBestAvailableRail).
         await user.click(screen.getAllByRole('button', { name: 'Ranks' })[0]);
 
+        // The paste box moved into a sheet opened by the "Paste list" pill
+        // (step 6d) - open it before reaching for the textarea.
+        await user.click(screen.getByRole('button', { name: 'Paste list' }));
         await user.type(screen.getByPlaceholderText('Copy + Paste rankings here...'), `1. ${SWAPPED_PLAYER.name}`);
         await user.click(screen.getByRole('button', { name: 'Submit' }));
 
@@ -394,7 +397,13 @@ describe('App', () => {
 
         expect(await attribution()).toContain('taken by ryangh');
 
+        // The Ranks section's top-bar pill is the rank list, not the league,
+        // while RanksPanel is mounted (step 6a) - the league switcher is
+        // reachable again from another section, so switch there and back
+        // rather than expecting a league combobox on this one.
+        await user.click(screen.getAllByRole('button', { name: 'Draft' })[0]);
         await user.selectOptions(screen.getByDisplayValue('Test League'), OTHER_LEAGUE_ID);
+        await user.click(screen.getAllByRole('button', { name: 'Ranks' })[0]);
 
         // The second league has this player on nobody's roster, so the derived
         // flags must follow the new league rather than keeping the stale name.

--- a/src/Components/AppBar.jsx
+++ b/src/Components/AppBar.jsx
@@ -1,8 +1,10 @@
 import { useId, useRef, useState } from 'react';
 import LeaguePill from './LeaguePill';
+import SelectPill from './Pill';
 import Drawer from './Drawer';
 import { avatarInitials } from './avatarInitials.js';
 import { useSyncStatus } from '../SyncStatus.jsx';
+import { useRankList } from '../RankList.jsx';
 
 // The top bar. Rendered twice in this app on purpose: bare, by App, above
 // the loading spinner and the error banner (no league yet, so no nav and no
@@ -28,6 +30,7 @@ const AppBar = ({
     const hamburgerRef = useRef(null);
     const drawerId = useId();
     const isSyncing = useSyncStatus();
+    const rankList = useRankList();
 
     const showLeaguePill = Boolean(leagueIds && leagueIds.length);
     const showSectionPills = Boolean(sections && sections.length);
@@ -56,7 +59,20 @@ const AppBar = ({
 
                 <span className="bg-line-mid hidden h-[22px] w-px md:block" />
 
-                {showLeaguePill ? (
+                {/* On the Ranks section, RanksPanel publishes a rank list -
+                    see RankList.jsx - and that replaces the league pill
+                    rather than sitting beside it: the list is what you're
+                    scoped to there, not the league. It disappears by itself
+                    when RanksPanel unmounts, which is also what brings the
+                    league pill back. */}
+                {rankList ? (
+                    <SelectPill
+                        ariaLabel="Rank list"
+                        value={rankList.currentValue}
+                        onChange={rankList.onChange}
+                        options={rankList.options}
+                    />
+                ) : showLeaguePill ? (
                     <LeaguePill leagueID={leagueID} leagueIds={leagueIds} updateLeagueID={updateLeagueID} />
                 ) : null}
 

--- a/src/Components/LeaguePill.jsx
+++ b/src/Components/LeaguePill.jsx
@@ -1,32 +1,21 @@
+import SelectPill from './Pill';
+
 // The league switcher, styled as a pill. Still a plain `<select>` under the
-// hood - same accessibility and switching behaviour LeagueBar had - with
-// `appearance-none` to drop the native arrow and a `▾` rendered ourselves in
-// its place. Reports league ids, not names: two leagues can share a name.
+// hood - same accessibility and switching behaviour LeagueBar had - via the
+// shared SelectPill geometry (see Pill.jsx). Reports league ids, not names:
+// two leagues can share a name.
 //
 // `leagueName` isn't read here - the select already shows the current
 // league's name via its selected option, so a second copy of it would just
 // be a redundant, unused prop. It is still accepted (and still passed by
 // callers) to keep this a drop-in replacement for LeagueBar's prop shape.
-const LeaguePill = ({ leagueID, leagueIds, updateLeagueID }) => {
-    return (
-        <span className="relative inline-flex items-center">
-            <select
-                aria-label="League"
-                value={leagueID}
-                onChange={(e) => updateLeagueID(e.target.value)}
-                className="border-line text-ink max-w-[150px] appearance-none truncate rounded-full border bg-transparent py-1 pr-5 pl-2.5 text-[13px] font-semibold tracking-[-0.01em] md:max-w-none"
-            >
-                {leagueIds.map((league) => (
-                    <option key={league.league_id} value={league.league_id}>
-                        {league.name}
-                    </option>
-                ))}
-            </select>
-            <span aria-hidden="true" className="text-ink-dim pointer-events-none absolute right-2.5 text-[9px]">
-                ▾
-            </span>
-        </span>
-    );
-};
+const LeaguePill = ({ leagueID, leagueIds, updateLeagueID }) => (
+    <SelectPill
+        ariaLabel="League"
+        value={leagueID}
+        onChange={updateLeagueID}
+        options={leagueIds.map((league) => ({ value: league.league_id, label: league.name }))}
+    />
+);
 
 export default LeaguePill;

--- a/src/Components/Pill.jsx
+++ b/src/Components/Pill.jsx
@@ -1,0 +1,26 @@
+// The shared "select styled as a pill" geometry: 1px border-line, rounded-full,
+// 13px/600 truncating text, with a 9px `▾` drawn ourselves in place of the
+// native arrow (`appearance-none` drops that). LeaguePill and the top bar's
+// rank-list pill (see RankList.jsx/AppBar.jsx) both wrap a plain `<select>`
+// in exactly this shape, so it lives here once rather than twice.
+const SelectPill = ({ ariaLabel, value, onChange, options }) => (
+    <span className="relative inline-flex items-center">
+        <select
+            aria-label={ariaLabel}
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            className="border-line text-ink max-w-[150px] appearance-none truncate rounded-full border bg-transparent py-1 pr-5 pl-2.5 text-[13px] font-semibold tracking-[-0.01em] md:max-w-none"
+        >
+            {options.map((option) => (
+                <option key={option.value} value={option.value}>
+                    {option.label}
+                </option>
+            ))}
+        </select>
+        <span aria-hidden="true" className="text-ink-dim pointer-events-none absolute right-2.5 text-[9px]">
+            ▾
+        </span>
+    </span>
+);
+
+export default SelectPill;

--- a/src/Components/PlayerInfoItem.jsx
+++ b/src/Components/PlayerInfoItem.jsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import Button from './Button';
 import ListRow from './ListRow';
 import PositionTag from './PositionTag';
 import { playerAccessibleName, playerAvailabilityText } from './playerInfoLabels.js';
@@ -66,7 +65,7 @@ const PlayerInfoItem = ({
             <div
                 role="group"
                 aria-label={accessibleName}
-                className={`m-0 flex w-full items-start gap-3 rounded-[5px] border bg-transparent px-3 py-2 ${
+                className={`bg-raised-2 rounded-row m-0 flex w-full items-start gap-3 border px-3 py-2 ${
                     isMine ? 'border-mine!' : lowConfidenceMatch ? 'border-warn!' : 'border-line'
                 }`}
             >
@@ -75,7 +74,7 @@ const PlayerInfoItem = ({
                         <select
                             value={player.player_id}
                             onChange={(e) => updatePlayerInfo(e.target.value)}
-                            className="border-line text-ink w-full appearance-none rounded-[5px] border bg-transparent px-2 py-1 text-sm"
+                            className="border-line text-ink bg-raised-2 rounded-row w-full appearance-none border px-2 py-1 text-sm"
                         >
                             {searchData.match_results.map((result) => (
                                 <option key={result[0]} value={result[0]}>{`${playerInfo[result[0]].full_name} - ${
@@ -84,8 +83,20 @@ const PlayerInfoItem = ({
                             ))}
                         </select>
                         <div className="flex gap-2">
-                            <Button text="Close" btnStyle="primary" onClick={() => setEditingPlayer(false)} />
-                            <Button text="Delete" btnStyle="alert" onClick={() => updatePlayerId(searchData, true)} />
+                            <button
+                                type="button"
+                                onClick={() => setEditingPlayer(false)}
+                                className="border-line text-ink-muted rounded-full border px-3.5 py-2 text-[13px] font-semibold"
+                            >
+                                Close
+                            </button>
+                            <button
+                                type="button"
+                                onClick={() => updatePlayerId(searchData, true)}
+                                className="border-line text-danger rounded-full border px-3.5 py-2 text-[13px] font-semibold"
+                            >
+                                Delete
+                            </button>
                         </div>
                         {(isNewRankList || lowConfidenceMatch || editingPlayer) && (
                             <div className="flex flex-col gap-1">
@@ -97,7 +108,7 @@ const PlayerInfoItem = ({
                                     type="text"
                                     onChange={(e) => setSearchValue(e.target.value)}
                                     placeholder="Manually update player"
-                                    className="border-line text-ink w-full rounded-[5px] border bg-transparent px-2 py-1 text-sm"
+                                    className="border-line text-ink bg-raised-2 rounded-row w-full border px-2 py-1 text-sm"
                                 />
                                 {searchValue.length > 2 && (
                                     <div className="flex max-h-[100px] flex-col gap-1 overflow-y-scroll">
@@ -116,7 +127,7 @@ const PlayerInfoItem = ({
                                                     type="button"
                                                     key={candidate.player_id}
                                                     onClick={() => updatePlayerInfo(candidate.player_id)}
-                                                    className="border-line text-ink hover:border-ink-muted flex w-full items-center gap-2 rounded-[4px] border px-2 py-1 text-left text-sm"
+                                                    className="border-line text-ink hover:border-ink-muted rounded-row flex w-full items-center gap-2 border px-2 py-1 text-left text-sm"
                                                 >
                                                     <span className="min-w-0 flex-1 truncate">
                                                         {candidate.full_name}
@@ -154,17 +165,19 @@ const PlayerInfoItem = ({
                         chip's text plus the manager-name/"free agent" line above,
                         not by tinting the row. */}
                     {taken && (
-                        <span className="border-line text-ink-muted shrink-0 rounded-[4px] border px-1.5 py-0.5 text-xs font-semibold">
+                        <span className="border-line text-ink-muted rounded-tag shrink-0 border px-1.5 py-0.5 text-xs font-semibold">
                             Taken
                         </span>
                     )}
                     {(!taken || isMine) && (
-                        <Button
-                            text={`${inLineup ? 'Added' : 'Add'}`}
-                            isDisabled={inLineup}
-                            btnStyle="player-add-button"
+                        <button
+                            type="button"
+                            disabled={inLineup}
                             onClick={() => addToRoster(player)}
-                        />
+                            className="bg-mine-chip text-mine shrink-0 rounded-full px-[11px] py-1.5 text-[11px] font-semibold disabled:opacity-50"
+                        >
+                            {inLineup ? 'Added' : 'Add'}
+                        </button>
                     )}
                 </div>
             </div>

--- a/src/Components/SearchFilterButton.jsx
+++ b/src/Components/SearchFilterButton.jsx
@@ -12,16 +12,12 @@ const SearchFilterButton = ({ checked, handleChange, labelName, name }) => {
             }`}
         >
             {labelName}
-            {/* The `relative` on the label above is what contains this input.
-                index.css still carries `input, select, textarea { width: 85%
-                !important }` below 767px; the old control was display:none so
-                had no box for that to stretch, but sr-only gives it a real
-                one - 319px wide, pushing the page 186px past a 375px
-                viewport. A `w-px!` utility does NOT win that fight: for
-                *important* declarations the cascade reverses layer order, so
-                index.css's `@layer base` beats anything in `@layer utilities`
-                no matter the specificity. Making the label the containing
-                block means 85% is 85% of a chip, which fits. */}
+            {/* index.css used to carry `input, select, textarea { width: 85%
+                !important }` below 767px, which would have given this
+                sr-only checkbox a real box to stretch against - the old
+                control was display:none, so it never had one to stretch.
+                That rule was deleted in step 1 of the redesign, so this is no
+                longer a live concern; sr-only is enough on its own now. */}
             <input className="sr-only" type="checkbox" checked={checked} onChange={handleChange} name={name} />
         </label>
     );

--- a/src/Panels/LeaguePanel.jsx
+++ b/src/Panels/LeaguePanel.jsx
@@ -16,12 +16,12 @@ const LeaguePanel = ({
     view,
 }) => {
     return (
-        // Panel chrome copied from RanksPanel's own conversion of `.panel` -
-        // both were `.panel` in the old sheet and must keep matching geometry.
-        // `.league-panel` only ever zeroed out the padding side of it (and lost
-        // that override on phones, where `.panel`'s `!important` rule won), so
-        // `p-0` plus the same `max-md:p-[5px]` reproduces both halves.
-        <div className="bg-raised mt-2 mr-[3px] mb-[3px] ml-[3px] flex h-full flex-1 flex-col rounded-[10px] p-0 max-md:p-[5px]">
+        // No card. The redesign puts lists directly on the ground plane -
+        // "no cards around lists" is one of design-system.md's hard rules, and
+        // the rounded `bg-raised` box this used to wear was the last of the
+        // old `.panel` chrome. Elevation is now reserved for the two surfaces
+        // that earn it: the clock card and sheets.
+        <div className="flex h-full flex-1 flex-col">
             {isLoading ? (
                 <Spinner size="panel" />
             ) : (

--- a/src/Panels/RanksPanel.jsx
+++ b/src/Panels/RanksPanel.jsx
@@ -1,16 +1,126 @@
-import { useState, useEffect } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import SearchFilterButton from '../Components/SearchFilterButton';
 import OnFocusButton from '../Components/OnFocusButton';
 import PlayerInfoItem from '../Components/PlayerInfoItem';
-import Dropdown from '../Components/Dropdown';
 import SegmentedControl from '../Components/SegmentedControl';
+import Sheet from '../Components/Sheet';
 import { auth } from '../firebase.js';
 import APP_DB_URLS from '../urls.js';
-import Button from '../Components/Button';
 import Spinner from '../Components/Spinner';
 import { isTaken, rosteredBy } from '../lib/rosterInfo.js';
 import { checkErrors, fetchRequest } from '../lib/http.js';
+import { positionClass } from './pickLabels.js';
+import { usePublishRankList } from '../RankList.jsx';
 const { APP_USERS, TYPE_PARAMS, DLF_ADP } = APP_DB_URLS;
+
+const POSITIONS = ['QB', 'RB', 'WR', 'TE', 'K', 'DEF'];
+
+const ADP_TYPE_OPTIONS = [
+    { value: 'startup_adp', label: 'Startup' },
+    { value: 'sf_startup_adp', label: 'SF startup' },
+    { value: 'rookie_adp', label: 'Rookie' },
+    { value: 'sf_rookie_adp', label: 'SF rookie' },
+];
+const ADP_TYPE_LABELS = Object.fromEntries(ADP_TYPE_OPTIONS.map((option) => [option.value, option.label]));
+
+// The defaults `filters` starts from, and what "FILTERS" (no count) means -
+// see nonDefaultFilterCount below. showTaken/showMyPlayers/showRookiesOnly/
+// showAllPlayers only: the position toggles (QB/RB/...) get their own chips
+// in the row and are never counted here.
+const DEFAULT_FLAG_FILTERS = {
+    showTaken: false,
+    showMyPlayers: true,
+    showRookiesOnly: false,
+    showAllPlayers: false,
+};
+
+const FLAG_TOGGLES = [
+    { label: 'Taken', name: 'showTaken' },
+    { label: 'My players', name: 'showMyPlayers' },
+    { label: 'Only rookies', name: 'showRookiesOnly' },
+    { label: 'All players', name: 'showAllPlayers' },
+];
+
+const positionChipClass = (active, position) =>
+    `rounded-full px-[11px] py-[7px] font-mono text-[11px] font-semibold tracking-[.08em] ${
+        active ? positionClass(position) : 'border-line text-ink-dim border'
+    }`;
+
+// The FILTERS chip's popover/sheet body - toggles plus the ADP type control.
+// Rendered twice by RanksPanel (an anchored desktop popover and a phone
+// Sheet - see the "filters" section below for why), so it's factored out
+// once here rather than kept in sync by hand in two places.
+const FiltersBody = ({ filters, updateFilters, adpType, setADPType }) => (
+    <div className="flex flex-col gap-4 p-4">
+        <div className="flex flex-row flex-wrap gap-1.5">
+            {FLAG_TOGGLES.map((filter) => (
+                <SearchFilterButton
+                    key={filter.name}
+                    name={filter.label}
+                    handleChange={() => updateFilters(filter.name, !filters[filter.name])}
+                    labelName={filter.label}
+                    checked={filters[filter.name]}
+                />
+            ))}
+        </div>
+        <div className="flex flex-col gap-2">
+            <p className="text-ink-dim m-0 font-mono text-[11px] tracking-[.08em]">ADP TYPE</p>
+            <SegmentedControl label="ADP type" options={ADP_TYPE_OPTIONS} value={adpType} onChange={setADPType} />
+        </div>
+    </div>
+);
+
+// The desktop half of the FILTERS control: anchored under the chip rather
+// than centred like Sheet, so it gets its own small close-on-Escape/
+// outside-click/focus-return handling instead of reusing Sheet's (which is
+// built around the bottom-sheet/centred-modal shape, not an anchored one).
+const FiltersDesktopPopover = ({ triggerRef, onClose, children }) => {
+    const popoverRef = useRef(null);
+
+    useEffect(() => {
+        popoverRef.current?.focus();
+        const trigger = triggerRef.current;
+        return () => {
+            trigger?.focus();
+        };
+        // Mount/unmount only, same as Sheet's own focus effect.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    useEffect(() => {
+        const onKeyDown = (event) => {
+            if (event.key === 'Escape') {
+                onClose();
+            }
+        };
+        const onPointerDown = (event) => {
+            const popover = popoverRef.current;
+            const trigger = triggerRef.current;
+            if (popover && !popover.contains(event.target) && trigger && !trigger.contains(event.target)) {
+                onClose();
+            }
+        };
+        document.addEventListener('keydown', onKeyDown);
+        document.addEventListener('mousedown', onPointerDown);
+        return () => {
+            document.removeEventListener('keydown', onKeyDown);
+            document.removeEventListener('mousedown', onPointerDown);
+        };
+    }, [onClose, triggerRef]);
+
+    return (
+        <div
+            ref={popoverRef}
+            role="dialog"
+            aria-modal="true"
+            aria-label="Filters"
+            tabIndex={-1}
+            className="border-line bg-raised rounded-card absolute top-full right-0 z-50 mt-2 hidden w-[260px] border outline-none md:block"
+        >
+            {children}
+        </div>
+    );
+};
 
 const RanksPanel = ({
     isLoading,
@@ -37,7 +147,6 @@ const RanksPanel = ({
     const [currentListVal, setCurrentListVal] = useState(defaultSelector);
     const [allRankLists, setAllRankLists] = useState({ [defaultSelector]: defaultSelectorObj });
     const [allListsVals, setAllListsVals] = useState([defaultSelector]);
-    const [rankListType, setRankListType] = useState('new');
     const [adp, setADP] = useState({});
     const [adpType, setADPType] = useState();
     const [filters, setFilters] = useState({
@@ -52,6 +161,10 @@ const RanksPanel = ({
         K: false,
         DEF: false,
     });
+    const [showPasteSheet, setShowPasteSheet] = useState(false);
+    const [filtersOpen, setFiltersOpen] = useState(false);
+    const pasteButtonRef = useRef(null);
+    const filtersChipRef = useRef(null);
 
     const startSearch = () => {
         updateRankingPlayersIdsList([]);
@@ -59,6 +172,9 @@ const RanksPanel = ({
         setIsNewRankList(true);
         startLoad(searchText);
         setSearchText('');
+        // The sheet has done its job once the list is in. Leaving it up hides
+        // the list the paste just produced behind the thing that produced it.
+        setShowPasteSheet(false);
     };
 
     const saveRankList = async () => {
@@ -120,9 +236,6 @@ const RanksPanel = ({
             if (allListsVals.length > 0) {
                 setAllListsVals(allListsVals);
                 updateRankList(defaultSelectorObj.route_name);
-                if (allListsVals.length < 2) {
-                    setRankListType('new');
-                }
             }
             console.log(updateResponse.status);
         } else {
@@ -130,15 +243,21 @@ const RanksPanel = ({
         }
     };
 
-    const updateRankList = (newListName) => {
-        setIsNewRankList(false);
-        setCurrentListVal(newListName);
-        if (newListName !== defaultSelector) {
-            updateRankingPlayersIdsList(allRankLists[newListName].rank_list);
-        } else {
-            updateRankingPlayersIdsList([]);
-        }
-    };
+    // useCallback here is ordinary hygiene, not a correctness requirement:
+    // usePublishRankList holds the handler in a ref precisely so it does not
+    // care about this identity. The body is otherwise untouched.
+    const updateRankList = useCallback(
+        (newListName) => {
+            setIsNewRankList(false);
+            setCurrentListVal(newListName);
+            if (newListName !== defaultSelector) {
+                updateRankingPlayersIdsList(allRankLists[newListName].rank_list);
+            } else {
+                updateRankingPlayersIdsList([]);
+            }
+        },
+        [allRankLists, updateRankingPlayersIdsList],
+    );
 
     const updateFilters = (filterName, filter) => {
         setFilters({ ...filters, [filterName]: filter });
@@ -226,9 +345,6 @@ const RanksPanel = ({
                 };
                 setAllRankLists(updatingRankList);
                 setAllListsVals(rankListNames);
-                if (rankListNames.length > 1) {
-                    setRankListType('saved');
-                }
             }
         };
         if (signedIn) {
@@ -238,195 +354,223 @@ const RanksPanel = ({
             setCurrentListVal(defaultSelector);
             setAllRankLists(defaultSelectorObj);
             setAllListsVals([defaultSelector]);
-            setRankListType('new');
         }
     }, [signedIn]);
 
+    // Published up to the top bar (see AppBar.jsx/RankList.jsx) so the
+    // rank-list selector can live in the pill instead of a dropdown buried in
+    // this panel. Memoised to avoid rebuilding the array every render;
+    // usePublishRankList compares it by value, so this is an optimisation
+    // rather than the thing that keeps it from looping.
+    const rankListOptions = useMemo(
+        () =>
+            allListsVals.map((list) => ({
+                value: list,
+                label: allRankLists[list] ? allRankLists[list].pretty_name : 'dunno',
+            })),
+        [allListsVals, allRankLists],
+    );
+    usePublishRankList({ options: rankListOptions, currentValue: currentListVal, onChange: updateRankList });
+
+    const filteredResults = rankingPlayersIdsList
+        .filter(filterPlayers)
+        .filter((results) =>
+            Object.entries(filters)
+                .filter((filter) => filter[1] === true)
+                .map((ar) => ar[0])
+                .includes(
+                    !filters.showAllPlayers ? playerInfo[results.match_results[0][0]].position : 'showAllPlayers',
+                ),
+        )
+        .filter((results) => (filters.showRookiesOnly ? playerInfo[results.match_results[0][0]].years_exp < 1 : true));
+
+    const adpTypeLabel = adpType ? ADP_TYPE_LABELS[adpType] : null;
+
+    const nonDefaultFilterCount =
+        Object.entries(DEFAULT_FLAG_FILTERS).filter(([name, def]) => filters[name] !== def).length + (adpType ? 1 : 0);
+
+    const showExistingListControls = !isNewRankList && currentListVal !== defaultSelector;
+
     return (
-        // Panel chrome copied from LeaguePanel rather than reinvented: both
-        // panels are `.panel` in the old sheet, and this is the surviving
-        // instance of that shared geometry now that it's gone. `mt-2` is a
-        // Tailwind spacing-scale match for the old 8px top margin; the other
-        // three sides use arbitrary 3px values because 3px isn't on the scale.
-        <div className="bg-raised mt-2 mr-[3px] mb-[3px] ml-[3px] flex h-full flex-1 flex-col rounded-[10px] pt-[5px] pr-[15px] pb-[15px] pl-[15px] max-md:p-[5px]">
+        <div className="flex h-full flex-1 flex-col gap-3.5 px-3.5 pt-5 pb-2.5">
             {isLoading ? (
                 <Spinner size="panel" />
             ) : (
                 <>
-                    <div className="flex flex-col">
-                        <p>
-                            <b>Player filters</b>
-                        </p>
-                        <div className="flex flex-row" style={{ overflow: 'scroll' }}>
-                            {['QB', 'RB', 'WR', 'TE', 'K', 'DEF'].map((pos, i) => (
-                                <SearchFilterButton
-                                    name={pos}
-                                    handleChange={() => updateFilters(pos, !filters[pos])}
-                                    labelName={pos}
-                                    key={pos + i}
-                                    checked={filters[pos]}
-                                />
-                            ))}
+                    <div className="flex items-start justify-between gap-3">
+                        <div className="min-w-0">
+                            <h2 className="text-ink m-0 text-[20px] font-bold tracking-[-0.02em]">Ranks</h2>
+                            <p className="text-ink-quiet m-0 truncate font-mono text-[11px]">
+                                {filteredResults.length} {filteredResults.length === 1 ? 'player' : 'players'}
+                                {adpTypeLabel ? ` · ${adpTypeLabel} ADP` : ''}
+                            </p>
                         </div>
-                        <div className="flex flex-row">
-                            {[
-                                { label: 'Taken', name: 'showTaken' },
-                                { label: 'My players', name: 'showMyPlayers' },
-                            ].map((filter) => (
-                                <SearchFilterButton
-                                    name={filter.label}
-                                    handleChange={() => updateFilters(filter.name, !filters[filter.name])}
-                                    labelName={filter.label}
-                                    checked={filters[filter.name]}
-                                    key={filter.name}
-                                />
-                            ))}
+                        <button
+                            type="button"
+                            ref={pasteButtonRef}
+                            onClick={() => {
+                                // Only one overlay at a time - opening this
+                                // over the filters sheet stacks two scrims and
+                                // two grab handles on top of each other.
+                                setFiltersOpen(false);
+                                setShowPasteSheet(true);
+                            }}
+                            className="bg-mine text-ground shrink-0 rounded-full px-3.5 py-2 text-[13px] font-semibold"
+                        >
+                            Paste list
+                        </button>
+                    </div>
+
+                    <div className="no-scrollbar flex flex-row gap-2 overflow-x-auto">
+                        {POSITIONS.map((position) => (
+                            <button
+                                key={position}
+                                type="button"
+                                aria-pressed={filters[position]}
+                                onClick={() => updateFilters(position, !filters[position])}
+                                className={positionChipClass(filters[position], position)}
+                            >
+                                {position}
+                            </button>
+                        ))}
+                        <div className="relative inline-block shrink-0">
+                            <button
+                                type="button"
+                                ref={filtersChipRef}
+                                aria-expanded={filtersOpen}
+                                onClick={() => {
+                                    setShowPasteSheet(false);
+                                    setFiltersOpen((open) => !open);
+                                }}
+                                className="border-line text-ink-dim rounded-full border px-[11px] py-[7px] font-mono text-[11px] font-semibold tracking-[.08em]"
+                            >
+                                FILTERS{nonDefaultFilterCount > 0 ? ` · ${nonDefaultFilterCount}` : ''}
+                            </button>
+                            {/* Rendered as two trees (anchored popover for md
+                                and up, Sheet for below it) rather than one
+                                repositioned element - the same "both exist,
+                                only one is visible" shape AppShell already
+                                uses for its section nav vs tab bar. */}
+                            {filtersOpen && (
+                                <FiltersDesktopPopover
+                                    triggerRef={filtersChipRef}
+                                    onClose={() => setFiltersOpen(false)}
+                                >
+                                    <FiltersBody
+                                        filters={filters}
+                                        updateFilters={updateFilters}
+                                        adpType={adpType}
+                                        setADPType={setADPType}
+                                    />
+                                </FiltersDesktopPopover>
+                            )}
                         </div>
-                        <div className="flex flex-row">
-                            <SearchFilterButton
-                                name={'Only rookies'}
-                                handleChange={() => updateFilters('showRookiesOnly', !filters['showRookiesOnly'])}
-                                labelName={'Only rookies'}
-                                checked={filters['showRookiesOnly']}
+                    </div>
+
+                    {filtersOpen && (
+                        // No `centerOnDesktop`, so Sheet already carries its
+                        // own `md:hidden` - this is the phone half of the
+                        // control; FiltersDesktopPopover above is the other.
+                        <Sheet title="Filters" onClose={() => setFiltersOpen(false)} triggerRef={filtersChipRef}>
+                            <FiltersBody
+                                filters={filters}
+                                updateFilters={updateFilters}
+                                adpType={adpType}
+                                setADPType={setADPType}
                             />
-                            <SearchFilterButton
-                                name={'All players'}
-                                handleChange={() => updateFilters('showAllPlayers', !filters['showAllPlayers'])}
-                                labelName={'All players'}
-                                checked={filters['showAllPlayers']}
-                            />
-                        </div>
-                        <p>
-                            <b>ADP type</b>
-                        </p>
-                        {/* Same shape as the view-toggle SegmentedControl already used in
-                            DraftPanel, reused rather than re-styled: four flat text
-                            options standing in for what used to be four `.radio-label`
-                            divs wired up by hand. */}
-                        <SegmentedControl
-                            label="ADP type"
-                            options={[
-                                { value: 'startup_adp', label: 'Startup' },
-                                { value: 'sf_startup_adp', label: 'SF startup' },
-                                { value: 'rookie_adp', label: 'Rookie' },
-                                { value: 'sf_rookie_adp', label: 'SF rookie' },
-                            ]}
-                            value={adpType}
-                            onChange={setADPType}
-                        />
-                        {signedIn && allListsVals.length > 1 && (
-                            <SegmentedControl
-                                label="Rank list source"
-                                options={[
-                                    {
-                                        value: 'new',
-                                        label: (
-                                            <>
-                                                <span className="block">New</span>
-                                                <span className="block text-xs font-normal">Rank list</span>
-                                            </>
-                                        ),
-                                    },
-                                    {
-                                        value: 'saved',
-                                        label: (
-                                            <>
-                                                <span className="block">Saved</span>
-                                                <span className="block text-xs font-normal">Rank lists</span>
-                                            </>
-                                        ),
-                                    },
-                                ]}
-                                value={rankListType}
-                                onChange={setRankListType}
-                            />
-                        )}
-                        {rankListType === 'saved' && (
-                            <div>
-                                <Dropdown currentValue={currentListVal} updateCurrentValue={updateRankList}>
-                                    {allListsVals.map((list) => (
-                                        <option key={list} value={list}>
-                                            {allRankLists[list] ? allRankLists[list].pretty_name : 'dunno'}
-                                        </option>
-                                    ))}
-                                </Dropdown>
-                                {currentListVal !== defaultSelector && (
-                                    <OnFocusButton event={deleteRankList} saveRankList={saveRankList} />
-                                )}
-                            </div>
-                        )}
-                        {rankListType === 'new' && (
-                            <>
-                                {signedIn && isNewRankList && (
-                                    <div>
-                                        <input
-                                            type="text"
-                                            placeholder="Enter new list name..."
-                                            className="border-line text-ink caret-ink-muted m-0 rounded-[10px] border-2 bg-transparent"
-                                            value={newRankListName}
-                                            onChange={(e) => setNewRankListName(e.target.value)}
-                                        />
-                                        <Button
-                                            text="Save"
-                                            btnStyle="primary"
-                                            isDisabled={newRankListName.length < 3 ? true : false}
-                                            onClick={saveRankList}
-                                        />
+                        </Sheet>
+                    )}
+
+                    {showPasteSheet && (
+                        <Sheet
+                            title="Paste list"
+                            subtitle="One player per line."
+                            onClose={() => setShowPasteSheet(false)}
+                            triggerRef={pasteButtonRef}
+                            centerOnDesktop
+                        >
+                            <div className="flex flex-col gap-3 p-4">
+                                {showExistingListControls && (
+                                    <div className="border-line rounded-row flex items-center justify-between gap-2 border p-3">
+                                        <p className="text-ink m-0 truncate text-[14px] font-semibold">
+                                            {allRankLists[currentListVal]?.pretty_name}
+                                        </p>
+                                        <OnFocusButton event={deleteRankList} saveRankList={saveRankList} />
                                     </div>
                                 )}
                                 {!isNewRankList && (
                                     <>
                                         <textarea
-                                            className="border-line text-ink caret-ink-muted mt-2 mr-[3px] h-[100px] w-[85%] rounded-[10px] border-2 bg-transparent"
+                                            className="border-line bg-raised-2 text-ink caret-ink-muted rounded-row w-full border p-3"
                                             placeholder="Copy + Paste rankings here..."
                                             value={searchText}
                                             onChange={(e) => setSearchText(e.target.value)}
                                         />
-                                        <Button
-                                            text="Submit"
-                                            btnStyle="primary-large"
-                                            isDisabled={searchText.length < 6 ? true : false}
+                                        <button
+                                            type="button"
+                                            disabled={searchText.length < 6}
                                             onClick={startSearch}
-                                        />
+                                            className="bg-mine text-ground rounded-full px-3.5 py-2 text-[13px] font-semibold disabled:opacity-50"
+                                        >
+                                            Submit
+                                        </button>
                                     </>
                                 )}
-                            </>
-                        )}
-                    </div>
-                    <div className="flex max-h-[600px] flex-col gap-0.5 overflow-x-visible overflow-y-scroll px-2">
-                        {rankingPlayersIdsList
-                            .filter(filterPlayers)
-                            .filter((results) =>
-                                Object.entries(filters)
-                                    .filter((filter) => filter[1] === true)
-                                    .map((ar) => ar[0])
-                                    .includes(
-                                        !filters.showAllPlayers
-                                            ? playerInfo[results.match_results[0][0]].position
-                                            : 'showAllPlayers',
-                                    ),
-                            )
-                            .filter((results) =>
-                                filters.showRookiesOnly ? playerInfo[results.match_results[0][0]].years_exp < 1 : true,
-                            )
-                            .map((results, i) => (
-                                <PlayerInfoItem
-                                    key={`${results.match_results[0]}${i}`}
-                                    player={playerInfo[results.match_results[0][0]]}
-                                    playerInfo={playerInfo}
-                                    rosterInfo={rosterInfo}
-                                    lineupSet={lineupSet}
-                                    isNewRankList={isNewRankList}
-                                    addToRoster={addToRoster}
-                                    updatePlayerId={updatePlayerId}
-                                    searchData={results}
-                                    adpData={adp?.[results.match_results[0][0]]?.[adpType] ?? null}
-                                    myDisplayName={myDisplayName}
-                                />
-                            ))}
-                        {notFoundPlayers.map((item, index) => (
-                            <p key={`${item}-${index}`}>{item}</p>
+                                {signedIn && isNewRankList && (
+                                    <div className="flex flex-col gap-2">
+                                        <input
+                                            type="text"
+                                            placeholder="Enter new list name..."
+                                            className="border-line bg-raised-2 text-ink caret-ink-muted rounded-row border p-3"
+                                            value={newRankListName}
+                                            onChange={(e) => setNewRankListName(e.target.value)}
+                                        />
+                                        <button
+                                            type="button"
+                                            disabled={newRankListName.length < 3}
+                                            onClick={saveRankList}
+                                            className="bg-mine text-ground rounded-full px-3.5 py-2 text-[13px] font-semibold disabled:opacity-50"
+                                        >
+                                            Save
+                                        </button>
+                                    </div>
+                                )}
+                            </div>
+                        </Sheet>
+                    )}
+
+                    <div className="flex flex-col gap-0.5 px-2">
+                        {filteredResults.map((results, i) => (
+                            <PlayerInfoItem
+                                key={`${results.match_results[0]}${i}`}
+                                player={playerInfo[results.match_results[0][0]]}
+                                playerInfo={playerInfo}
+                                rosterInfo={rosterInfo}
+                                lineupSet={lineupSet}
+                                isNewRankList={isNewRankList}
+                                addToRoster={addToRoster}
+                                updatePlayerId={updatePlayerId}
+                                searchData={results}
+                                adpData={adp?.[results.match_results[0][0]]?.[adpType] ?? null}
+                                myDisplayName={myDisplayName}
+                            />
                         ))}
+                        {notFoundPlayers.length > 0 && (
+                            <div className="flex flex-col gap-1 px-1 pt-3">
+                                <p className="text-ink-dim m-0 font-mono text-[11px]">
+                                    {notFoundPlayers.length} pasted line{notFoundPlayers.length === 1 ? '' : 's'}{' '}
+                                    matched nothing
+                                </p>
+                                {notFoundPlayers.map((item, index) => (
+                                    <p
+                                        key={`${item}-${index}`}
+                                        className="text-ink-dim m-0 truncate font-mono text-[11px]"
+                                    >
+                                        {item}
+                                    </p>
+                                ))}
+                            </div>
+                        )}
                     </div>
                 </>
             )}

--- a/src/Panels/RanksPanel.test.jsx
+++ b/src/Panels/RanksPanel.test.jsx
@@ -69,9 +69,40 @@ function renderPanel(overrides = {}) {
     return { ...props, container };
 }
 
+// The paste box moved from the page into a sheet opened by the "Paste list"
+// pill (step 6d) - every test that needs the textarea has to open it first.
+const openPasteSheet = async (user) => {
+    await user.click(screen.getByRole('button', { name: 'Paste list' }));
+};
+
+// The four flag toggles (Taken/My players/Only rookies/All players) and the
+// ADP type control both moved into the FILTERS popover (step 6e), which
+// renders as two trees at once - an anchored desktop popover and a phone
+// Sheet, both always in the DOM together the same way AppShell's section nav
+// and tab bar are (see RanksPanel.jsx's comment on FiltersDesktopPopover) -
+// so every query against something inside it comes back twice. `openFilters`
+// is idempotent (checks before clicking) so tests can call it before more
+// than one toggle in the same case without accidentally closing it again.
+const openFilters = async (user) => {
+    if (screen.queryAllByRole('checkbox', { name: 'Taken' }).length === 0) {
+        await user.click(screen.getByRole('button', { name: /^FILTERS/ }));
+    }
+};
+
 // The filter controls are <label> elements wrapping a checkbox, so the
-// accessible name is what to click rather than the label text node.
-const toggle = (user, name) => user.click(screen.getByRole('checkbox', { name }));
+// accessible name is what to click rather than the label text node. Takes
+// the first of the two (popover + sheet) matches - see openFilters above.
+const toggleFlag = async (user, name) => {
+    await openFilters(user);
+    await user.click(screen.getAllByRole('checkbox', { name })[0]);
+};
+
+// Position chips are plain toggle buttons now (aria-pressed), not checkboxes,
+// and they live in the always-visible chip row rather than behind FILTERS -
+// see RanksPanel.jsx's positionChipClass/POSITIONS.
+const togglePosition = async (user, position) => {
+    await user.click(screen.getByRole('button', { name: position }));
+};
 
 const visiblePlayers = () =>
     [FREE_AGENT, OTHERS_PLAYER, MY_PLAYER].filter((p) => screen.queryByText(p.name) !== null).map((p) => p.name);
@@ -92,6 +123,7 @@ describe('RanksPanel loading', () => {
         const user = userEvent.setup();
         const { startLoad } = renderPanel();
 
+        await openPasteSheet(user);
         await user.type(screen.getByPlaceholderText('Copy + Paste rankings here...'), 'Ja  rr Chase');
         await user.click(screen.getByRole('button', { name: 'Submit' }));
 
@@ -117,7 +149,7 @@ describe('RanksPanel player filters', () => {
     it('shows every player once Taken is on alongside My players', async () => {
         renderPanel();
 
-        await toggle(user, 'Taken');
+        await toggleFlag(user, 'Taken');
 
         expect(visiblePlayers()).toEqual([FREE_AGENT.name, OTHERS_PLAYER.name, MY_PLAYER.name]);
     });
@@ -125,7 +157,7 @@ describe('RanksPanel player filters', () => {
     it('shows only free agents when both Taken and My players are off', async () => {
         renderPanel();
 
-        await toggle(user, 'My players');
+        await toggleFlag(user, 'My players');
 
         expect(visiblePlayers()).toEqual([FREE_AGENT.name]);
     });
@@ -136,8 +168,8 @@ describe('RanksPanel player filters', () => {
         // of the league without their own roster in the way.
         renderPanel();
 
-        await toggle(user, 'Taken');
-        await toggle(user, 'My players');
+        await toggleFlag(user, 'Taken');
+        await toggleFlag(user, 'My players');
 
         expect(visiblePlayers()).toEqual([FREE_AGENT.name, OTHERS_PLAYER.name]);
     });
@@ -148,7 +180,7 @@ describe('RanksPanel player filters', () => {
         // for the TE that remains.
         renderPanel();
 
-        await toggle(user, 'WR');
+        await togglePosition(user, 'WR');
 
         expect(visiblePlayers()).toEqual([FREE_AGENT.name]);
     });
@@ -160,31 +192,76 @@ describe('RanksPanel player filters', () => {
         // underlying input.
         renderPanel();
 
-        expect(screen.getByRole('checkbox', { name: 'Taken' }).checked).toBe(false);
+        await openFilters(user);
+        expect(screen.getAllByRole('checkbox', { name: 'Taken' })[0].checked).toBe(false);
 
-        await toggle(user, 'Taken');
+        await toggleFlag(user, 'Taken');
 
-        expect(screen.getByRole('checkbox', { name: 'Taken' }).checked).toBe(true);
+        expect(screen.getAllByRole('checkbox', { name: 'Taken' })[0].checked).toBe(true);
         // WR defaults on (see the top-of-file position filter defaults) and is
-        // untouched by toggling Taken.
-        expect(screen.getByRole('checkbox', { name: 'WR' }).checked).toBe(true);
+        // untouched by toggling Taken. It's a button now (aria-pressed), not a
+        // checkbox - see togglePosition above.
+        expect(screen.getByRole('button', { name: 'WR' })).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    it('marks a position chip pressed once toggled on, with its own position colours', async () => {
+        renderPanel();
+
+        expect(screen.getByRole('button', { name: 'K' })).toHaveAttribute('aria-pressed', 'false');
+
+        await togglePosition(user, 'K');
+
+        expect(screen.getByRole('button', { name: 'K' })).toHaveAttribute('aria-pressed', 'true');
+        // Off by default and untouched by turning K on.
+        expect(screen.getByRole('button', { name: 'WR' })).toHaveAttribute('aria-pressed', 'true');
+        expect(screen.getByRole('button', { name: 'DEF' })).toHaveAttribute('aria-pressed', 'false');
+    });
+
+    it('counts non-default filters on the FILTERS chip, and shows no count when everything is default', async () => {
+        renderPanel();
+
+        // Nothing has been touched yet: showTaken/showMyPlayers/
+        // showRookiesOnly/showAllPlayers and adpType are all still their
+        // initial values, so the chip carries no count.
+        expect(screen.getByRole('button', { name: 'FILTERS' })).toBeTruthy();
+
+        await toggleFlag(user, 'Taken');
+
+        expect(screen.getByRole('button', { name: 'FILTERS · 1' })).toBeTruthy();
+
+        await toggleFlag(user, 'Only rookies');
+
+        expect(screen.getByRole('button', { name: 'FILTERS · 2' })).toBeTruthy();
+
+        // My players defaults to true, so turning it off is a third
+        // non-default filter, not a fourth toggle back toward zero.
+        await toggleFlag(user, 'My players');
+
+        expect(screen.getByRole('button', { name: 'FILTERS · 3' })).toBeTruthy();
     });
 });
 
 describe('RanksPanel ADP type picker', () => {
-    it('has no ADP type selected by default, then reflects the pressed option', async () => {
+    it('has no ADP type selected by default, then reflects the pressed option, and counts toward FILTERS', async () => {
         // adpType starts as undefined - no `.radio-label.checked` div in the old
         // markup, no `aria-pressed` segment here - and a click should move
-        // exactly one segment into the pressed state.
+        // exactly one segment into the pressed state. The control now lives in
+        // the FILTERS popover, which renders twice (desktop popover + phone
+        // sheet) - see openFilters/toggleFlag above - so every query takes the
+        // first of the two matches.
         const user = userEvent.setup();
         renderPanel();
 
-        expect(screen.getByRole('button', { name: 'Startup' })).toHaveAttribute('aria-pressed', 'false');
-        expect(screen.getByRole('button', { name: 'Rookie' })).toHaveAttribute('aria-pressed', 'false');
+        await openFilters(user);
 
-        await user.click(screen.getByRole('button', { name: 'Rookie' }));
+        expect(screen.getAllByRole('button', { name: 'Startup' })[0]).toHaveAttribute('aria-pressed', 'false');
+        expect(screen.getAllByRole('button', { name: 'Rookie' })[0]).toHaveAttribute('aria-pressed', 'false');
+        expect(screen.getByRole('button', { name: 'FILTERS' })).toBeTruthy();
 
-        expect(screen.getByRole('button', { name: 'Rookie' })).toHaveAttribute('aria-pressed', 'true');
-        expect(screen.getByRole('button', { name: 'Startup' })).toHaveAttribute('aria-pressed', 'false');
+        await user.click(screen.getAllByRole('button', { name: 'Rookie' })[0]);
+
+        expect(screen.getAllByRole('button', { name: 'Rookie' })[0]).toHaveAttribute('aria-pressed', 'true');
+        expect(screen.getAllByRole('button', { name: 'Startup' })[0]).toHaveAttribute('aria-pressed', 'false');
+        expect(screen.getByRole('button', { name: 'FILTERS · 1' })).toBeTruthy();
     });
 });

--- a/src/RankList.jsx
+++ b/src/RankList.jsx
@@ -1,0 +1,84 @@
+import { createContext, useContext, useEffect, useMemo, useRef, useState } from 'react';
+
+// Which rank list the Ranks section is scoped to, read by AppBar so it can
+// swap the league pill for a rank-list pill. The state itself is owned by
+// RanksPanel - see usePublishRankList below for why it stays there instead of
+// moving up, which mirrors SyncStatus.jsx's reasoning almost exactly.
+//
+// `null` (rather than a default object) means "no provider", which is how
+// useRankList tells that case apart from "a provider with nothing published".
+const RankListContext = createContext(null);
+
+export const RankListProvider = ({ children }) => {
+    const [rankList, setRankList] = useState(null);
+    // The published `onChange` lives in a ref, not in state - see
+    // usePublishRankList for why that distinction is load-bearing.
+    const onChangeRef = useRef(() => {});
+    const value = useMemo(() => ({ rankList, setRankList, onChangeRef }), [rankList]);
+    return <RankListContext.Provider value={value}>{children}</RankListContext.Provider>;
+};
+
+// Read-only access for the top bar. `null` means "nothing to show here" -
+// either RanksPanel has never mounted, or it just unmounted - and AppBar
+// falls back to the league pill in both cases.
+export const useRankList = () => {
+    const context = useContext(RankListContext);
+    if (!context?.rankList) {
+        return null;
+    }
+    const { rankList, onChangeRef } = context;
+    // Re-wrapped rather than handed over directly so the caller always reaches
+    // the current handler, not whichever one happened to be published when
+    // this value was last written.
+    return { ...rankList, onChange: (value) => onChangeRef.current(value) };
+};
+
+// Publishes the saved-list selector up to the provider, for RanksPanel, which
+// owns `currentListVal`/`allRankLists`/`allListsVals`/`updateRankList` itself
+// and only needs the shell above it to see them. Lifting that state into App
+// was the more obvious shape and the wrong one, for the same reason
+// SyncStatus.jsx gives for isSyncing: RanksPanel unmounts whenever the user
+// switches to another section, and the top bar has to stop showing its pill at
+// exactly that moment rather than keep showing a selector for a panel that is
+// no longer on screen. The cleanup below is what does that.
+//
+// The rest of this is about not looping. Publishing writes to the provider,
+// which re-renders every consumer including the publisher - so if the effect
+// depended on the *identity* of `options` or `onChange`, a caller that rebuilt
+// either inline would refire it every render, forever. SyncStatus gets away
+// with a plain dependency because it publishes one boolean; this publishes an
+// array and a function.
+//
+// So neither identity is a dependency. `onChange` goes into a ref, which
+// updates without a render. `options` is compared by value through a
+// serialised key, so an equal-but-new array is a no-op. That makes the hook
+// safe for any caller rather than only for one that remembers to memoise -
+// which the first version was not, and it hung the test worker rather than
+// failing an assertion.
+export const usePublishRankList = ({ options, currentValue, onChange }) => {
+    const context = useContext(RankListContext);
+    const setRankList = context?.setRankList;
+    const onChangeRef = context?.onChangeRef;
+
+    useEffect(() => {
+        if (onChangeRef) {
+            onChangeRef.current = onChange;
+        }
+    });
+
+    const optionsKey = JSON.stringify(options ?? null);
+
+    useEffect(() => {
+        if (!setRankList) {
+            return;
+        }
+        setRankList({ options: JSON.parse(optionsKey), currentValue });
+    }, [optionsKey, currentValue, setRankList]);
+
+    useEffect(() => {
+        if (!setRankList) {
+            return undefined;
+        }
+        return () => setRankList(null);
+    }, [setRankList]);
+};

--- a/src/RankList.test.jsx
+++ b/src/RankList.test.jsx
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RankListProvider, useRankList, usePublishRankList } from './RankList';
+
+const OPTIONS = [
+    { value: 'default', label: '-- Select saved ranks list' },
+    { value: 'rookies_v3', label: '2026 Rookie Ranks v3' },
+];
+
+const Publisher = ({ currentValue }) => {
+    usePublishRankList({ options: OPTIONS, currentValue, onChange: () => {} });
+    return null;
+};
+
+const Consumer = () => {
+    const rankList = useRankList();
+    return <div data-testid="status">{rankList ? rankList.currentValue : 'none'}</div>;
+};
+
+// `showPublisher` unmounts Publisher without unmounting Consumer, which is
+// the shape that matters: RanksPanel (Publisher here) unmounts on its own
+// whenever the user switches sections, while the top bar (Consumer) stays on
+// screen and has to notice - the same reasoning SyncStatus.test.jsx exercises
+// for isSyncing.
+const Harness = ({ showPublisher, currentValue }) => (
+    <RankListProvider>
+        {showPublisher ? <Publisher currentValue={currentValue} /> : null}
+        <Consumer />
+    </RankListProvider>
+);
+
+describe('RankList', () => {
+    it('reports no rank list with no publisher mounted', () => {
+        render(<Harness showPublisher={false} />);
+
+        expect(screen.getByTestId('status')).toHaveTextContent('none');
+    });
+
+    it('reports whatever the publisher publishes', () => {
+        render(<Harness showPublisher={true} currentValue="rookies_v3" />);
+
+        expect(screen.getByTestId('status')).toHaveTextContent('rookies_v3');
+    });
+
+    it('clears back to null when the publisher unmounts, even if it had published a list', () => {
+        const { rerender } = render(<Harness showPublisher={true} currentValue="rookies_v3" />);
+        expect(screen.getByTestId('status')).toHaveTextContent('rookies_v3');
+
+        rerender(<Harness showPublisher={false} currentValue="rookies_v3" />);
+
+        expect(screen.getByTestId('status')).toHaveTextContent('none');
+    });
+
+    it('reads no rank list when used with no provider at all', () => {
+        render(<Consumer />);
+
+        expect(screen.getByTestId('status')).toHaveTextContent('none');
+    });
+
+    // The regression this file was written by: publishing re-renders every
+    // consumer, the publisher included, so an effect keyed off the identity of
+    // `options` or `onChange` refires forever for any caller that builds
+    // either inline. The first version of the hook did exactly that and hung
+    // the test worker until it ran out of memory rather than failing an
+    // assertion - so this publisher deliberately passes a brand new array and
+    // a brand new function on every single render.
+    it('does not loop when the publisher rebuilds its options and handler every render', () => {
+        let renders = 0;
+        const UnstablePublisher = () => {
+            renders += 1;
+            usePublishRankList({
+                options: [{ value: 'rookies_v3', label: '2026 Rookie Ranks v3' }],
+                currentValue: 'rookies_v3',
+                onChange: () => {},
+            });
+            return null;
+        };
+
+        render(
+            <RankListProvider>
+                <UnstablePublisher />
+                <Consumer />
+            </RankListProvider>,
+        );
+
+        expect(screen.getByTestId('status')).toHaveTextContent('rookies_v3');
+        // One render to publish, one for the provider's resulting state
+        // change, and StrictMode-free rendering adds nothing else. A loop
+        // would be in the thousands before the worker died.
+        expect(renders).toBeLessThan(5);
+    });
+
+    it('reaches the latest onChange rather than the one published first', async () => {
+        const calls = [];
+        const LatestHandlerPublisher = ({ tag }) => {
+            usePublishRankList({
+                options: OPTIONS,
+                currentValue: 'rookies_v3',
+                onChange: () => calls.push(tag),
+            });
+            return null;
+        };
+        const Invoker = () => {
+            const rankList = useRankList();
+            return (
+                <button type="button" onClick={() => rankList?.onChange('x')}>
+                    change
+                </button>
+            );
+        };
+
+        const { rerender } = render(
+            <RankListProvider>
+                <LatestHandlerPublisher tag="first" />
+                <Invoker />
+            </RankListProvider>,
+        );
+        rerender(
+            <RankListProvider>
+                <LatestHandlerPublisher tag="second" />
+                <Invoker />
+            </RankListProvider>,
+        );
+
+        await userEvent.click(screen.getByRole('button', { name: 'change' }));
+
+        expect(calls).toEqual(['second']);
+    });
+});

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -221,6 +221,19 @@
      * attribute DraftGrid sets on its table root, and the component consumes
      * them through arbitrary-value utilities (`w-[var(--cell-w)]` etc).
      */
+    /*
+     * The chip rows scroll horizontally when they overflow, but the scrollbar
+     * itself is chrome the design does not have - and on a 14px-tall strip of
+     * chips it reads as a rule under them rather than as an affordance.
+     */
+    .no-scrollbar {
+        scrollbar-width: none;
+    }
+
+    .no-scrollbar::-webkit-scrollbar {
+        display: none;
+    }
+
     .draft-grid[data-zoom='overview'] {
         --cell-w: 23px;
         --cell-h: 23px;


### PR DESCRIPTION
Step 6. Eight stacked control groups — position chips, taken/mine chips, rookies/all chips, an ADP segmented control, a list-source segmented control, a saved-list dropdown, a textarea and a submit button — become a title block, one chip row, and two overlays.

**No data logic moved.** `filterPlayers`, the ADP effect, `getSavedRankLists`, `saveRankList`, `deleteRankList` and the filter semantics are untouched.

- **Saved-list selector → the top bar pill**, replacing the league pill while you're on Ranks. Position chips wear their own tinted position colours when on. `FILTERS · n` counts non-default filters and opens a sheet holding the four toggles plus the ADP type. `Paste list` opens the textarea, the save-as-new-list flow, and the delete action as a sheet.
- **The panels lose their `bg-raised` card** — "no cards around lists" is one of `design-system.md`'s hard rules, and that rounded box was the last of the old `.panel` chrome.

**The interesting failure.** Getting the list selector into the top bar is the same "state lives three levels down but the shell has to see it" problem `SyncStatus` solved, so `RankList.jsx` solves it the same way. But the first version **deadlocked**: publishing re-renders every consumer *including the publisher*, so an effect keyed off the identity of `options` or `onChange` refires forever for any caller that builds either inline. It didn't fail an assertion — it hung the vitest worker until it ran out of memory, taking the suite from 4s to 175s and silently skipping 4 tests.

`SyncStatus` gets away with a plain dependency because it publishes one boolean. This publishes an array and a function, so now `onChange` lives in a ref (updates without a render) and `options` is compared by value through a serialised key. The hook is safe for **any** caller rather than only for one that remembers to memoise — which is the point, since the next caller won't know the rule. The regression test passes a brand new array and a brand new function on every single render.

Four smaller things found in the browser and fixed: submitting a pasted list left its own sheet open on top of the list it had just produced; opening Filters over Paste stacked two scrims and two grab handles; `1 players`; and the chip row rendered a horizontal scrollbar that read as a rule beneath the chips.

Verified at 375 and 1280: pill swaps to the rank list and back on navigation, `FILTERS · 1` tracks a toggled filter, both sheets open and close, paste → submit → list renders.

All six gates green; 343 → 351 tests, suite back to 3.7s.