### PR TITLE
Restyle the last components, and take the QB hue off destructive actions

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -496,16 +496,22 @@ class App extends React.Component {
                                         onSignIn={this.googleSignIn}
                                         onSignOut={this.signOut}
                                     />
-                                    {loadError ? (
-                                        <ErrorBanner message={loadError} onRetry={this.retryLeagueLoad} />
-                                    ) : null}
-                                    {!loadError && draftWarning ? (
-                                        <ErrorBanner
-                                            message={draftWarning}
-                                            variant="warning"
-                                            onRetry={this.retryDraftLoad}
-                                        />
-                                    ) : null}
+                                    {/* The banner is a card, so it needs the
+                                        screen's own gutter around it rather
+                                        than sitting flush to the viewport
+                                        edges with its corners rounded. */}
+                                    <div className="p-3.5 md:p-4">
+                                        {loadError ? (
+                                            <ErrorBanner message={loadError} onRetry={this.retryLeagueLoad} />
+                                        ) : null}
+                                        {!loadError && draftWarning ? (
+                                            <ErrorBanner
+                                                message={draftWarning}
+                                                variant="warning"
+                                                onRetry={this.retryDraftLoad}
+                                            />
+                                        ) : null}
+                                    </div>
                                 </>
                             )}
                         </div>

--- a/src/Components/AppShell.jsx
+++ b/src/Components/AppShell.jsx
@@ -62,7 +62,7 @@ const AppShell = ({
                 {/* Above `main` rather than inside it: `main` turns into a row
                     at md, and a banner in there would become a column beside
                     the section instead of a strip across the top of it. */}
-                {banner}
+                <div className="px-3.5 pt-3.5 md:p-0">{banner}</div>
                 <main className="order-2 flex flex-1 flex-col gap-4 pb-[var(--tab-bar-h)] md:order-2 md:flex-row md:pb-0">
                     <div className="min-w-0 flex-1">{renderSection(activeId)}</div>
                     {/* Wide screens only. `hidden md:block` rather than a JS width

--- a/src/Components/Button/Button.tsx
+++ b/src/Components/Button/Button.tsx
@@ -8,49 +8,45 @@ interface Props {
     isDisabled: boolean;
 }
 
-// The disabled overrides carry `!` (Tailwind's important modifier) because
-// Tailwind orders utilities by utility group rather than by class-string
-// order, so :disabled has to beat the hover rules below it regardless of
-// which one the cascade would otherwise prefer.
-const BASE =
-    'text-ink border border-ink-muted rounded-[5px] min-w-max mb-[7px] hover:scale-[1.02] motion-reduce:hover:transform-none disabled:scale-100! disabled:border-line! disabled:text-line!';
+// Shape and type are shared by every variant: rounded-full, 13px/600,
+// px-3.5 py-2. No margins here at all - call sites space buttons with the
+// flex/gap they already have, same as every other converted component.
+// No `scale()` hover anywhere in this file (a hard rule) - a fill button
+// shifts its own background on hover, an outlined one shifts border/text.
+const BASE = 'min-w-max rounded-full px-3.5 py-2 text-[13px] font-semibold transition-colors disabled:opacity-50';
 
 // One entry per value `btnStyle` is called with at a call site today. Keyed
 // by the exact string (or, for the "variant plus modifier" form, by each
 // space-separated token individually - see btnClass below) so a lookup miss
 // is a real bug rather than a silently-unstyled button.
 //
-// `alert` fills with the `qb` token, not a `danger` token: #ff2a6d is the QB
-// position colour (see theme.css), reused here as a destructive-action
-// signal. That collision predates this change and is left alone - flagged in
-// the PR, not fixed here.
+// `alert` now fills with `bg-danger`, not the `qb` token: the old version
+// reused #ff2a6d, the QB position colour (see theme.css), as a destructive-
+// action signal - the design system calls that collision out by name and
+// asks for `--raw-danger` instead. `text-ground` on the danger fill measures
+// 6.47:1 (danger #ff5f56 against ground #0a0e14's near-black ink token) -
+// comfortably past AA, same reasoning the old QB fill used.
 //
-// A handful of these carry `!`. Tailwind utilities aren't ordered by where
-// they appear in the class string - the generated stylesheet orders them by
-// utility group - so `bg-transparent` from BASE compiles *after* `bg-line`
-// and silently wins even though `bg-line` reads later in the className.
-// Verified against the running app: without `!` here, "Sync draft"'s active
-// state and the alert/invert buttons rendered with BASE's colours instead of
-// their own. `!` is the same fix already used below for the disabled state.
+// `active` is the outlined/"engaged" shape (border-line, text-ink-muted,
+// transparent) - used standalone (OnFocusButton's Save) and stacked onto
+// `primary-large` for the live-sync toggle's "on" state, where the filled
+// primary button ("Sync draft") becomes outlined ("Stop sync") once syncing
+// starts. Its three overrides carry `!`: Tailwind orders utilities by group
+// rather than by class-string order, so `primary-large`'s `bg-mine`/
+// `text-ground` would otherwise silently win over `active`'s
+// `bg-transparent`/`text-ink-muted` regardless of which token reads later in
+// the merged className. Verified against the running app: without `!` here,
+// "Stop sync" rendered filled violet instead of outlined. Same fix already
+// established for the disabled state below.
+//
+// `player-add-button` and `primary-invert` are gone - PlayerInfoItem, their
+// only caller, was converted off Button entirely in an earlier step, so
+// nothing in the app calls either any more.
 const VARIANTS: Record<string, string> = {
-    primary: 'hover:text-ink hover:border-ink-muted',
-    'primary-large': 'w-4/5 text-center mt-2 mb-[15px] text-base h-[30px] hover:text-ink hover:border-ink-muted',
-    // `text-ground!` because BASE's light ink on the QB fill measured 3.07:1
-    // in a browser - below AA. Every position chip already puts near-black on
-    // these fills (5.0:1 on QB, the palette's floor), so this only brings the
-    // button in line with them. Whether a destructive action should be wearing
-    // the QB *hue* at all is the separate open decision noted above.
-    alert: 'bg-qb! border-qb! text-ground! hover:scale-[1.05]!',
-    active: 'bg-line! border-ink-muted overflow-hidden hover:text-ink',
-    // `player-add-button` used to invert - `text-ground! border-ground!` - and
-    // it was legible only because PlayerInfoItem's row was filled with a
-    // position colour behind it. That fill was the availability encoding that
-    // failed AA, and removing it left this button dark-on-dark: measured at
-    // 1.16:1 in a browser, effectively invisible. It takes BASE's ink now.
-    // `primary-invert` went the same way and is gone entirely - PlayerInfoItem
-    // was its only caller, so nothing renders on a coloured ground any more.
-    'player-add-button':
-        'hover:text-ink hover:border-ink-muted self-center justify-self-end text-center w-[45px] mt-2 mb-0! ml-[3px]',
+    primary: 'bg-mine text-ground hover:bg-mine/90',
+    'primary-large': 'bg-mine text-ground hover:bg-mine/90 w-full text-center',
+    alert: 'bg-danger text-ground hover:bg-danger/90',
+    active: 'border border-line! text-ink-muted! bg-transparent! hover:text-ink! hover:border-ink-muted!',
 };
 
 export const Button = ({ text, onClick, btnStyle = 'primary', isDisabled = false }: Props): React.JSX.Element => {

--- a/src/Components/ErrorBanner.jsx
+++ b/src/Components/ErrorBanner.jsx
@@ -13,23 +13,27 @@ import Button from './Button';
 // unreachable, and a sabotage that made the button unconditional passed the
 // whole suite. Untested speculative generality is worse than the one-line
 // change it would save if a retryless notice ever turns up.
-// First component converted onto Tailwind. The 10px radius, 15px padding and 3px
-// margins are legacy geometry carried over verbatim to keep this change
-// invisible; they become scale values when the shell is rebuilt.
-//
-// The border style is set on the left edge specifically, via an arbitrary
-// value, rather than with the `border-solid` utility, which applies to all
-// four sides.
-const BANNER =
-    'mx-[3px] mt-2 mb-[3px] flex flex-row flex-wrap items-center justify-between gap-3 rounded-[10px] border-l-4 [border-left-style:solid] bg-raised px-[15px] py-3';
+// The shell is rebuilt now, so the legacy 10px radius / 15px padding / 3px
+// margins carried over verbatim from this component's original stylesheet
+// conversion become the scale values the shell already uses elsewhere:
+// `rounded-card`, a raised surface, a 1px `border-line` shell, and a 6px
+// leading dot in the variant's tone (danger/warn) instead of the old 4px
+// left border - the dot marks the banner's tone without needing a
+// border-side utility of its own.
+const BANNER = 'border-line bg-raised rounded-card flex flex-row flex-wrap items-center gap-3 border p-4';
+
+const DOT_TONE = {
+    warning: 'bg-warn',
+    error: 'bg-danger',
+};
 
 const ErrorBanner = ({ message, onRetry, variant = 'error' }) => {
-    const className = `${BANNER} ${variant === 'warning' ? 'border-l-warn' : 'border-l-danger'}`;
     const role = variant === 'warning' ? 'status' : 'alert';
     return (
-        <div className={className} role={role}>
-            <p className="m-0">{message}</p>
-            <Button text="Retry" btnStyle="primary" onClick={onRetry} />
+        <div className={BANNER} role={role}>
+            <span aria-hidden="true" className={`h-1.5 w-1.5 shrink-0 rounded-full ${DOT_TONE[variant]}`} />
+            <p className="text-ink m-0 flex-1">{message}</p>
+            <Button text="Retry" btnStyle="active" onClick={onRetry} />
         </div>
     );
 };

--- a/src/Components/OnFocusButton.jsx
+++ b/src/Components/OnFocusButton.jsx
@@ -8,7 +8,7 @@ const OnFocusButton = ({ event, ...rest }) => {
         <>
             {!isFocused && <Button text="Edit" onClick={() => setIsFocused(true)} btnStyle="primary" />}
             {isFocused && (
-                <div>
+                <div className="flex flex-row gap-2">
                     <Button text="Delete" onClick={event} btnStyle="alert" />
                     <Button
                         text="Save"

--- a/src/Components/SegmentedControl.jsx
+++ b/src/Components/SegmentedControl.jsx
@@ -1,8 +1,17 @@
 // A two-state (or more) segmented control. Used both for the Feed/Grid
 // toggle in DraftPanel and the Overview/Readable zoom switch in DraftGrid -
 // pulled out here rather than written twice so the two don't drift apart.
+//
+// Labels are uppercased with the `uppercase` CSS class, never by changing the
+// label strings themselves - one call site (DraftGrid's zoom switch) passes
+// mixed-case React text, and tests/accessible names key off the text as
+// written, not as rendered.
 const SegmentedControl = ({ label, options, value, onChange }) => (
-    <div role="group" aria-label={label} className="border-line m-0 inline-flex gap-0.5 rounded-[6px] border p-0.5">
+    <div
+        role="group"
+        aria-label={label}
+        className="bg-raised border-line-mid inline-flex gap-0.5 rounded-full border p-0.5"
+    >
         {options.map((option) => (
             <button
                 key={option.value}
@@ -13,10 +22,8 @@ const SegmentedControl = ({ label, options, value, onChange }) => (
                 // is reserved for "yours" - your picks, your slots, your turn - so
                 // a filled violet segment would say this view belongs to you.
                 // Same rule that took the old teal fill off the filter chips.
-                className={`min-h-11 rounded-[4px] px-3 py-1 text-sm ${
-                    value === option.value
-                        ? 'border-ink-muted! bg-line! text-ink! border font-semibold'
-                        : 'text-ink-muted'
+                className={`min-h-11 rounded-full px-3 py-1.5 font-mono text-[11px] font-semibold tracking-[.06em] uppercase ${
+                    value === option.value ? 'bg-selected text-ink' : 'text-ink-muted'
                 }`}
             >
                 {option.label}

--- a/src/Components/Spinner.jsx
+++ b/src/Components/Spinner.jsx
@@ -14,8 +14,15 @@ const SIZING = {
         label: 'Loading your leagues',
     },
     panel: {
-        wrapper: 'flex items-center justify-center py-6',
-        ring: 'h-10 w-10 border-4',
+        // A row-sized box - three ListRow single-line rows (46px each) -
+        // rather than a fixed py-6 wrapper, so the panel that will hold rows
+        // once loading finishes already occupies the space they'll land in
+        // and the page doesn't jump when they arrive. border-4 read heavy at
+        // this box's 40px scale (the ring nearly touched itself in the
+        // middle); border-2 keeps the same two tokens legible without
+        // looking like a solid disc.
+        wrapper: 'flex min-h-[138px] items-center justify-center',
+        ring: 'h-10 w-10 border-2',
         label: 'Loading',
     },
 };

--- a/src/Panels/DraftGrid.jsx
+++ b/src/Panels/DraftGrid.jsx
@@ -39,12 +39,24 @@ const GridCell = ({ round, pick, playerInfo, rosterData, myDisplayName, zoom, on
     const accessibleName = pickAccessibleName({ round, pick, player, manager });
     const isMade = Boolean(pick.player_id);
 
-    // A made pick fills with the position colour (near-black text on top of
-    // it); an unmade one stays a dashed, unfilled cell so the two can never be
-    // confused for one another, even at a glance in overview mode.
+    // A made pick fills with the position colour. Near-black text (`text-ground`)
+    // reads on all four skill-position fills - measured 5.55:1 (QB), 7.92:1
+    // (RB), 6.07:1 (WR), 6.93:1 (TE) against the design's raw hex values, all
+    // clearing AA and all but QB/WR clearing AAA. K/DEF (and any pick missing
+    // a position) fall back to `positionFillClass`'s neutral `bg-line`, which
+    // `text-ground` measured at only 1.36:1 on - so that one case takes
+    // `text-ink` instead, measured at 12.6:1.
+    //
+    // An unmade cell used to be a dashed, unfilled box; that reads as an
+    // "empty slot" everywhere else in the app via a quiet tint instead
+    // (`--raw-empty`, literally "a hint of a row, not a dashed box" in
+    // theme.css), so this cell uses the same token rather than its own
+    // one-off dashed treatment. Either way it stays visibly distinct from a
+    // made cell's saturated fill, even at a glance in overview mode.
+    const hasHueFill = ['QB', 'RB', 'WR', 'TE'].includes(player?.position);
     const stateClasses = isMade
-        ? `text-ground ${positionFillClass(player?.position)}`
-        : 'border border-dashed border-line text-ink-muted';
+        ? `${hasHueFill ? 'text-ground' : 'text-ink'} ${positionFillClass(player?.position)}`
+        : 'bg-empty border border-line-quiet text-ink-muted';
 
     // Violet marks "yours" as an outline, not a fill, so the position colour
     // underneath a made pick still shows through. `!` because outline and
@@ -123,8 +135,9 @@ const DraftGrid = ({
     };
 
     const headerCellClasses =
-        'border-line bg-ground text-ink sticky top-0 z-10 border p-1 text-xs font-semibold truncate';
-    const gutterCellClasses = 'border-line bg-ground text-ink sticky left-0 z-10 w-10 border p-1 text-xs font-semibold';
+        'border-line-quiet bg-ground text-ink-muted sticky top-0 z-10 border p-1 font-mono text-[11px] font-semibold tracking-[.08em] uppercase truncate';
+    const gutterCellClasses =
+        'border-line-quiet bg-ground text-ink-muted sticky left-0 z-10 w-10 border p-1 font-mono text-[11px] font-semibold tracking-[.08em] uppercase';
 
     return (
         <div>
@@ -186,7 +199,7 @@ const DraftGrid = ({
                                         return (
                                             <td
                                                 key={team.boardSpot}
-                                                className="border-line h-[var(--cell-h)] w-[var(--cell-w)] border"
+                                                className="border-line-quiet h-[var(--cell-h)] w-[var(--cell-w)] border"
                                             />
                                         );
                                     }

--- a/src/Panels/DraftPanel.jsx
+++ b/src/Panels/DraftPanel.jsx
@@ -144,17 +144,21 @@ const DraftPanel = ({ leagueData, playerInfo, rosterInfo, rankingPlayersIdsList,
                     value={currentDraftId}
                     onChange={(e) => updateDraftID(e.target.value)}
                 />
-                <Button text="Update" btnStyle="primary" onClick={getLiveDraft} />
+                <div className="mt-2">
+                    <Button text="Update" btnStyle="primary" onClick={getLiveDraft} />
+                </div>
                 <p>
                     <b>{`${currentDraft.season} ${currentDraft.player_pool} Draft`}</b>
                 </p>
                 <p>Status: {currentDraft.status}</p>
                 <PickClock draft={currentDraft} />
-                <Button
-                    text={!isSyncing ? 'Sync draft' : 'Stop sync'}
-                    btnStyle={isSyncing ? 'primary-large active' : 'primary-large'}
-                    onClick={() => setIsSyncing(!isSyncing)}
-                />
+                <div className="mt-2">
+                    <Button
+                        text={!isSyncing ? 'Sync draft' : 'Stop sync'}
+                        btnStyle={isSyncing ? 'primary-large active' : 'primary-large'}
+                        onClick={() => setIsSyncing(!isSyncing)}
+                    />
+                </div>
             </div>
             <div className="max-h-[600px] overflow-x-visible overflow-y-scroll">
                 {currentDraft.built_draft && (

--- a/src/Panels/RanksPanel.jsx
+++ b/src/Panels/RanksPanel.jsx
@@ -115,7 +115,7 @@ const FiltersDesktopPopover = ({ triggerRef, onClose, children }) => {
             aria-modal="true"
             aria-label="Filters"
             tabIndex={-1}
-            className="border-line bg-raised rounded-card absolute top-full right-0 z-50 mt-2 hidden w-[260px] border outline-none md:block"
+            className="border-line bg-raised rounded-card shadow-float absolute top-full right-0 z-50 mt-2 hidden w-[260px] border outline-none md:block"
         >
             {children}
         </div>

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -111,6 +111,12 @@
      * sheet sits above content the user is more likely to still be tracking
      * (the board, the lineup) than the drawer's full-page nav does. */
     --raw-scrim: rgba(7, 9, 13, 0.55);
+
+    /* Elevation is flat by default - depth comes from the surface steps and
+     * the scrim, not shadows. The one exception is a floating layer that has
+     * no scrim of its own (the rank-list popover, the Ranks FILTERS popover),
+     * which earns this shadow plus its own 1px border instead. */
+    --raw-shadow-float: 0 12px 32px rgba(3, 6, 10, 0.55);
 }
 
 /* `inline` so the utilities resolve through the variable at runtime, which is
@@ -160,6 +166,8 @@
     --color-empty: var(--raw-empty);
     --color-scrim-heavy: var(--raw-scrim-heavy);
     --color-scrim: var(--raw-scrim);
+
+    --shadow-float: var(--raw-shadow-float);
 
     /*
      * Two families, and the split is semantic rather than decorative: Archivo


### PR DESCRIPTION
Step 7, the last of the seven.

**`Button`** — the `alert` variant filled with `bg-qb`, the QB *position* colour reused as a destructive signal. `design-system.md` calls that collision out by name; it fills with `danger` now (near-black on it measures **6.47:1**). The whole component moves to the design's shapes: `rounded-full` pills at 13/600, **no margins** (call sites space their own buttons with the flex/gap they already have), no `scale()` hover, no `w-4/5`, no 45px fixed width. `player-add-button` and `primary-invert` are deleted — `PlayerInfoItem` was their only caller and came off `Button` in step 4.

The `!` modifiers that survive are the ones still doing work: `active` stacks onto `primary-large` for the sync toggle, and Tailwind orders utilities by group rather than class-string order, so without them "Stop sync" renders filled instead of outlined. The ones on `alert` are gone because `BASE` no longer sets a background to fight.

**`ErrorBanner`** — raised card, `rounded-card`, 1px border, and a 6px leading dot in `danger`/`warn` instead of the 4px left border. Its callers now give it the screen gutter: browser-checked against a forced load failure, a card flush to the viewport edge with rounded corners reads as a mistake.

**`SegmentedControl`** — pill shell, mono uppercase labels, `bg-selected` active. Uppercasing is the CSS class, not the label strings, so accessible names are unchanged. Violet stays reserved for "yours".

**`Spinner`** — panel ring drops to `border-2` (`border-4` read as a near-solid disc at 40px) and reserves three rows of height, so the page stops jumping when content arrives.

**`DraftGrid`** — tokens only. Structure, zoom stops, the explicit `calc()` table width and the `board_spot` column keying are all untouched. Unmade cells swap the dashed border for the `empty` tint.

One catch found while measuring rather than computing: near-black on the neutral K/DEF fallback fill is **1.36:1** — effectively invisible. That case takes `text-ink` (**12.6:1**); the four position fills keep near-black at 5.6–7.9:1. Same family as the invisible Add button in #133.

Also adds the design system's new floating-layer shadow token and applies it to the one surface that qualifies — the desktop `FILTERS` popover, which has no scrim of its own. Cards, sheets, rails and rows stay flat.

All six gates green; 351 tests unchanged.

**Note:** the last two PRs' preview deploys fail on `channel quota reached` — the Firebase project is out of preview channels. Every gate (lint/format/typecheck/tests/build) passes; only the ephemeral preview deploy is red. Pruning old channels in the Firebase console will clear it.