### PR TITLE
Lock the page behind an open sheet so iOS scrolls the sheet, not the page

### DIFF
--- a/src/Components/Drawer.jsx
+++ b/src/Components/Drawer.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { useBodyScrollLock } from '../useBodyScrollLock.js';
 import { SECTIONS, PLANNED_SECTIONS } from '../sections.js';
 import { avatarInitials } from './avatarInitials.js';
 
@@ -27,6 +28,8 @@ const Drawer = ({
     onSignOut,
 }) => {
     const panelRef = useRef(null);
+
+    useBodyScrollLock();
 
     useEffect(() => {
         panelRef.current?.focus();

--- a/src/Components/Sheet.jsx
+++ b/src/Components/Sheet.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { useBodyScrollLock } from '../useBodyScrollLock.js';
 
 // Focusable elements worth trapping Tab within - close enough to the real
 // definition for a sheet's contents (rows, chips, an input, buttons) without
@@ -21,6 +22,8 @@ const FOCUSABLE_SELECTOR =
 // the set of focusable things in any of these three callers is short.
 const Sheet = ({ title, subtitle, onClose, triggerRef, centerOnDesktop = false, children }) => {
     const panelRef = useRef(null);
+
+    useBodyScrollLock();
 
     useEffect(() => {
         panelRef.current?.focus();
@@ -100,7 +103,7 @@ const Sheet = ({ title, subtitle, onClose, triggerRef, centerOnDesktop = false, 
                         </button>
                     </div>
                 </div>
-                <div className="min-h-0 flex-1 overflow-y-auto">{children}</div>
+                <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">{children}</div>
             </div>
         </div>
     );

--- a/src/useBodyScrollLock.js
+++ b/src/useBodyScrollLock.js
@@ -1,0 +1,48 @@
+import { useEffect } from 'react';
+
+// Freezes the page behind an open overlay, and puts it back exactly where it
+// was on close. Called by Sheet and Drawer, both of which are mounted only
+// while open, so the lock rides their mount/unmount.
+//
+// `overflow: hidden` on the body alone is the usual advice and it does not
+// work on iOS Safari: the page keeps scrolling under a fixed-position
+// overlay, which is what made dragging inside the rank sheet on an iPhone
+// scroll the lineup behind it instead of the sheet's own rows. Taking the
+// body out of flow with `position: fixed` is what actually stops it - at the
+// cost of losing the scroll offset, since a fixed body jumps to the top. So
+// the offset is captured first, held as a negative `top` while the overlay is
+// up, and restored with an explicit scrollTo afterwards.
+//
+// The sheet's scrolling region also needs `overscroll-contain`, so that
+// reaching the end of the rows does not chain the gesture onward. The two are
+// complementary: containment handles the scrollable case, this handles the
+// case where the sheet's content is shorter than its box and there is nothing
+// to scroll at all.
+export function useBodyScrollLock() {
+    useEffect(() => {
+        const { body } = document;
+        const scrollY = window.scrollY;
+        const previous = {
+            position: body.style.position,
+            top: body.style.top,
+            left: body.style.left,
+            right: body.style.right,
+            width: body.style.width,
+            overflow: body.style.overflow,
+        };
+
+        body.style.position = 'fixed';
+        body.style.top = `-${scrollY}px`;
+        body.style.left = '0';
+        body.style.right = '0';
+        body.style.width = '100%';
+        body.style.overflow = 'hidden';
+
+        return () => {
+            Object.assign(body.style, previous);
+            // Instant rather than smooth: this is restoring a position the
+            // user never left, not navigating to a new one.
+            window.scrollTo(0, scrollY);
+        };
+    }, []);
+}

--- a/src/useBodyScrollLock.test.jsx
+++ b/src/useBodyScrollLock.test.jsx
@@ -1,0 +1,64 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { useBodyScrollLock } from './useBodyScrollLock.js';
+
+const Locker = () => {
+    useBodyScrollLock();
+    return null;
+};
+
+// jsdom implements neither real scrolling nor `window.scrollTo` - `scrollY`
+// stays 0 whatever you call, so the offset has to be stood up by hand for the
+// hook to have anything to capture, and the restore has to be asserted on the
+// call rather than on the resulting position.
+let scrollY = 0;
+let scrollToSpy;
+
+const setScroll = (value) => {
+    scrollY = value;
+};
+
+describe('useBodyScrollLock', () => {
+    beforeEach(() => {
+        document.body.style.cssText = '';
+        scrollY = 0;
+        vi.spyOn(window, 'scrollY', 'get').mockImplementation(() => scrollY);
+        scrollToSpy = vi.fn();
+        window.scrollTo = scrollToSpy;
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('takes the body out of flow while mounted', () => {
+        render(<Locker />);
+
+        expect(document.body.style.position).toBe('fixed');
+        expect(document.body.style.overflow).toBe('hidden');
+    });
+
+    // The half that actually bites: `position: fixed` on the body drops the
+    // page to the top, so the offset has to be held as a negative `top` and
+    // put back afterwards. Without it, opening and closing a sheet halfway
+    // down the lineup jumps the page to the top.
+    it('holds the scroll offset while locked and restores it on unmount', () => {
+        setScroll(240);
+        const { unmount } = render(<Locker />);
+
+        expect(document.body.style.top).toBe('-240px');
+
+        unmount();
+
+        expect(document.body.style.position).toBe('');
+        expect(document.body.style.top).toBe('');
+        expect(scrollToSpy).toHaveBeenCalledWith(0, 240);
+    });
+
+    it('leaves no inline styles behind after unmount', () => {
+        const { unmount } = render(<Locker />);
+        unmount();
+
+        expect(document.body.getAttribute('style')).toBe('');
+    });
+});


### PR DESCRIPTION
Fixes the reported bug: on iPhone, dragging inside the open rank sheet on the Lineup section scrolled the page behind it instead of the sheet's rows.

Two things were missing.

**Scroll chaining.** The sheet's scrolling region had no `overscroll-behavior`, so reaching either end of the rows handed the gesture on to the page. That's `overscroll-contain` on the sheet body.

**The bigger half.** iOS Safari keeps scrolling the document under a fixed-position overlay regardless of that, and `overflow: hidden` on the body — the usual advice — does not stop it. Taking the body out of flow with `position: fixed` does, at the cost of dropping the page to the top. So `useBodyScrollLock` captures the offset first, holds it as a negative `top` while the overlay is up, and restores it with an explicit `scrollTo` on the way out.

That restore is the part that breaks silently — you'd only notice the page jumping to the top after closing a sheet halfway down a lineup — so it has its own test. (jsdom implements neither real scrolling nor `scrollTo`, so the test stands the offset up by hand and asserts on the restore call.)

`Drawer` had the same gap and takes the same hook.

**Verified in a desktop browser**: the lock engages on open, releases on close, and leaves no inline styles behind. **The iOS behaviour itself I can't exercise here** — worth a check on the phone before trusting it, since that's the platform the bug is specific to.

All six gates green; 351 → 354 tests.