### PR TITLE
Make slot-tap the primary lineup path, and add a rank-list switcher

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,8 +21,22 @@ import {
 import { addPlayerToRoster, removePlayerFromLineup, toRosterSlots } from './lib/roster.js';
 import { buildLineupSet, memoizeRosterInfo } from './lib/rosterInfo.js';
 import { resolveMyDisplayName } from './lib/sleeper.js';
-import { SLEEPER_USER_ID } from './urls.js';
+import { checkErrors } from './lib/http.js';
+import { auth } from './firebase.js';
+import APP_DB_URLS, { SLEEPER_USER_ID } from './urls.js';
 import BestAvailable, { countAvailable } from './Components/BestAvailable';
+
+const { APP_USERS, TYPE_PARAMS } = APP_DB_URLS;
+
+// The rank-list switcher's "nothing saved yet" state - the same placeholder
+// RanksPanel's own selector has always shown. Lifted alongside the fetch it
+// used to own (see loadSavedRankLists below) so the switcher (in
+// LineupPanel, via the Lineup section) and the selector (in RanksPanel) read
+// off one map rather than two independently-fetched copies of it.
+const DEFAULT_RANK_LIST_SELECTOR = 'default';
+const DEFAULT_SAVED_RANK_LISTS = {
+    [DEFAULT_RANK_LIST_SELECTOR]: { pretty_name: '-- Select saved ranks list', route_name: DEFAULT_RANK_LIST_SELECTOR },
+};
 
 // What, if anything, is currently loading. These states are mutually exclusive
 // - at most one thing loads at a time - which is why this is one field rather
@@ -77,6 +91,8 @@ class App extends React.Component {
         signedInEmail: null,
         season: null,
         myDisplayName: null,
+        savedRankLists: DEFAULT_SAVED_RANK_LISTS,
+        savedRankListsLoading: false,
     };
 
     selectRosterInfo = memoizeRosterInfo();
@@ -97,9 +113,61 @@ class App extends React.Component {
         });
     }
 
+    componentDidUpdate(prevProps, prevState) {
+        // Mirrors the effect RanksPanel used to run on `[signedIn]`: a fresh
+        // sign-in fetches the saved lists, a sign-out (or the initial
+        // not-yet-signed-in render) resets to the placeholder-only map.
+        if (prevState.signedIn !== this.state.signedIn) {
+            this.loadSavedRankLists();
+        }
+    }
+
     componentWillUnmount() {
         this.unsubscribeAuth();
     }
+
+    // Lifted out of RanksPanel's getSavedRankLists effect so the rank-list
+    // switcher (LineupPanel, reached from the Lineup section) and RanksPanel's
+    // own selector can both read the same fetch's result instead of each
+    // running it independently. Uses the raw `fetch` + `checkErrors` pattern
+    // the original effect used, not `fetchRequest` - this is a GET with no
+    // body to swallow errors around, and the original never used fetchRequest
+    // here either.
+    loadSavedRankLists = async () => {
+        if (!this.state.signedIn) {
+            this.setState({ savedRankLists: DEFAULT_SAVED_RANK_LISTS, savedRankListsLoading: false });
+            return;
+        }
+        this.setState({ savedRankListsLoading: true });
+        const result = await fetch(
+            APP_USERS + auth.currentUser.uid + TYPE_PARAMS + (await auth.currentUser.getIdToken(true)),
+        )
+            .then(checkErrors)
+            .then((response) => response.json())
+            .catch((error) => {
+                console.error('Error:', error);
+                return null;
+            });
+        if (result) {
+            this.setState({
+                savedRankLists: { ...DEFAULT_SAVED_RANK_LISTS, ...result },
+                savedRankListsLoading: false,
+            });
+        } else {
+            this.setState({ savedRankListsLoading: false });
+        }
+    };
+
+    // The updater RanksPanel's saveRankList/deleteRankList call instead of
+    // mutating the map directly. Accepting either a plain value or a
+    // prevState -> nextState function mirrors setState's own dual signature -
+    // both callers need the previous value, since both build a new object
+    // from it rather than replacing the whole map.
+    updateSavedRankLists = (updater) => {
+        this.setState((prevState) => ({
+            savedRankLists: typeof updater === 'function' ? updater(prevState.savedRankLists) : updater,
+        }));
+    };
 
     // The whole load chain, from player database through to a built draft
     // board. Each step passes its result to the next as an argument instead of
@@ -289,6 +357,14 @@ class App extends React.Component {
         this.setState((prevState) => addPlayerToRoster({ player, rosterSlots: prevState.rosterSlots }));
     };
 
+    // The slot-scoped sheet's fill action: unlike addToRoster above, the
+    // target slot is already chosen (the user tapped it), so this always
+    // fills or replaces that exact index rather than searching for the first
+    // eligible open one.
+    fillSlot = (slotIndex, player) => {
+        this.setState((prevState) => addPlayerToRoster({ player, rosterSlots: prevState.rosterSlots, slotIndex }));
+    };
+
     removeFromLineup = (i) => {
         this.setState((prevState) => removePlayerFromLineup({ i, rosterSlots: prevState.rosterSlots }));
     };
@@ -390,6 +466,8 @@ class App extends React.Component {
             signedIn,
             signedInEmail,
             myDisplayName,
+            savedRankLists,
+            savedRankListsLoading,
         } = this.state;
         if (loading === LOADING.INITIAL) {
             return <Spinner size="page" />;
@@ -416,6 +494,9 @@ class App extends React.Component {
                     rankingPlayersIdsList={rankingPlayersIdsList}
                     myDisplayName={myDisplayName}
                     lineupSet={lineupSet}
+                    savedRankLists={savedRankLists}
+                    savedRankListsLoading={savedRankListsLoading}
+                    updateSavedRankLists={this.updateSavedRankLists}
                 />
             );
             return (
@@ -483,6 +564,10 @@ class App extends React.Component {
                                                 updateDraftBoard={this.updateDraftBoard}
                                                 myDisplayName={myDisplayName}
                                                 addToRoster={this.addToRoster}
+                                                fillSlot={this.fillSlot}
+                                                savedRankLists={savedRankLists}
+                                                savedRankListsLoading={savedRankListsLoading}
+                                                signedIn={signedIn}
                                             />
                                         );
                                     }}

--- a/src/Components/BestAvailable.jsx
+++ b/src/Components/BestAvailable.jsx
@@ -2,12 +2,22 @@ import { useState } from 'react';
 import ListRow from './ListRow';
 import PositionTag from './PositionTag';
 import { playerAccessibleName } from './playerInfoLabels.js';
-import { getEligiblePositions } from '../lib/roster.js';
+import { eligiblePositionsForSlot } from '../lib/roster.js';
 import { isTaken, rosteredBy } from '../lib/rosterInfo.js';
 
 const playerId = (entry) => entry.match_results[0][0];
 
-const eligibleForAny = (player, slots) => getEligiblePositions(player).some((pos) => slots.includes(pos));
+// Eligibility expressed from the slot's side, not the player's: for each slot
+// label in `slots`, ask which real positions it admits
+// (eligiblePositionsForSlot), then check whether the player's own positions
+// include any of them. A `TE` slot's admitted-positions list is `['TE']`
+// alone, so this can never let a non-TE through it - the old direction
+// (asking the player which slots it could ever fill, including every flex
+// slot its position implies, then checking whether that list intersects
+// `slots`) happened to agree in every case this app exercises, but expressed
+// the relationship backwards.
+const eligibleForAny = (player, slots) =>
+    slots.some((slot) => eligiblePositionsForSlot(slot).some((pos) => player.fantasy_positions.includes(pos)));
 
 /**
  * `entries` narrowed down to the ones with a resolvable player and (when
@@ -45,8 +55,22 @@ const chipClasses = (active) =>
 // the whole rank list unfiltered and carries no chip row at all; an array
 // (Lineup's open slot labels) filters to players eligible for at least one of
 // them and adds the chip row to narrow further to a single slot.
-const BestAvailable = ({ entries, playerInfo, rosterInfo, myDisplayName, eligibleSlots, onSelect }) => {
-    const [activeChip, setActiveChip] = useState(null);
+// `initialActiveChip` seeds which chip starts pressed - null (ALL) for the
+// bottom handle's "every open slot" entry point, a specific label for a
+// slot-tap entry that opens already scoped to the tapped slot. It only ever
+// matters at mount: LineupPanel remounts this component fresh each time the
+// sheet opens (see LineupPanel.jsx), so there is no need for this to be a
+// controlled prop that keeps tracking a later change from outside.
+const BestAvailable = ({
+    entries,
+    playerInfo,
+    rosterInfo,
+    myDisplayName,
+    eligibleSlots,
+    initialActiveChip = null,
+    onSelect,
+}) => {
+    const [activeChip, setActiveChip] = useState(initialActiveChip);
 
     // No rank list at all is the normal state for a signed-out user (or one
     // who hasn't pasted anything yet), not an edge case of an otherwise-full
@@ -93,6 +117,14 @@ const BestAvailable = ({ entries, playerInfo, rosterInfo, myDisplayName, eligibl
                     const taken = isTaken(rosterInfo, id);
                     const rosteredByName = rosteredBy(rosterInfo, id);
                     const isMine = taken && rosteredByName === myDisplayName;
+                    // "Taken" means taken *from you* - rostered by somebody
+                    // else. Your own players are the whole point of the lineup
+                    // sheet: those are the ones you can actually start, so they
+                    // keep their Add action rather than being greyed out with
+                    // everyone else's. Same rule PlayerInfoItem has always used
+                    // (`!taken || isMine`). On the draft sheet this changes
+                    // nothing, because that sheet passes no onSelect at all.
+                    const unavailable = taken && !isMine;
                     const accessibleName = playerAccessibleName({ player, taken, rosteredByName, isMine });
 
                     return (
@@ -104,7 +136,7 @@ const BestAvailable = ({ entries, playerInfo, rosterInfo, myDisplayName, eligibl
                                 ordinalWidth="20px"
                                 ordinalClassName="text-right text-[12px] text-ink-muted"
                                 name={player.full_name}
-                                nameTone={taken ? 'muted' : 'default'}
+                                nameTone={unavailable ? 'muted' : 'default'}
                                 flag={isMine ? { text: 'YOU', tone: 'mine' } : undefined}
                                 meta={
                                     <>
@@ -116,7 +148,7 @@ const BestAvailable = ({ entries, playerInfo, rosterInfo, myDisplayName, eligibl
                                 trailing={
                                     <>
                                         <PositionTag position={player.position} />
-                                        {taken ? (
+                                        {unavailable ? (
                                             <span className="text-ink-quiet shrink-0 font-mono text-[11px] font-semibold">
                                                 Taken
                                             </span>

--- a/src/Components/BestAvailable.test.jsx
+++ b/src/Components/BestAvailable.test.jsx
@@ -74,7 +74,24 @@ describe('BestAvailable', () => {
         expect(screen.getByText(FREE_AGENT.name)).toBeInTheDocument();
         expect(screen.getByText(TAKEN_BY_OTHERS.name)).toBeInTheDocument();
         expect(screen.getByText(TAKEN_BY_ME.name)).toBeInTheDocument();
-        expect(screen.getAllByText('Taken')).toHaveLength(2);
+        // Only the one on somebody else's roster. "Taken" means taken *from
+        // you* - see the next test.
+        expect(screen.getAllByText('Taken')).toHaveLength(1);
+    });
+
+    // The lineup sheet exists to fill your starting slots, and the only
+    // players you can start are the ones you already roster - so greying those
+    // out alongside every other manager's would make the sheet useless for its
+    // main job. Same rule PlayerInfoItem has always used.
+    it("keeps the action on your own rostered player and withholds it from someone else's", () => {
+        renderBestAvailable({ onSelect: vi.fn() });
+
+        const mine = screen.getByText(TAKEN_BY_ME.name).closest('li');
+        const theirs = screen.getByText(TAKEN_BY_OTHERS.name).closest('li');
+
+        expect(within(mine).getByRole('button', { name: 'Add' })).toBeInTheDocument();
+        expect(within(theirs).queryByRole('button', { name: 'Add' })).toBeNull();
+        expect(within(theirs).getByText('Taken')).toBeInTheDocument();
     });
 
     it('renders an empty state when there is no rank list at all', () => {

--- a/src/Components/RankListSwitcher.jsx
+++ b/src/Components/RankListSwitcher.jsx
@@ -1,0 +1,156 @@
+import { useEffect, useRef, useState } from 'react';
+
+const DEFAULT_ROUTE_NAME = 'default';
+
+// The outlined pill rendered in a Sheet's header (via its `headerAction`
+// slot) that lets the Lineup sheet read a different rank list than the one
+// Ranks is currently editing. `rankListId` is null for "the live session
+// list" (whatever RanksPanel currently has in rankingPlayersIdsList) or a
+// saved list's route_name; `onSelect` re-scopes in place without closing the
+// sheet - the caller (LineupPanel) is what actually re-filters the rows, this
+// component only reports the choice.
+const RankListSwitcher = ({
+    savedRankLists,
+    savedRankListsLoading,
+    signedIn,
+    rankListId,
+    onSelect,
+    onPasteNew,
+    sessionCount,
+    sessionLabel = 'Current list',
+}) => {
+    const [isOpen, setIsOpen] = useState(false);
+    const buttonRef = useRef(null);
+    const popoverRef = useRef(null);
+
+    useEffect(() => {
+        if (!isOpen) {
+            return undefined;
+        }
+        const onKeyDown = (event) => {
+            if (event.key === 'Escape') {
+                // Escape closes the popover, not the sheet underneath it -
+                // stopPropagation keeps the sheet's own Escape handler (which
+                // would otherwise also see this same keydown) from closing
+                // the whole sheet in the same keystroke.
+                event.stopPropagation();
+                setIsOpen(false);
+            }
+        };
+        const onPointerDown = (event) => {
+            const popover = popoverRef.current;
+            const button = buttonRef.current;
+            if (popover && !popover.contains(event.target) && button && !button.contains(event.target)) {
+                setIsOpen(false);
+            }
+        };
+        document.addEventListener('keydown', onKeyDown, true);
+        document.addEventListener('mousedown', onPointerDown);
+        return () => {
+            document.removeEventListener('keydown', onKeyDown, true);
+            document.removeEventListener('mousedown', onPointerDown);
+        };
+    }, [isOpen]);
+
+    // The placeholder-only entry (route_name 'default') is RanksPanel's
+    // "nothing selected yet" state, not a real saved list - it never belongs
+    // in this switcher. Signed-out users never have anything else in
+    // savedRankLists (see App.loadSavedRankLists), so filtering it out here
+    // is also what makes "signed out shows only the session list" true
+    // without a separate branch for it.
+    const savedEntries = Object.values(savedRankLists || {}).filter((list) => list.route_name !== DEFAULT_ROUTE_NAME);
+
+    const currentLabel = rankListId ? (savedRankLists?.[rankListId]?.pretty_name ?? sessionLabel) : sessionLabel;
+
+    const select = (id) => {
+        onSelect(id);
+        setIsOpen(false);
+    };
+
+    const rowNameClass = (active) => `truncate text-[13px] font-semibold ${active ? 'text-ink' : 'text-ink-muted'}`;
+    const rowDotClass = (active) => `h-1.5 w-1.5 shrink-0 rounded-full ${active ? 'bg-mine' : 'bg-transparent'}`;
+
+    return (
+        <div className="relative shrink-0">
+            {/* aria-label rather than letting the accessible name fall out of
+                the visible text: that text is "{current list name}" alone,
+                which collides with the popover's own row for the same list
+                (both would read as a button named e.g. "My Rankings") once
+                the popover is open. */}
+            <button
+                type="button"
+                ref={buttonRef}
+                aria-expanded={isOpen}
+                aria-label={`Rank list: ${currentLabel}`}
+                onClick={() => setIsOpen((open) => !open)}
+                className={`flex items-center gap-1 rounded-full border px-2.5 py-1.5 text-[12px] font-semibold ${
+                    isOpen ? 'bg-mine-chip border-mine text-mine' : 'border-line text-ink-muted'
+                }`}
+            >
+                <span className="max-w-[110px] truncate" aria-hidden="true">
+                    {currentLabel}
+                </span>
+                <span className="text-[9px]" aria-hidden="true">
+                    {isOpen ? '▴' : '▾'}
+                </span>
+            </button>
+            {isOpen && (
+                <div
+                    ref={popoverRef}
+                    role="dialog"
+                    aria-label="Choose rank list"
+                    tabIndex={-1}
+                    className="border-line bg-raised-2 shadow-float absolute top-full right-0 z-50 mt-1.5 box-border w-[236px] rounded-xl border p-1.5"
+                >
+                    <button
+                        type="button"
+                        onClick={() => select(null)}
+                        className="flex w-full items-center gap-2.5 rounded-lg p-2.5 text-left"
+                    >
+                        <span className={rowDotClass(rankListId === null)} />
+                        <span className="flex min-w-0 flex-col">
+                            <span className={rowNameClass(rankListId === null)}>{sessionLabel}</span>
+                            <span className="text-ink-quiet font-mono text-[10px]">{sessionCount} players</span>
+                        </span>
+                    </button>
+                    {signedIn && savedRankListsLoading && (
+                        <p className="text-ink-dim m-0 px-2.5 py-2 font-mono text-[10px]">Loading your lists…</p>
+                    )}
+                    {signedIn &&
+                        !savedRankListsLoading &&
+                        savedEntries.map((list) => (
+                            <button
+                                key={list.route_name}
+                                type="button"
+                                onClick={() => select(list.route_name)}
+                                className="flex w-full items-center gap-2.5 rounded-lg p-2.5 text-left"
+                            >
+                                <span className={rowDotClass(rankListId === list.route_name)} />
+                                <span className="flex min-w-0 flex-col">
+                                    <span className={rowNameClass(rankListId === list.route_name)}>
+                                        {list.pretty_name}
+                                    </span>
+                                    <span className="text-ink-quiet font-mono text-[10px]">
+                                        {(list.rank_list || []).length} players
+                                    </span>
+                                </span>
+                            </button>
+                        ))}
+                    <div className="bg-line mx-1.5 my-1 h-px" />
+                    <button
+                        type="button"
+                        onClick={() => {
+                            onPasteNew();
+                            setIsOpen(false);
+                        }}
+                        className="text-mine w-full rounded-lg p-2.5 text-left text-[13px] font-semibold"
+                    >
+                        Paste a new list
+                    </button>
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default RankListSwitcher;

--- a/src/Components/Sheet.jsx
+++ b/src/Components/Sheet.jsx
@@ -20,7 +20,7 @@ const FOCUSABLE_SELECTOR =
 // mounts that). The one thing Drawer doesn't do is trap Tab within the
 // panel - this does, via a small manual cycle rather than a library, since
 // the set of focusable things in any of these three callers is short.
-const Sheet = ({ title, subtitle, onClose, triggerRef, centerOnDesktop = false, children }) => {
+const Sheet = ({ title, subtitle, onClose, triggerRef, centerOnDesktop = false, headerAction, children }) => {
     const panelRef = useRef(null);
 
     useBodyScrollLock();
@@ -93,6 +93,7 @@ const Sheet = ({ title, subtitle, onClose, triggerRef, centerOnDesktop = false, 
                                 <p className="text-ink-quiet m-0 truncate font-mono text-[11px]">{subtitle}</p>
                             )}
                         </div>
+                        {headerAction}
                         <button
                             type="button"
                             onClick={onClose}

--- a/src/Panels/LeaguePanel.jsx
+++ b/src/Panels/LeaguePanel.jsx
@@ -13,6 +13,10 @@ const LeaguePanel = ({
     updateDraftBoard,
     myDisplayName,
     addToRoster,
+    fillSlot,
+    savedRankLists,
+    savedRankListsLoading,
+    signedIn,
     view,
 }) => {
     return (
@@ -35,6 +39,10 @@ const LeaguePanel = ({
                             rankingPlayersIdsList={rankingPlayersIdsList}
                             myDisplayName={myDisplayName}
                             addToRoster={addToRoster}
+                            fillSlot={fillSlot}
+                            savedRankLists={savedRankLists}
+                            savedRankListsLoading={savedRankListsLoading}
+                            signedIn={signedIn}
                         />
                     )}
                     {view === 'draft' && (

--- a/src/Panels/LineupPanel.jsx
+++ b/src/Panels/LineupPanel.jsx
@@ -1,8 +1,12 @@
 import { useRef, useState } from 'react';
 import SlotRow from './SlotRow';
+import { slotAccessibleName, slotOccupantLabel } from './lineupLabels.js';
 import Sheet from '../Components/Sheet';
-import BestAvailable from '../Components/BestAvailable';
+import BestAvailable, { filterBestAvailable } from '../Components/BestAvailable';
 import BestAvailableHandle from '../Components/BestAvailableHandle';
+import ListRow from '../Components/ListRow';
+import PositionTag from '../Components/PositionTag';
+import RankListSwitcher from '../Components/RankListSwitcher';
 
 const LineupPanel = ({
     playerInfo,
@@ -12,15 +16,84 @@ const LineupPanel = ({
     rankingPlayersIdsList,
     myDisplayName,
     addToRoster,
+    fillSlot,
+    savedRankLists,
+    savedRankListsLoading,
+    signedIn,
 }) => {
     const emptyCount = rosterSlots.filter((slot) => !slot.playerId).length;
-    const [isBestAvailableOpen, setIsBestAvailableOpen] = useState(false);
+    const [isSheetOpen, setIsSheetOpen] = useState(false);
+    // null while the sheet was opened from the bottom handle (every open slot
+    // selected); { index, label } while it was opened by tapping a specific
+    // slot - the two are the same view at different starting chip states, per
+    // the design, so this is the one piece of state that tells them apart
+    // rather than two separate sheets.
+    const [scope, setScope] = useState(null);
+    // null means "the live session list" (rankingPlayersIdsList); otherwise a
+    // saved list's route_name, resolved against savedRankLists below.
+    const [rankListId, setRankListId] = useState(null);
+    // Only meaningful for the handle entry point - Sheet returns focus to it
+    // on close. A slot-tap entry has no single stable trigger element to
+    // return to (each SlotRow button is one of many, re-rendered on every
+    // roster change), so triggerRef is left undefined for that path and Sheet
+    // already tolerates that (see its own optional chaining).
     const bestAvailableHandleRef = useRef(null);
 
     // The slots still worth filling, by label - the chip row and the
     // eligibility filter both key off this. Order follows rosterSlots, and
     // duplicates collapse: two open FLX slots must not produce two FLX chips.
     const openSlotLabels = [...new Set(rosterSlots.filter((slot) => !slot.playerId).map((slot) => slot.label))];
+
+    const openFromHandle = () => {
+        setScope(null);
+        setIsSheetOpen(true);
+    };
+
+    const openSlot = (index) => {
+        setScope({ index, label: rosterSlots[index].label });
+        setIsSheetOpen(true);
+    };
+
+    const closeSheet = () => setIsSheetOpen(false);
+
+    // Selecting a candidate for a slot tapped directly fills that exact slot
+    // - the user already chose it - rather than the first eligible open one,
+    // which is what the handle's un-scoped entry point still does.
+    const handleSelect = (player) => {
+        if (scope) {
+            fillSlot(scope.index, player);
+        } else {
+            addToRoster(player);
+        }
+        // The sheet stays open after a fill so several slots can be filled in
+        // a row - only Remove (below) closes it.
+    };
+
+    const handleRemove = () => {
+        removeFromLineup(scope.index);
+        closeSheet();
+    };
+
+    const entries =
+        rankListId && savedRankLists?.[rankListId] ? savedRankLists[rankListId].rank_list : rankingPlayersIdsList;
+
+    // The chip row's full set: the tapped slot's own label plus every other
+    // open slot. A tapped slot can itself be filled (that's what lets
+    // Remove/replace work), so its label is not necessarily already in
+    // openSlotLabels - union rather than reusing that list outright.
+    const sheetEligibleSlots = scope ? [...new Set([scope.label, ...openSlotLabels])] : openSlotLabels;
+    // The subtitle's count is fixed at the sheet's *initial* scope (the
+    // tapped slot alone, or every open slot for the handle) rather than
+    // tracking BestAvailable's own internal chip clicks, which this
+    // component has no view into once the chip row is live.
+    const subtitleEligibleSlots = scope ? [scope.label] : openSlotLabels;
+    const subtitleCount = filterBestAvailable({ entries, playerInfo, eligibleSlots: subtitleEligibleSlots }).length;
+
+    const occupantSlot = scope ? rosterSlots[scope.index] : null;
+    const occupantPlayer = occupantSlot?.playerId ? playerInfo[occupantSlot.playerId] : null;
+
+    const title = scope ? `Fill ${scope.label}` : 'Best available';
+    const subtitle = `${subtitleCount} eligible in this list`;
 
     return (
         <div>
@@ -51,45 +124,24 @@ const LineupPanel = ({
                         slot={slot}
                         index={i}
                         playerInfo={playerInfo}
-                        onRemove={removeFromLineup}
+                        onOpen={openSlot}
                     />
                 ))}
             </ul>
-            {/* Phone only, filtered to the slots still open - the aside
-                covers `md` and up with the desktop rail instead (see
-                AppShell / App's renderAside). Unlike Draft's read-only sheet,
-                there is an unambiguous target here: the first open slot the
-                selected player is eligible for, exactly what
-                addPlayerToRoster (src/lib/roster.js) already computes - so
-                selecting a player here is a real add, and the sheet stays
-                open afterward so several slots can be filled in a row. */}
+            {/* Phone only - the aside covers `md` and up with the desktop
+                rail instead (see AppShell / App's renderAside). This strip is
+                the bottom-handle entry point specifically; every slot row
+                above opens the same sheet directly regardless of whether
+                there is a rank list to show in it (BestAvailable's own empty
+                state covers that), so this block is not the only way in. */}
             {openSlotLabels.length > 0 &&
                 (rankingPlayersIdsList.length > 0 ? (
-                    <>
-                        <BestAvailableHandle
-                            buttonRef={bestAvailableHandleRef}
-                            isExpanded={isBestAvailableOpen}
-                            onClick={() => setIsBestAvailableOpen((open) => !open)}
-                            subtitle={`fills ${openSlotLabels.join(', ')}`}
-                        />
-                        {isBestAvailableOpen && (
-                            <Sheet
-                                title="Best available"
-                                subtitle={`fills ${openSlotLabels.join(', ')}`}
-                                onClose={() => setIsBestAvailableOpen(false)}
-                                triggerRef={bestAvailableHandleRef}
-                            >
-                                <BestAvailable
-                                    entries={rankingPlayersIdsList}
-                                    playerInfo={playerInfo}
-                                    rosterInfo={rosterInfo}
-                                    myDisplayName={myDisplayName}
-                                    eligibleSlots={openSlotLabels}
-                                    onSelect={addToRoster}
-                                />
-                            </Sheet>
-                        )}
-                    </>
+                    <BestAvailableHandle
+                        buttonRef={bestAvailableHandleRef}
+                        isExpanded={isSheetOpen && !scope}
+                        onClick={openFromHandle}
+                        subtitle={`fills ${openSlotLabels.join(', ')}`}
+                    />
                 ) : (
                     <div className="border-line bg-raised border-t md:hidden">
                         <BestAvailable
@@ -100,6 +152,63 @@ const LineupPanel = ({
                         />
                     </div>
                 ))}
+            {isSheetOpen && (
+                <Sheet
+                    title={title}
+                    subtitle={subtitle}
+                    onClose={closeSheet}
+                    triggerRef={scope ? undefined : bestAvailableHandleRef}
+                    headerAction={
+                        <RankListSwitcher
+                            savedRankLists={savedRankLists}
+                            savedRankListsLoading={savedRankListsLoading}
+                            signedIn={signedIn}
+                            rankListId={rankListId}
+                            onSelect={setRankListId}
+                            onPasteNew={() => {
+                                window.location.hash = '#/ranks';
+                            }}
+                            sessionCount={rankingPlayersIdsList.length}
+                        />
+                    }
+                >
+                    {/* A filled slot's occupant renders first, above the
+                        candidates, carrying Remove instead of Add - the same
+                        sheet opens for a filled slot as for an empty one, this
+                        row is the only difference. */}
+                    {occupantSlot?.playerId && (
+                        <div className="border-line-mid border-b px-2 py-2.5">
+                            <ListRow
+                                as="div"
+                                label={slotAccessibleName({ slot: occupantSlot, player: occupantPlayer })}
+                                name={slotOccupantLabel({ slot: occupantSlot, player: occupantPlayer })}
+                                meta={occupantPlayer?.team}
+                                trailing={
+                                    <>
+                                        {occupantPlayer && <PositionTag position={occupantPlayer.position} />}
+                                        <button
+                                            type="button"
+                                            onClick={handleRemove}
+                                            className="bg-danger/15 text-danger shrink-0 rounded-full px-[11px] py-1.5 font-mono text-[11px] font-semibold"
+                                        >
+                                            Remove
+                                        </button>
+                                    </>
+                                }
+                            />
+                        </div>
+                    )}
+                    <BestAvailable
+                        entries={entries}
+                        playerInfo={playerInfo}
+                        rosterInfo={rosterInfo}
+                        myDisplayName={myDisplayName}
+                        eligibleSlots={sheetEligibleSlots}
+                        initialActiveChip={scope ? scope.label : null}
+                        onSelect={handleSelect}
+                    />
+                </Sheet>
+            )}
         </div>
     );
 };

--- a/src/Panels/LineupPanel.test.jsx
+++ b/src/Panels/LineupPanel.test.jsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import LineupPanel from './LineupPanel';
 import { buildRosterInfo, decorateRosters } from '../lib/rosterInfo.js';
@@ -47,9 +47,12 @@ const ROSTER_SLOTS = [
     { label: 'WR', playerId: null },
 ];
 
+const SAVED_RANK_LISTS = { default: { pretty_name: '-- Select saved ranks list', route_name: 'default' } };
+
 function renderLineup(overrides = {}) {
     const removeFromLineup = vi.fn();
     const addToRoster = vi.fn();
+    const fillSlot = vi.fn();
     const { unmount } = render(
         <LineupPanel
             playerInfo={PLAYER_INFO}
@@ -59,10 +62,14 @@ function renderLineup(overrides = {}) {
             rankingPlayersIdsList={[]}
             myDisplayName={MY_DISPLAY_NAME}
             addToRoster={addToRoster}
+            fillSlot={fillSlot}
+            savedRankLists={SAVED_RANK_LISTS}
+            savedRankListsLoading={false}
+            signedIn={false}
             {...overrides}
         />,
     );
-    return { removeFromLineup, addToRoster, unmount };
+    return { removeFromLineup, addToRoster, fillSlot, unmount };
 }
 
 describe('LineupPanel', () => {
@@ -81,31 +88,33 @@ describe('LineupPanel', () => {
         expect(screen.getByText('FLX')).toBeVisible();
     });
 
-    it('renders empty slots as bare, non-interactive rows', () => {
+    it('renders every slot, filled or empty, as a real button - both open the scoped sheet now', () => {
         renderLineup();
 
-        // Empty slots have no fill-from-slot action in this app, so they are
-        // not buttons at all - only filled slots get a role of button.
-        expect(screen.queryByRole('button', { name: 'QB, empty' })).toBeNull();
-        expect(screen.queryByRole('button', { name: 'WR, empty' })).toBeNull();
-        expect(screen.getByLabelText('QB, empty')).toBeTruthy();
-        expect(screen.getByLabelText('WR, empty')).toBeTruthy();
+        // A single tap must not be destructive any more: removal moved into
+        // the sheet's own Remove action (see the describe block below), so
+        // every slot - including an empty one, which used to be a bare
+        // non-interactive row - is a button that opens it.
+        expect(screen.getByRole('button', { name: 'QB, empty' })).toBeTruthy();
+        expect(screen.getByRole('button', { name: 'WR, empty' })).toBeTruthy();
+        expect(screen.getByRole('button', { name: 'FLX, Germie Bernard, WR' })).toBeTruthy();
     });
 
-    it('calls removeFromLineup with the slot index, and ignores clicks on empty slots', async () => {
+    it('opens the slot-scoped sheet on a tap, titled for that slot, whether the slot is empty or filled', async () => {
         const user = userEvent.setup();
-        const { removeFromLineup } = renderLineup();
+        renderLineup();
 
-        // Empty slots are not buttons, so there is nothing to click - this
-        // just confirms no stray handler exists on them.
-        await user.click(screen.getByLabelText('QB, empty'));
-        expect(removeFromLineup).not.toHaveBeenCalled();
+        await user.click(screen.getByRole('button', { name: 'QB, empty' }));
+        expect(screen.getByRole('dialog', { name: 'Fill QB' })).toBeInTheDocument();
 
+        await user.click(screen.getByRole('button', { name: 'Close' }));
+        expect(screen.queryByRole('dialog')).toBeNull();
+
+        // Tapping a filled slot opens the same sheet, under the same title -
+        // the design doc is explicit that the occupant appears inside it
+        // rather than the slot getting a different sheet altogether.
         await user.click(screen.getByRole('button', { name: 'FLX, Germie Bernard, WR' }));
-        // The index is which slot gets emptied, so passing the wrong one
-        // clears someone else's.
-        expect(removeFromLineup).toHaveBeenCalledTimes(1);
-        expect(removeFromLineup).toHaveBeenCalledWith(1);
+        expect(screen.getByRole('dialog', { name: 'Fill FLX' })).toBeInTheDocument();
     });
 
     it('shows a muted count of unfilled slots, omitted entirely when zero', () => {
@@ -118,7 +127,7 @@ describe('LineupPanel', () => {
         expect(screen.queryByText(/empty$/)).toBeNull();
     });
 
-    it('renders a slot holding an id missing from the player database, and keeps it removable', async () => {
+    it('renders a slot holding an id missing from the player database, and keeps it removable via the sheet', async () => {
         const user = userEvent.setup();
         const slots = [{ label: 'TE', playerId: MISSING_ID }];
         const { removeFromLineup } = renderLineup({ rosterSlots: slots });
@@ -133,7 +142,10 @@ describe('LineupPanel', () => {
         expect(screen.getByText(`Unknown player ${MISSING_ID}`)).toBeVisible();
 
         await user.click(row);
+        await user.click(screen.getByRole('button', { name: 'Remove' }));
         expect(removeFromLineup).toHaveBeenCalledWith(0);
+        // Remove is the one action that closes the sheet - unlike a fill.
+        expect(screen.queryByRole('dialog')).toBeNull();
     });
 
     it('shows the occupant name and team on screen, and a placeholder for an unfilled slot', () => {
@@ -185,5 +197,160 @@ describe('LineupPanel best-available sheet', () => {
         // sheet - it stays open so several slots can be filled in a row.
         expect(dialog).toBeInTheDocument();
         expect(screen.getByRole('dialog', { name: 'Best available' })).toBeInTheDocument();
+    });
+});
+
+describe('LineupPanel slot-scoped sheet', () => {
+    // A free agent RB, absent from the shared fixture's actual free agents -
+    // built by hand so a TE-scoped sheet has a real "hide this one" case to
+    // assert against, rather than only a "show this one".
+    const FREE_AGENT_RB = { id: '55501', name: 'Test Runningback' };
+    const RB_PLAYER_INFO = {
+        ...PLAYER_INFO,
+        [FREE_AGENT_RB.id]: {
+            player_id: FREE_AGENT_RB.id,
+            full_name: FREE_AGENT_RB.name,
+            position: 'RB',
+            fantasy_positions: ['RB'],
+            team: 'FA',
+        },
+    };
+    const TE_AND_RB_SLOTS = [
+        { label: 'TE', playerId: null },
+        { label: 'RB', playerId: null },
+    ];
+    const TE_AND_RB_ENTRIES = [rankEntry(FREE_AGENT_TE.id, 1), rankEntry(FREE_AGENT_RB.id, 2)];
+
+    it('scopes to the tapped slot, showing an eligible TE and hiding an RB', async () => {
+        const user = userEvent.setup();
+        renderLineup({
+            rosterSlots: TE_AND_RB_SLOTS,
+            rankingPlayersIdsList: TE_AND_RB_ENTRIES,
+            playerInfo: RB_PLAYER_INFO,
+        });
+
+        await user.click(screen.getByRole('button', { name: 'TE, empty' }));
+
+        expect(screen.getByRole('dialog', { name: 'Fill TE' })).toBeInTheDocument();
+        expect(screen.getByText(FREE_AGENT_TE.name)).toBeInTheDocument();
+        expect(screen.queryByText(FREE_AGENT_RB.name)).toBeNull();
+    });
+
+    it('widens to every open slot on ALL, without dropping the underlying list', async () => {
+        const user = userEvent.setup();
+        renderLineup({
+            rosterSlots: TE_AND_RB_SLOTS,
+            rankingPlayersIdsList: TE_AND_RB_ENTRIES,
+            playerInfo: RB_PLAYER_INFO,
+        });
+
+        await user.click(screen.getByRole('button', { name: 'TE, empty' }));
+        expect(screen.queryByText(FREE_AGENT_RB.name)).toBeNull();
+
+        await user.click(screen.getByRole('button', { name: 'ALL' }));
+
+        expect(screen.getByText(FREE_AGENT_TE.name)).toBeInTheDocument();
+        expect(screen.getByText(FREE_AGENT_RB.name)).toBeInTheDocument();
+    });
+
+    it('fills the exact tapped slot on Add, not the first eligible open one', async () => {
+        const user = userEvent.setup();
+        const { fillSlot, addToRoster } = renderLineup({
+            // RB (index 0) is also open and eligible for nothing here since
+            // the rank list holds only a TE - so this also proves the fill
+            // isn't accidentally landing on RB by search order.
+            rosterSlots: [
+                { label: 'RB', playerId: null },
+                { label: 'TE', playerId: null },
+            ],
+            rankingPlayersIdsList: [rankEntry(FREE_AGENT_TE.id, 1)],
+        });
+
+        await user.click(screen.getByRole('button', { name: 'TE, empty' }));
+        await user.click(screen.getByRole('button', { name: 'Add' }));
+
+        expect(fillSlot).toHaveBeenCalledWith(1, fixturePlayerInfo[FREE_AGENT_TE.id]);
+        expect(addToRoster).not.toHaveBeenCalled();
+    });
+
+    it("replaces a filled slot's occupant on Add, via fillSlot rather than addToRoster", async () => {
+        const user = userEvent.setup();
+        const { fillSlot, addToRoster } = renderLineup({
+            rosterSlots: [{ label: 'FLX', playerId: STARTER.player_id }],
+            rankingPlayersIdsList: [rankEntry(FREE_AGENT_TE.id, 1)],
+        });
+
+        await user.click(screen.getByRole('button', { name: 'FLX, Germie Bernard, WR' }));
+        // The occupant renders first, with Remove rather than Add - scoped to
+        // the dialog, since the same name still shows in the SlotRow behind
+        // it, which stays mounted underneath the sheet.
+        const dialog = screen.getByRole('dialog', { name: 'Fill FLX' });
+        expect(within(dialog).getByText(STARTER.full_name)).toBeInTheDocument();
+        expect(within(dialog).getByRole('button', { name: 'Remove' })).toBeInTheDocument();
+
+        await user.click(within(dialog).getByRole('button', { name: 'Add' }));
+
+        expect(fillSlot).toHaveBeenCalledWith(0, fixturePlayerInfo[FREE_AGENT_TE.id]);
+        expect(addToRoster).not.toHaveBeenCalled();
+    });
+});
+
+describe('LineupPanel rank-list switcher', () => {
+    const SAVED_LIST_ID = 'my_rankings';
+    // A different QB from the fixture than FREE_AGENT_QB, so the saved
+    // list's row is distinguishable on screen from the session list's.
+    const SAVED_LIST_QB = { id: '167', name: 'Tom Brady' };
+
+    it('re-filters the rows in place on a list switch, without closing the sheet or losing the slot scope', async () => {
+        const user = userEvent.setup();
+        renderLineup({
+            rosterSlots: [{ label: 'QB', playerId: null }],
+            rankingPlayersIdsList: [rankEntry(FREE_AGENT_QB.id, 1)],
+            signedIn: true,
+            savedRankLists: {
+                ...SAVED_RANK_LISTS,
+                [SAVED_LIST_ID]: {
+                    pretty_name: 'My Rankings',
+                    route_name: SAVED_LIST_ID,
+                    rank_list: [rankEntry(SAVED_LIST_QB.id, 1)],
+                },
+            },
+        });
+
+        await user.click(screen.getByRole('button', { name: 'QB, empty' }));
+        expect(screen.getByText(FREE_AGENT_QB.name)).toBeInTheDocument();
+        expect(screen.queryByText(SAVED_LIST_QB.name)).toBeNull();
+
+        await user.click(screen.getByRole('button', { name: /^Rank list/ }));
+        await user.click(screen.getByRole('button', { name: /^My Rankings/ }));
+
+        // Still open, still scoped to QB, and now showing the saved list's
+        // player instead of the session one - a re-filter, not a reset.
+        expect(screen.getByRole('dialog', { name: 'Fill QB' })).toBeInTheDocument();
+        expect(screen.queryByText(FREE_AGENT_QB.name)).toBeNull();
+        expect(screen.getByText(SAVED_LIST_QB.name)).toBeInTheDocument();
+    });
+
+    it('shows only the session list and the paste action when signed out', async () => {
+        const user = userEvent.setup();
+        renderLineup({
+            rosterSlots: [{ label: 'QB', playerId: null }],
+            rankingPlayersIdsList: [rankEntry(FREE_AGENT_QB.id, 1)],
+            signedIn: false,
+            savedRankLists: {
+                ...SAVED_RANK_LISTS,
+                [SAVED_LIST_ID]: {
+                    pretty_name: 'My Rankings',
+                    route_name: SAVED_LIST_ID,
+                    rank_list: [rankEntry(SAVED_LIST_QB.id, 1)],
+                },
+            },
+        });
+
+        await user.click(screen.getByRole('button', { name: 'QB, empty' }));
+        await user.click(screen.getByRole('button', { name: /^Rank list/ }));
+
+        expect(screen.queryByRole('button', { name: /^My Rankings/ })).toBeNull();
+        expect(screen.getByRole('button', { name: 'Paste a new list' })).toBeInTheDocument();
     });
 });

--- a/src/Panels/RanksPanel.jsx
+++ b/src/Panels/RanksPanel.jsx
@@ -8,7 +8,7 @@ import { auth } from '../firebase.js';
 import APP_DB_URLS from '../urls.js';
 import Spinner from '../Components/Spinner';
 import { isTaken, rosteredBy } from '../lib/rosterInfo.js';
-import { checkErrors, fetchRequest } from '../lib/http.js';
+import { fetchRequest } from '../lib/http.js';
 import { positionClass } from './pickLabels.js';
 import { usePublishRankList } from '../RankList.jsx';
 const { APP_USERS, TYPE_PARAMS, DLF_ADP } = APP_DB_URLS;
@@ -135,18 +135,14 @@ const RanksPanel = ({
     updatePlayerId,
     notFoundPlayers,
     myDisplayName,
+    savedRankLists,
+    updateSavedRankLists,
 }) => {
     const defaultSelector = 'default';
-    const defaultSelectorObj = {
-        pretty_name: '-- Select saved ranks list',
-        route_name: defaultSelector,
-    };
     const [isNewRankList, setIsNewRankList] = useState(false);
     const [searchText, setSearchText] = useState('');
     const [newRankListName, setNewRankListName] = useState('');
     const [currentListVal, setCurrentListVal] = useState(defaultSelector);
-    const [allRankLists, setAllRankLists] = useState({ [defaultSelector]: defaultSelectorObj });
-    const [allListsVals, setAllListsVals] = useState([defaultSelector]);
     const [adp, setADP] = useState({});
     const [adpType, setADPType] = useState();
     const [filters, setFilters] = useState({
@@ -177,6 +173,16 @@ const RanksPanel = ({
         setShowPasteSheet(false);
     };
 
+    // savedRankLists is a prop now (lifted to App - see §6 of the redesign
+    // doc), so every write to it goes through updateSavedRankLists rather
+    // than a local setter. The old version mutated allRankLists in place
+    // (`allRankLists[newRankList].rank_list = ...`, `allRankLists[newRankList]
+    // = {}` + Object.assign) and then called setAllRankLists with that same
+    // reference - which only re-rendered anything because some other state
+    // change happened to force it. Lifted, that bug would have meant nothing
+    // downstream (the switcher, this panel's own selector) ever saw the
+    // update: React bails out of a setState whose value is `===` the
+    // previous one. Both branches below build a brand new object instead.
     const saveRankList = async () => {
         let newRankList;
         let rankListData;
@@ -189,8 +195,7 @@ const RanksPanel = ({
             };
         } else if (!isNewRankList) {
             newRankList = currentListVal;
-            allRankLists[newRankList].rank_list = rankingPlayersIdsList;
-            rankListData = allRankLists[newRankList];
+            rankListData = { ...savedRankLists[newRankList], rank_list: rankingPlayersIdsList };
         } else {
             console.log('List not saved: name for a new rank list should be longer than 3 characters');
             return;
@@ -204,17 +209,9 @@ const RanksPanel = ({
         if (updateResponse && updateResponse.ok) {
             if (isNewRankList) {
                 setIsNewRankList(false);
-                allListsVals.push(newRankList);
-                setAllListsVals(allListsVals);
                 setCurrentListVal(newRankList);
-                allRankLists[newRankList] = {};
-                Object.assign(allRankLists[newRankList], {
-                    rank_list: rankingPlayersIdsList,
-                    pretty_name: newRankListName,
-                    route_name: newRankList,
-                });
             }
-            setAllRankLists(allRankLists);
+            updateSavedRankLists((prevSavedRankLists) => ({ ...prevSavedRankLists, [newRankList]: rankListData }));
             setNewRankListName('');
             console.log(updateResponse.status);
         } else {
@@ -231,12 +228,13 @@ const RanksPanel = ({
         );
         if (updateResponse && updateResponse.ok) {
             setIsNewRankList(false);
-            const deleteIndex = allListsVals.indexOf(currentListVal);
-            allListsVals.splice(deleteIndex, 1);
-            if (allListsVals.length > 0) {
-                setAllListsVals(allListsVals);
-                updateRankList(defaultSelectorObj.route_name);
-            }
+            const deletedListVal = currentListVal;
+            updateSavedRankLists((prevSavedRankLists) => {
+                const nextSavedRankLists = { ...prevSavedRankLists };
+                delete nextSavedRankLists[deletedListVal];
+                return nextSavedRankLists;
+            });
+            updateRankList(defaultSelector);
             console.log(updateResponse.status);
         } else {
             console.log(updateResponse);
@@ -251,12 +249,12 @@ const RanksPanel = ({
             setIsNewRankList(false);
             setCurrentListVal(newListName);
             if (newListName !== defaultSelector) {
-                updateRankingPlayersIdsList(allRankLists[newListName].rank_list);
+                updateRankingPlayersIdsList(savedRankLists[newListName].rank_list);
             } else {
                 updateRankingPlayersIdsList([]);
             }
         },
-        [allRankLists, updateRankingPlayersIdsList],
+        [savedRankLists, updateRankingPlayersIdsList],
     );
 
     const updateFilters = (filterName, filter) => {
@@ -317,43 +315,14 @@ const RanksPanel = ({
         getADP();
     }, []);
 
+    // The saved-lists fetch itself now lives in App (loadSavedRankLists) - it
+    // resets isNewRankList/currentListVal back to the default whenever
+    // signedIn goes false, which App's version of this effect can't reach
+    // into this panel's local state to do, so that half stays here.
     useEffect(() => {
-        const defaultSelectorObj = {
-            [defaultSelector]: { pretty_name: '-- Select saved ranks list', route_name: defaultSelector },
-        };
-        const getSavedRankLists = async () => {
-            const getSavedRankListsResult = await fetch(
-                APP_USERS + auth.currentUser.uid + TYPE_PARAMS + (await auth.currentUser.getIdToken(true)),
-            )
-                .then(checkErrors)
-                .then((response) => response.json())
-                .then((data) => {
-                    return data;
-                })
-                .catch((error) => {
-                    console.error('Error:', error);
-                });
-
-            if (getSavedRankListsResult) {
-                const rankListNames = Object.keys(getSavedRankListsResult).map(
-                    (key) => getSavedRankListsResult[key].route_name,
-                );
-                rankListNames.unshift(defaultSelector);
-                const updatingRankList = {
-                    ...defaultSelectorObj,
-                    ...getSavedRankListsResult,
-                };
-                setAllRankLists(updatingRankList);
-                setAllListsVals(rankListNames);
-            }
-        };
-        if (signedIn) {
-            getSavedRankLists();
-        } else if (!signedIn) {
+        if (!signedIn) {
             setIsNewRankList(false);
             setCurrentListVal(defaultSelector);
-            setAllRankLists(defaultSelectorObj);
-            setAllListsVals([defaultSelector]);
         }
     }, [signedIn]);
 
@@ -361,14 +330,17 @@ const RanksPanel = ({
     // rank-list selector can live in the pill instead of a dropdown buried in
     // this panel. Memoised to avoid rebuilding the array every render;
     // usePublishRankList compares it by value, so this is an optimisation
-    // rather than the thing that keeps it from looping.
+    // rather than the thing that keeps it from looping. Order follows
+    // savedRankLists' own key order - `default` first, since App always
+    // spreads it as the base of that map - rather than a separately lifted
+    // list of ids.
     const rankListOptions = useMemo(
         () =>
-            allListsVals.map((list) => ({
+            Object.keys(savedRankLists).map((list) => ({
                 value: list,
-                label: allRankLists[list] ? allRankLists[list].pretty_name : 'dunno',
+                label: savedRankLists[list] ? savedRankLists[list].pretty_name : 'dunno',
             })),
-        [allListsVals, allRankLists],
+        [savedRankLists],
     );
     usePublishRankList({ options: rankListOptions, currentValue: currentListVal, onChange: updateRankList });
 
@@ -493,7 +465,7 @@ const RanksPanel = ({
                                 {showExistingListControls && (
                                     <div className="border-line rounded-row flex items-center justify-between gap-2 border p-3">
                                         <p className="text-ink m-0 truncate text-[14px] font-semibold">
-                                            {allRankLists[currentListVal]?.pretty_name}
+                                            {savedRankLists[currentListVal]?.pretty_name}
                                         </p>
                                         <OnFocusButton event={deleteRankList} saveRankList={saveRankList} />
                                     </div>

--- a/src/Panels/RanksPanel.test.jsx
+++ b/src/Panels/RanksPanel.test.jsx
@@ -63,6 +63,12 @@ function renderPanel(overrides = {}) {
         updatePlayerId: vi.fn(),
         notFoundPlayers: [],
         myDisplayName: MY_DISPLAY_NAME,
+        // savedRankLists/updateSavedRankLists are lifted to App (see
+        // App.jsx's loadSavedRankLists/updateSavedRankLists) - RanksPanel now
+        // just receives them. signedIn stays false in every test here, so
+        // the map never grows past the placeholder entry.
+        savedRankLists: { default: { pretty_name: '-- Select saved ranks list', route_name: 'default' } },
+        updateSavedRankLists: vi.fn(),
         ...overrides,
     };
     const { container } = render(<RanksPanel {...props} />);

--- a/src/Panels/SlotRow.jsx
+++ b/src/Panels/SlotRow.jsx
@@ -2,7 +2,7 @@ import { slotAccessibleName, slotOccupantLabel } from './lineupLabels.js';
 import ListRow from '../Components/ListRow';
 import PositionTag from '../Components/PositionTag';
 
-const SlotRow = ({ slot, index, playerInfo, onRemove }) => {
+const SlotRow = ({ slot, index, playerInfo, onOpen }) => {
     // A slot is occupied whenever it holds a player id, even if that id is
     // missing from the player database (a retired player dropped from it).
     // Keying the occupied state off the id rather than off the lookup means
@@ -16,17 +16,16 @@ const SlotRow = ({ slot, index, playerInfo, onRemove }) => {
     const occupantName = slotOccupantLabel({ slot, player });
     const accessibleName = slotAccessibleName({ slot, player });
 
-    // Filled slots remove on click; empty slots have nothing to do. The
-    // design captions empty slots "Tap to fill", but no fill-from-slot action
-    // exists in this app - filling happens from the Ranks panel's Add button.
-    // A control that does nothing is worse than none, so an empty slot is a
-    // plain non-interactive row rather than a button with no effect.
+    // Both states now open the slot-scoped sheet: a filled slot's Remove
+    // action moved there (a single tap must not be destructive), and an empty
+    // slot fills from there too - there is no longer such a thing as a
+    // fill-from-slot-that-does-nothing row.
     if (!slot.playerId) {
         return (
             <li>
                 <ListRow
-                    as="div"
                     label={accessibleName}
+                    onClick={() => onOpen(index)}
                     ordinal={slot.label}
                     ordinalWidth="44px"
                     ordinalClassName="text-[10px] font-semibold tracking-[.08em] text-ink-muted"
@@ -34,6 +33,7 @@ const SlotRow = ({ slot, index, playerInfo, onRemove }) => {
                     nameTone="dim"
                     meta="Empty slot"
                     tone="empty"
+                    trailing={<span className="text-ink-dim w-[7px] shrink-0 text-center text-[13px]">›</span>}
                 />
             </li>
         );
@@ -43,7 +43,7 @@ const SlotRow = ({ slot, index, playerInfo, onRemove }) => {
         <li>
             <ListRow
                 label={accessibleName}
-                onClick={() => onRemove(index)}
+                onClick={() => onOpen(index)}
                 ordinal={slot.label}
                 ordinalWidth="44px"
                 ordinalClassName="text-[10px] font-semibold tracking-[.08em] text-ink-muted"

--- a/src/lib/roster.js
+++ b/src/lib/roster.js
@@ -5,6 +5,12 @@ const EXTRA_FLEX_POSITIONS = {
     QB: ['SFLX'],
 };
 
+// The real positions eligiblePositionsForSlot can ever return, in the order
+// the design doc lists them - QB before RB/WR/TE, since SFLX is the only slot
+// that admits a QB. Kept as one list rather than duplicated in each flex
+// slot's expected output, so the two can't drift.
+const POSITION_ORDER = ['QB', 'RB', 'WR', 'TE'];
+
 /**
  * Returns the list of fantasy positions a player is eligible for, including
  * the flex/superflex slots implied by their real position. Never mutates the
@@ -16,6 +22,25 @@ const EXTRA_FLEX_POSITIONS = {
 export function getEligiblePositions(player) {
     const extras = EXTRA_FLEX_POSITIONS[player.position] || [];
     return [...player.fantasy_positions, ...extras.filter((pos) => !player.fantasy_positions.includes(pos))];
+}
+
+/**
+ * The real positions eligible to fill a given slot label - the inverse of
+ * EXTRA_FLEX_POSITIONS above. `FLX` -> `['RB', 'WR', 'TE']`, `SFLX` ->
+ * `['QB', 'RB', 'WR', 'TE']`, and any other slot label (this app's slot
+ * labels are already the short forms - `FLX`/`SFLX`, never `FLEX`/`SFLEX` -
+ * see toRosterSlots) admits only itself: a `TE` slot admits TE, a `QB` slot
+ * admits QB.
+ *
+ * Derived from EXTRA_FLEX_POSITIONS rather than hand-maintained as a second
+ * table, so the two can never independently drift - see roster.test.js's
+ * agreement test, which checks both directions.
+ */
+export function eligiblePositionsForSlot(slotLabel) {
+    const flexEligible = POSITION_ORDER.filter((position) =>
+        (EXTRA_FLEX_POSITIONS[position] || []).includes(slotLabel),
+    );
+    return flexEligible.length > 0 ? flexEligible : [slotLabel];
 }
 
 /**
@@ -46,15 +71,31 @@ export function toRosterSlots(rosterPositions) {
  * one of the player's eligible positions. Returns new slots; the player
  * database is neither an input nor an output, because assigning a player to a
  * lineup slot is a fact about the slot, not about the player.
+ *
+ * An optional `slotIndex` bypasses the "first eligible open slot" search
+ * entirely and fills (or replaces the occupant of) that exact index instead -
+ * what a slot-scoped sheet needs, since the user already chose which slot by
+ * tapping it. Unlike the search above, this never checks eligibility: the
+ * candidate list shown for a tapped slot is already filtered to it, and a
+ * currently-filled slot is meant to have its occupant replaced regardless.
  */
-export function addPlayerToRoster({ player, rosterSlots }) {
+export function addPlayerToRoster({ player, rosterSlots, slotIndex }) {
+    if (slotIndex !== undefined && slotIndex !== null) {
+        if (!rosterSlots[slotIndex]) {
+            return { rosterSlots };
+        }
+        const newSlots = [...rosterSlots];
+        newSlots[slotIndex] = { ...newSlots[slotIndex], playerId: player.player_id };
+        return { rosterSlots: newSlots };
+    }
+
     const eligiblePositions = getEligiblePositions(player);
 
     for (const eligiblePosition of eligiblePositions) {
-        const slotIndex = rosterSlots.findIndex((slot) => slot.playerId === null && slot.label === eligiblePosition);
-        if (slotIndex !== -1) {
+        const openIndex = rosterSlots.findIndex((slot) => slot.playerId === null && slot.label === eligiblePosition);
+        if (openIndex !== -1) {
             const newSlots = [...rosterSlots];
-            newSlots[slotIndex] = { ...newSlots[slotIndex], playerId: player.player_id };
+            newSlots[openIndex] = { ...newSlots[openIndex], playerId: player.player_id };
             return { rosterSlots: newSlots };
         }
     }

--- a/src/lib/roster.test.js
+++ b/src/lib/roster.test.js
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { addPlayerToRoster, getEligiblePositions, removePlayerFromLineup, toRosterSlots } from './roster.js';
+import {
+    addPlayerToRoster,
+    eligiblePositionsForSlot,
+    getEligiblePositions,
+    removePlayerFromLineup,
+    toRosterSlots,
+} from './roster.js';
 
 const makePlayer = (overrides = {}) => ({
     player_id: '1001',
@@ -53,6 +59,55 @@ describe('getEligiblePositions', () => {
         const second = getEligiblePositions(updatedPlayer);
         expect(second).toEqual(first);
         expect(second).toEqual(['RB', 'FLX', 'SFLX']);
+    });
+});
+
+describe('eligiblePositionsForSlot', () => {
+    it('admits RB/WR/TE for FLX, in that order', () => {
+        expect(eligiblePositionsForSlot('FLX')).toEqual(['RB', 'WR', 'TE']);
+    });
+
+    it('admits QB/RB/WR/TE for SFLX, in that order', () => {
+        expect(eligiblePositionsForSlot('SFLX')).toEqual(['QB', 'RB', 'WR', 'TE']);
+    });
+
+    it('admits only itself for a direct slot label - a TE slot admits only TE', () => {
+        expect(eligiblePositionsForSlot('TE')).toEqual(['TE']);
+        expect(eligiblePositionsForSlot('QB')).toEqual(['QB']);
+        expect(eligiblePositionsForSlot('RB')).toEqual(['RB']);
+        expect(eligiblePositionsForSlot('WR')).toEqual(['WR']);
+    });
+
+    it('admits only itself for a slot with no flex mapping at all', () => {
+        expect(eligiblePositionsForSlot('K')).toEqual(['K']);
+        expect(eligiblePositionsForSlot('DEF')).toEqual(['DEF']);
+    });
+
+    // getEligiblePositions (player -> slots) and eligiblePositionsForSlot
+    // (slot -> positions) are two views of the same underlying table. If they
+    // are ever hand-maintained separately, this is the test that notices they
+    // drifted - checked in both directions rather than just one, since a
+    // one-way check would pass even if a slot admitted a position that never
+    // reports being eligible for it.
+    describe('agreement with getEligiblePositions, in both directions', () => {
+        const player = (position) => ({ player_id: '1', position, fantasy_positions: [position] });
+
+        it('every position getEligiblePositions adds a flex slot for is also returned by that slot', () => {
+            for (const position of ['QB', 'RB', 'WR', 'TE']) {
+                const eligibleSlots = getEligiblePositions(player(position));
+                for (const slot of eligibleSlots.filter((label) => label === 'FLX' || label === 'SFLX')) {
+                    expect(eligiblePositionsForSlot(slot)).toContain(position);
+                }
+            }
+        });
+
+        it('every position a flex slot admits also has that slot in its own getEligiblePositions', () => {
+            for (const slot of ['FLX', 'SFLX']) {
+                for (const position of eligiblePositionsForSlot(slot)) {
+                    expect(getEligiblePositions(player(position))).toContain(slot);
+                }
+            }
+        });
     });
 });
 
@@ -122,6 +177,39 @@ describe('addPlayerToRoster', () => {
 
         expect(player).toEqual(clonedPlayer);
         expect(rosterSlots).toEqual(clonedSlots);
+    });
+
+    describe('with a slotIndex', () => {
+        it('fills that exact slot rather than searching for an eligible one', () => {
+            // TE at index 0 would not even be eligible for this RB under the
+            // normal search - the point of slotIndex is to skip that search
+            // entirely, because the user already chose the slot by tapping it.
+            const result = addPlayerToRoster({
+                player: makePlayer({ position: 'RB', fantasy_positions: ['RB'] }),
+                rosterSlots: slots('TE', 'RB'),
+                slotIndex: 0,
+            });
+
+            expect(result.rosterSlots[0]).toEqual({ label: 'TE', playerId: '1001' });
+            expect(result.rosterSlots[1]).toEqual({ label: 'RB', playerId: null });
+        });
+
+        it('replaces an already-filled slot rather than leaving it or looking elsewhere', () => {
+            const taken = slots('QB', 'RB');
+            taken[0] = { label: 'QB', playerId: 'old-occupant' };
+
+            const result = addPlayerToRoster({ player: makePlayer(), rosterSlots: taken, slotIndex: 0 });
+
+            expect(result.rosterSlots[0]).toEqual({ label: 'QB', playerId: '1001' });
+            expect(result.rosterSlots[1].playerId).toBeNull();
+        });
+
+        it('leaves the slots unchanged for an out-of-range index', () => {
+            const rosterSlots = slots('QB', 'RB');
+            const result = addPlayerToRoster({ player: makePlayer(), rosterSlots, slotIndex: 5 });
+
+            expect(result.rosterSlots).toEqual(rosterSlots);
+        });
     });
 
     it('never touches the player database, because it is not given one', () => {


### PR DESCRIPTION
Follows the updated design doc. Slot-tap becomes the primary fill path; the bottom handle stays as the browse-everything entry.

**Every slot row is a button now**, filled ones included, and both open the same sheet scoped to that slot — titled `Fill TE`, filtered to players your rank list holds that can fill it, with the other open slots and `ALL` one tap away. The handle entry is the same view with every open slot selected, so the two are **one code path with a `scope` prop**, not two sheets.

**Removal moves into the sheet.** Tapping a filled slot used to remove its player outright — a destructive action on a single tap. Now the occupant renders at the top of the scoped sheet with a `Remove` that closes it.

**Eligibility comes from the slot label**, not the player's position: `FLX` admits RB/WR/TE, `SFLX` adds QB. `eligiblePositionsForSlot` derives that from the *same* table as the existing position→slot mapping, with a test asserting the two agree in both directions so they can't drift. Selecting a candidate fills the slot you actually tapped, not the first eligible open one, and replaces an existing occupant.

**Rank-list switcher** in the sheet header: a pill opening a 236px popover of the saved lists plus `Paste a new list`, wearing the floating-layer shadow (the only shadow in the system — a popover has no scrim). Switching re-filters in place, keeping the slot scope and chip selection, so Lineup can read a different list than Ranks is editing.

## Two things found on the way

**The saved-list state was mutating in place.** Lifting it out of `RanksPanel` exposed that `saveRankList` and `deleteRankList` mutated the list map and then called `setState` with the *same reference*. It only ever re-rendered because something else forced one — and it would have gone silent the moment the switcher depended on it. Both build new objects now.

**The sheet marked every rostered player `Taken`, including your own.** That makes a lineup sheet useless: your own players are exactly the ones you can start, so the TE slot showed two tight ends and no way to pick either. "Taken" now means taken *by somebody else*, matching the `!taken || isMine` rule `PlayerInfoItem` has always used. Only affects Lineup — the draft sheet passes no `onSelect` at all.

## Two deviations worth your call

1. **`Paste a new list` navigates to the Ranks section** rather than opening the paste sheet in place. Opening it in place means reaching into `RanksPanel`'s internals; navigating away mid-fill loses the slot scope. Happy to extract a shared `PasteListSheet` if you'd rather have it in place.
2. **Focus doesn't return to the tapped slot row on close** (the bottom handle still gets its focus back). Slot rows re-render on every roster change, so there's no stable element to hold a ref to without keying refs by index. Fixable, just not free.

Verified at 375: tapping the TE slot opens `Fill TE / 2 eligible in this list` with the TE chip on and RBs/WRs hidden; `ALL` widens 2 → 8 rows keeping the list and the scope; the switcher pill flips its caret, fills violet, and its popover measures 236px wide, 12px radius, 6px below the pill, with `0 12px 32px rgba(3,6,10,.55)`.

All six gates green; 354 → 370 tests.