### PR TITLE
Finish the draft screen top, and give the lineup sheet real filters

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
             "name": "sleeper-app",
             "runtimeExecutable": "npm",
             "runtimeArgs": ["run", "dev"],
-            "port": 3000
+            "port": 3000,
+            "autoPort": true
         }
     ]
 }

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -47,6 +47,9 @@ const LEAGUE_ID = '1312088290526003200';
 const OTHER_LEAGUE_ID = '9999999999999999999';
 const DRAFT_ID = 'draft123';
 const OTHER_DRAFT_ID = 'draftOther';
+// The clock card's draft-source pill: the only place the active draft id is
+// shown now that the raw "Draft ID" input moved into the Draft source sheet.
+const SOURCE_PILL = `Draft source: …${DRAFT_ID.slice(-4)}`;
 
 // On roster 1 (mine) in the first league, dropped from every roster in the
 // second - so switching leagues must change this player's attribution from
@@ -192,7 +195,7 @@ describe('App', () => {
         // a pick the sync can't legitimately overwrite.
         const manualPickBox = screen.getByText('3.01').closest('button');
 
-        await user.click(screen.getByRole('button', { name: 'Update' }));
+        await user.click(screen.getByRole('button', { name: 'Sync draft' }));
 
         await user.click(manualPickBox);
         await user.type(screen.getByPlaceholderText('Start typing player name to search'), 'Brady');
@@ -259,9 +262,9 @@ describe('App', () => {
     it('survives a draft request that fails', async () => {
         // getSpecificDraft's own catch resolves draftData to undefined on a
         // failed fetch, and DraftPanel reads currentDraft.draft_id
-        // unconditionally to render its "Draft ID" input - so this only
-        // passes if currentDraft fell back to a real object instead of
-        // crashing the render.
+        // unconditionally to label the clock card's draft-source pill - so
+        // this only passes if currentDraft fell back to a real object instead
+        // of crashing the render.
         const rejections = [];
         const recordRejection = (reason) => rejections.push(reason);
         process.on('unhandledRejection', recordRejection);
@@ -279,7 +282,7 @@ describe('App', () => {
 
             render(<App />);
 
-            expect(await screen.findByDisplayValue(DRAFT_ID, {}, { timeout: 5000 })).toBeTruthy();
+            expect(await screen.findByRole('button', { name: SOURCE_PILL }, { timeout: 5000 })).toBeTruthy();
             await new Promise((resolve) => setTimeout(resolve, 0));
 
             expect(rejections).toEqual([]);
@@ -613,11 +616,10 @@ describe('App', () => {
 
         const renderAndSettle = async () => {
             render(<App />);
-            // The draft header renders from currentDraft regardless of whether a
-            // board could be built, so it is the signal that the load chain ran
-            // to completion rather than throwing partway.
-            // Scoped to the <b> header: the panel tab is also called "Draft".
-            return await screen.findByText(/Draft$/, { selector: 'b' }, { timeout: 5000 });
+            // The clock card renders from currentDraft regardless of whether a
+            // board could be built, so its eyebrow is the signal that the load
+            // chain ran to completion rather than throwing partway.
+            return await screen.findByText('On the clock', {}, { timeout: 5000 });
         };
 
         it('renders the panels when the draft response has no settings', async () => {
@@ -625,7 +627,7 @@ describe('App', () => {
 
             await renderAndSettle();
 
-            expect(screen.getByDisplayValue(DRAFT_ID)).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: SOURCE_PILL })).toBeInTheDocument();
             // No board, but a live app rather than a permanent loader.
             expect(screen.queryAllByRole('button', { name: /^Round \d+, pick \d+/ }).length).toBe(0);
         });
@@ -635,7 +637,7 @@ describe('App', () => {
 
             await renderAndSettle();
 
-            expect(screen.getByDisplayValue(DRAFT_ID)).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: SOURCE_PILL })).toBeInTheDocument();
             expect(screen.queryAllByRole('button', { name: /^Round \d+, pick \d+/ }).length).toBe(0);
         });
     });
@@ -711,9 +713,10 @@ describe('App', () => {
             return mockFetch(url);
         });
 
-        // Scoped to the <b> header: the panel tab is also called "Draft".
+        // The clock card renders whether or not a board could be built, so its
+        // eyebrow is the signal the load chain finished.
         render(<App />);
-        await screen.findByText(/Draft$/, { selector: 'b' }, { timeout: 5000 });
+        await screen.findByText('On the clock', {}, { timeout: 5000 });
 
         expect(screen.queryAllByRole('button', { name: /^Round \d+, pick \d+/ }).length).toBe(0);
         expect(screen.queryByRole('status')).toBeNull();

--- a/src/Components/BestAvailable.jsx
+++ b/src/Components/BestAvailable.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import ListRow from './ListRow';
 import PositionTag from './PositionTag';
+import OwnershipFilters, { DEFAULT_OWNERSHIP, matchesOwnership } from './OwnershipFilters';
 import { playerAccessibleName } from './playerInfoLabels.js';
 import { eligiblePositionsForSlot } from '../lib/roster.js';
 import { isTaken, rosteredBy } from '../lib/rosterInfo.js';
@@ -16,8 +17,13 @@ const playerId = (entry) => entry.match_results[0][0];
 // slot its position implies, then checking whether that list intersects
 // `slots`) happened to agree in every case this app exercises, but expressed
 // the relationship backwards.
+//
+// `fantasy_positions` is defaulted rather than dereferenced: a player database
+// entry without one is rare but real, and reading straight through it threw
+// out of the render and took the whole sheet down rather than dropping the one
+// player nothing can be said about.
 const eligibleForAny = (player, slots) =>
-    slots.some((slot) => eligiblePositionsForSlot(slot).some((pos) => player.fantasy_positions.includes(pos)));
+    slots.some((slot) => eligiblePositionsForSlot(slot).some((pos) => (player.fantasy_positions || []).includes(pos)));
 
 /**
  * `entries` narrowed down to the ones with a resolvable player and (when
@@ -25,12 +31,23 @@ const eligibleForAny = (player, slots) =>
  * is exported so a caller's collapsed handle (BestAvailableHandle) can build
  * its own count off the same rule this component renders by - see
  * `countAvailable` below for the "n left" figure specifically.
+ *
+ * `ownership` is optional and defaults to no ownership filtering at all, which
+ * is what keeps `countAvailable` below (and the draft's unfiltered list)
+ * reading exactly as they did before the FILTERS chip existed. Callers that
+ * show the chip pass their scope so the count in a subtitle and the rows under
+ * it can't disagree.
  */
-export function filterBestAvailable({ entries, playerInfo, eligibleSlots }) {
+export function filterBestAvailable({ entries, playerInfo, eligibleSlots, ownership, rosterInfo, myDisplayName }) {
     return entries
         .map((entry) => ({ entry, player: playerInfo[playerId(entry)] }))
         .filter(({ player }) => Boolean(player))
-        .filter(({ player }) => eligibleSlots === null || eligibleForAny(player, eligibleSlots));
+        .filter(({ player }) => eligibleSlots === null || eligibleForAny(player, eligibleSlots))
+        .filter(
+            ({ entry, player }) =>
+                !ownership ||
+                matchesOwnership({ ownership, player, playerId: playerId(entry), rosterInfo, myDisplayName }),
+        );
 }
 
 /**
@@ -68,9 +85,20 @@ const BestAvailable = ({
     myDisplayName,
     eligibleSlots,
     initialActiveChip = null,
+    ownership: controlledOwnership,
+    onOwnershipChange,
     onSelect,
 }) => {
     const [activeChip, setActiveChip] = useState(initialActiveChip);
+    const [filtersOpen, setFiltersOpen] = useState(false);
+    // Uncontrolled by default so the draft sheet and the desktop rail keep
+    // working untouched; LineupPanel controls it instead, because its sheet is
+    // mounted only while open and a scope held down here would reset every
+    // time the sheet was reopened - which is precisely what "Reset to default"
+    // exists to do deliberately.
+    const [localOwnership, setLocalOwnership] = useState(DEFAULT_OWNERSHIP);
+    const ownership = controlledOwnership ?? localOwnership;
+    const setOwnership = onOwnershipChange ?? setLocalOwnership;
 
     // No rank list at all is the normal state for a signed-out user (or one
     // who hasn't pasted anything yet), not an edge case of an otherwise-full
@@ -86,30 +114,68 @@ const BestAvailable = ({
 
     const chipLabels = eligibleSlots ? [...new Set(eligibleSlots)] : [];
     const narrowedSlots = eligibleSlots && activeChip ? [activeChip] : eligibleSlots;
-    const rows = filterBestAvailable({ entries, playerInfo, eligibleSlots: narrowedSlots });
+    // The ownership scope only applies where the chip that controls it is
+    // rendered - the lineup's slot-scoped list. The draft's read-only sheet
+    // passes `eligibleSlots: null` and shows the whole ranked board, taken
+    // players included and marked, which is what it is for.
+    const rows = filterBestAvailable({
+        entries,
+        playerInfo,
+        eligibleSlots: narrowedSlots,
+        ownership: eligibleSlots ? ownership : undefined,
+        rosterInfo,
+        myDisplayName,
+    });
 
     return (
         <div className="flex flex-col gap-3">
             {eligibleSlots && (
-                <div className="flex flex-wrap gap-2 px-2 pt-2">
-                    <button
-                        type="button"
-                        className={chipClasses(activeChip === null)}
-                        onClick={() => setActiveChip(null)}
-                    >
-                        ALL
-                    </button>
-                    {chipLabels.map((label) => (
+                // Only the slot chips scroll. FILTERS is pinned to the end
+                // because it is how you get rows back when the list looks
+                // empty - it must not be the thing that has scrolled out of
+                // sight when that happens. A lineup with six distinct slot
+                // labels overflows any phone width, so wrapping the whole row
+                // instead just left the divider stranded mid-air.
+                <div className="flex items-stretch gap-2 px-2 pt-2">
+                    <div className="no-scrollbar flex min-w-0 flex-1 gap-2 overflow-x-auto">
                         <button
-                            key={label}
                             type="button"
-                            className={chipClasses(activeChip === label)}
-                            onClick={() => setActiveChip(label)}
+                            className={`shrink-0 ${chipClasses(activeChip === null)}`}
+                            onClick={() => setActiveChip(null)}
                         >
-                            {label}
+                            ALL
                         </button>
-                    ))}
+                        {chipLabels.map((label) => (
+                            <button
+                                key={label}
+                                type="button"
+                                className={`shrink-0 ${chipClasses(activeChip === label)}`}
+                                onClick={() => setActiveChip(label)}
+                            >
+                                {label}
+                            </button>
+                        ))}
+                    </div>
+                    {/* Divided off from the slot chips because it filters a
+                        different axis: those narrow *where* a player could go,
+                        this narrows *whether you can have them*. */}
+                    <span className="bg-line my-0.5 w-px shrink-0" />
+                    <OwnershipFilters
+                        ownership={ownership}
+                        onChange={setOwnership}
+                        isOpen={filtersOpen}
+                        onToggle={() => setFiltersOpen((open) => !open)}
+                    />
                 </div>
+            )}
+            {/* Distinct from the "no rank list yet" message above: there is a
+                list, it just has nothing left in it once the chips and the
+                ownership scope are applied. Saying so beats an empty box under
+                a row of controls the user just touched. */}
+            {rows.length === 0 && (
+                <p className="text-ink-muted m-0 flex min-h-11 items-center px-4 text-sm">
+                    Nothing in this list fits - try another slot chip, or widen FILTERS.
+                </p>
             )}
             <ul className="flex flex-col gap-0.5 px-2 py-2.5">
                 {rows.map(({ entry, player }) => {

--- a/src/Components/ClockCard.jsx
+++ b/src/Components/ClockCard.jsx
@@ -1,0 +1,96 @@
+import PickClock from './PickClock';
+import { pickProgress, pickDeadline, URGENT_MS } from '../lib/draftClock.js';
+
+// The one always-elevated surface on the draft screen (the other is a sheet).
+// Everything the old panel header said in a stack of paragraphs and a bordered
+// clock box - whose turn it is, which pick, how long is left, and where sync is
+// reading from - reads across three rows here.
+//
+// The draft-source pill is the only way to point sync somewhere else now: the
+// raw "Draft ID" text input that used to sit at the top of the panel body moved
+// behind it (see DraftSourceSheet.jsx), so a mock draft id is still one tap
+// away without a bare id field on the main screen.
+const ClockCard = ({
+    draft,
+    onTheClockName,
+    pickLabel,
+    picksUntilMine,
+    sourceLabel,
+    sourceRef,
+    isSourceOpen,
+    onOpenSource,
+    isSyncing,
+    onToggleSync,
+}) => {
+    const progress = pickProgress(draft);
+    const deadline = pickDeadline(draft);
+    const urgent = deadline !== null && deadline - Date.now() <= URGENT_MS;
+
+    // "YOU IN 0" is nonsense for the case that matters most, so zero gets its
+    // own words. `null` (no pick of yours left on the board, or no display
+    // name yet) shows nothing at all rather than a guess.
+    const yourTurnLabel =
+        picksUntilMine === null ? null : picksUntilMine === 0 ? 'YOUR PICK' : `YOU IN ${picksUntilMine}`;
+
+    return (
+        <div className="bg-raised border-line rounded-card m-3.5 flex flex-col gap-3.5 border p-4">
+            <div className="flex items-center gap-2.5">
+                <span className="text-ink-quiet font-mono text-[10px] font-semibold tracking-[.14em] uppercase">
+                    On the clock
+                </span>
+                <span className="ml-auto flex items-center gap-2.5">
+                    {yourTurnLabel && (
+                        <span className="text-mine font-mono text-[10px] font-semibold tracking-[.14em]">
+                            {yourTurnLabel}
+                        </span>
+                    )}
+                    <button
+                        type="button"
+                        ref={sourceRef}
+                        aria-expanded={isSourceOpen}
+                        aria-label={`Draft source: ${sourceLabel}`}
+                        onClick={onOpenSource}
+                        className={`shrink-0 rounded-full border px-2 py-1 font-mono text-[10px] font-semibold tracking-[.06em] ${
+                            isSourceOpen ? 'border-mine bg-mine-chip text-mine' : 'border-line text-ink-quiet'
+                        }`}
+                    >
+                        <span aria-hidden="true">
+                            {sourceLabel} {isSourceOpen ? '▴' : '▾'}
+                        </span>
+                    </button>
+                </span>
+            </div>
+
+            <div className="flex items-end justify-between gap-3">
+                <span className="flex min-w-0 flex-col">
+                    <span className="text-ink truncate text-[19px] font-semibold tracking-[-0.02em]">
+                        {onTheClockName}
+                    </span>
+                    {pickLabel && <span className="text-ink-quiet font-mono text-[12px]">{pickLabel}</span>}
+                </span>
+                <PickClock draft={draft} />
+            </div>
+
+            {progress !== null && (
+                <div className="bg-line-mid h-[3px] w-full overflow-hidden rounded-full">
+                    <div
+                        className={`h-full rounded-full ${urgent ? 'bg-danger' : 'bg-mine'}`}
+                        style={{ width: `${Math.round(progress * 100)}%` }}
+                    />
+                </div>
+            )}
+
+            <button
+                type="button"
+                onClick={onToggleSync}
+                className={`min-h-11 w-full rounded-full text-[13px] font-semibold ${
+                    isSyncing ? 'border-line text-ink-muted border' : 'bg-mine text-ground'
+                }`}
+            >
+                {isSyncing ? 'Stop sync' : 'Sync draft'}
+            </button>
+        </div>
+    );
+};
+
+export default ClockCard;

--- a/src/Components/ClockCard.test.jsx
+++ b/src/Components/ClockCard.test.jsx
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import ClockCard from './ClockCard';
+
+// The card replaced a stack of paragraphs, a bordered clock box and two
+// buttons. Its three genuinely conditional pieces are what this covers: the
+// "you in n" line, the progress bar (and its urgent colour), and the sync
+// action's two states. The clock numeral itself is PickClock's, tested
+// separately; the arithmetic under both is draftClock.js's.
+
+const NOW = Date.UTC(2026, 6, 27, 12, 0, 0);
+
+const liveDraft = (pickTimer = 100) => ({
+    status: 'drafting',
+    start_time: NOW,
+    last_picked: null,
+    settings: { pick_timer: pickTimer },
+});
+
+function renderCard(overrides = {}) {
+    const onToggleSync = vi.fn();
+    const onOpenSource = vi.fn();
+    render(
+        <ClockCard
+            draft={liveDraft()}
+            onTheClockName="crbiehl"
+            pickLabel="Pick 2.05 · Round 2"
+            picksUntilMine={2}
+            sourceLabel="…3201"
+            isSourceOpen={false}
+            onOpenSource={onOpenSource}
+            isSyncing={false}
+            onToggleSync={onToggleSync}
+            {...overrides}
+        />,
+    );
+    return { onToggleSync, onOpenSource };
+}
+
+describe('ClockCard', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(NOW);
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('shows who is on the clock, which pick, and how far away yours is', () => {
+        renderCard();
+
+        expect(screen.getByText('crbiehl')).toBeVisible();
+        expect(screen.getByText('Pick 2.05 · Round 2')).toBeVisible();
+        expect(screen.getByText('YOU IN 2')).toBeVisible();
+    });
+
+    it('says YOUR PICK rather than "YOU IN 0" when you are the one on the clock', () => {
+        renderCard({ picksUntilMine: 0 });
+
+        expect(screen.getByText('YOUR PICK')).toBeVisible();
+        expect(screen.queryByText(/YOU IN/)).toBeNull();
+    });
+
+    it('shows nothing at all when you have no pick left, rather than guessing at one', () => {
+        renderCard({ picksUntilMine: null });
+
+        expect(screen.queryByText(/YOU/)).toBeNull();
+    });
+
+    it('draws the progress bar for a timed draft and leaves it out entirely for an untimed one', () => {
+        const { container } = render(
+            <ClockCard
+                draft={liveDraft()}
+                onTheClockName="crbiehl"
+                pickLabel="Pick 2.05 · Round 2"
+                picksUntilMine={2}
+                sourceLabel="…3201"
+                onOpenSource={vi.fn()}
+                onToggleSync={vi.fn()}
+            />,
+        );
+        expect(container.querySelector('[class*="bg-line-mid"]')).not.toBeNull();
+
+        const untimed = render(
+            <ClockCard
+                draft={{ status: 'drafting', start_time: NOW, last_picked: null, settings: { pick_timer: 0 } }}
+                onTheClockName="crbiehl"
+                pickLabel="Untimed"
+                picksUntilMine={null}
+                sourceLabel="…3201"
+                onOpenSource={vi.fn()}
+                onToggleSync={vi.fn()}
+            />,
+        );
+        expect(untimed.container.querySelector('[class*="bg-line-mid"]')).toBeNull();
+    });
+
+    it('turns the bar and the numeral danger-red inside the last 30 seconds', () => {
+        // 20s pick timer: the whole pick is inside the urgent window.
+        const { container } = render(
+            <ClockCard
+                draft={liveDraft(20)}
+                onTheClockName="crbiehl"
+                pickLabel="Pick 2.05 · Round 2"
+                picksUntilMine={0}
+                sourceLabel="…3201"
+                onOpenSource={vi.fn()}
+                onToggleSync={vi.fn()}
+            />,
+        );
+
+        expect(container.querySelector('[class*="bg-danger"]')).not.toBeNull();
+        expect(screen.getByText('0:20').className).toMatch(/text-danger/);
+    });
+
+    it('is the only way to start and stop sync, and says which it will do', async () => {
+        const { onToggleSync } = renderCard();
+
+        screen.getByRole('button', { name: 'Sync draft' }).click();
+        expect(onToggleSync).toHaveBeenCalledTimes(1);
+
+        renderCard({ isSyncing: true });
+        expect(screen.getByRole('button', { name: 'Stop sync' })).toBeInTheDocument();
+    });
+
+    it('labels the draft-source pill by the id it points at, not by the word "source" alone', async () => {
+        const { onOpenSource } = renderCard();
+
+        const pill = screen.getByRole('button', { name: 'Draft source: …3201' });
+        expect(pill).toHaveAttribute('aria-expanded', 'false');
+
+        pill.click();
+        expect(onOpenSource).toHaveBeenCalledTimes(1);
+    });
+});

--- a/src/Components/OwnershipFilters.jsx
+++ b/src/Components/OwnershipFilters.jsx
@@ -1,0 +1,167 @@
+import { useRef } from 'react';
+import Popover from './Popover';
+import { isTaken, rosteredBy } from '../lib/rosterInfo.js';
+
+/**
+ * The ownership scope a candidate list is read through. The sheet answers
+ * "who can I put here?", and by default that means *your* players plus
+ * anything unowned - so an upgrade sitting on waivers is visible - while
+ * players locked on somebody else's roster are hidden until asked for.
+ *
+ * Free agency and waivers are one bucket on purpose: "unowned in the league's
+ * rosters" is all `rosterInfo` knows. Telling them apart would need Sleeper's
+ * transactions endpoint, which is out of scope.
+ */
+export const DEFAULT_OWNERSHIP = {
+    mine: true,
+    available: true,
+    others: false,
+    rookiesOnly: false,
+};
+
+const OWNERSHIP_OPTIONS = [
+    { name: 'mine', label: 'My players', explainer: 'on your roster' },
+    { name: 'available', label: 'Free agents & waivers', explainer: 'available to add' },
+    { name: 'others', label: 'Other rosters', explainer: 'not gettable now' },
+];
+
+/**
+ * The number the `FILTERS · n` chip shows: how many ownership buckets are
+ * being shown. It is a count of what is on, not of what differs from the
+ * default, so the default state reads `FILTERS · 2` (as in the design) rather
+ * than a bare `FILTERS`.
+ */
+export const ownershipCount = (ownership) => OWNERSHIP_OPTIONS.filter((option) => ownership[option.name]).length;
+
+/** True when the scope is untouched - what makes the chip read as "at rest". */
+export const isDefaultOwnership = (ownership) =>
+    Object.keys(DEFAULT_OWNERSHIP).every((key) => ownership[key] === DEFAULT_OWNERSHIP[key]);
+
+/**
+ * Whether one player survives the ownership scope. Split three ways by who
+ * holds them, which is the same `!taken || isMine` distinction PlayerInfoItem
+ * and BestAvailable already draw - "taken" has always meant taken by somebody
+ * *else* in this app, and this filter keeps that meaning rather than
+ * introducing a fourth reading of it.
+ */
+export function matchesOwnership({ ownership, player, playerId, rosterInfo, myDisplayName }) {
+    if (ownership.rookiesOnly && !(player?.years_exp < 1)) {
+        return false;
+    }
+    if (!isTaken(rosterInfo, playerId)) {
+        return ownership.available;
+    }
+    return rosteredBy(rosterInfo, playerId) === myDisplayName ? ownership.mine : ownership.others;
+}
+
+const Checkbox = ({ checked }) => (
+    <span
+        aria-hidden="true"
+        className={`flex h-4 w-4 shrink-0 items-center justify-center rounded-[5px] text-[10px] ${
+            checked ? 'bg-mine text-ground' : 'border-mark border'
+        }`}
+    >
+        {checked ? '✓' : ''}
+    </span>
+);
+
+/**
+ * The `SHOW PLAYERS` body: three ownership checkboxes, a rookies-only toggle,
+ * and a reset. Exported separately from the chip so the same body can sit in
+ * whatever container a caller has (the anchored popover below, or a panel).
+ */
+export const OwnershipFiltersBody = ({ ownership, onChange }) => {
+    const toggle = (name) => onChange({ ...ownership, [name]: !ownership[name] });
+
+    return (
+        <div className="flex flex-col">
+            <p className="text-ink-quiet m-0 px-2.5 pt-2 pb-1 font-mono text-[10px] font-semibold tracking-[.12em]">
+                SHOW PLAYERS
+            </p>
+            {OWNERSHIP_OPTIONS.map((option) => (
+                <button
+                    key={option.name}
+                    type="button"
+                    role="checkbox"
+                    aria-checked={ownership[option.name]}
+                    onClick={() => toggle(option.name)}
+                    className="flex w-full items-center gap-2.5 rounded-lg px-2.5 py-[9px] text-left"
+                >
+                    <Checkbox checked={ownership[option.name]} />
+                    <span className="flex min-w-0 flex-col">
+                        <span
+                            className={`truncate text-[13px] ${
+                                ownership[option.name] ? 'text-ink font-semibold' : 'text-ink-muted font-medium'
+                            }`}
+                        >
+                            {option.label}
+                        </span>
+                        <span className="text-ink-quiet font-mono text-[10px]">{option.explainer}</span>
+                    </span>
+                </button>
+            ))}
+            <div className="bg-line mx-1.5 my-1 h-px" />
+            <button
+                type="button"
+                role="switch"
+                aria-checked={ownership.rookiesOnly}
+                onClick={() => toggle('rookiesOnly')}
+                className="flex w-full items-center justify-between gap-2.5 rounded-lg px-2.5 py-[9px] text-left"
+            >
+                <span className={`text-[13px] ${ownership.rookiesOnly ? 'text-ink font-semibold' : 'text-ink-muted'}`}>
+                    Rookies only
+                </span>
+                <span
+                    aria-hidden="true"
+                    className={`flex h-5 w-9 shrink-0 items-center rounded-full p-0.5 ${
+                        ownership.rookiesOnly ? 'bg-mine justify-end' : 'bg-line-mid justify-start'
+                    }`}
+                >
+                    <span
+                        className={`block h-4 w-4 rounded-full ${ownership.rookiesOnly ? 'bg-ground' : 'bg-ink-dim'}`}
+                    />
+                </span>
+            </button>
+            <button
+                type="button"
+                onClick={() => onChange(DEFAULT_OWNERSHIP)}
+                className="text-mine w-full rounded-lg px-2.5 py-[9px] text-left text-[13px] font-semibold"
+            >
+                Reset to default
+            </button>
+        </div>
+    );
+};
+
+/**
+ * The `FILTERS · n` chip and its popover. Violet-filled while open or while
+ * the scope is non-default, outlined at rest - the chip has to say that
+ * something is being hidden without the popover being open to explain it.
+ */
+const OwnershipFilters = ({ ownership, onChange, isOpen, onToggle }) => {
+    const chipRef = useRef(null);
+    const active = isOpen || !isDefaultOwnership(ownership);
+
+    return (
+        <div className="relative inline-block shrink-0">
+            <button
+                type="button"
+                ref={chipRef}
+                aria-expanded={isOpen}
+                onClick={onToggle}
+                className={`rounded-full border px-[11px] py-[7px] font-mono text-[11px] font-semibold tracking-[.08em] ${
+                    active ? 'bg-mine-chip border-mine text-mine' : 'border-line text-ink-muted'
+                }`}
+            >
+                FILTERS · {ownershipCount(ownership)}
+            </button>
+            {isOpen && (
+                <Popover triggerRef={chipRef} onClose={onToggle} label="Filters">
+                    <OwnershipFiltersBody ownership={ownership} onChange={onChange} />
+                </Popover>
+            )}
+        </div>
+    );
+};
+
+export default OwnershipFilters;

--- a/src/Components/PickClock.jsx
+++ b/src/Components/PickClock.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { pickClockMode, pickDeadline, formatTimeLeft } from '../lib/draftClock.js';
+import { pickClockMode, pickDeadline, formatTimeLeft, URGENT_MS } from '../lib/draftClock.js';
 
 // Re-render cadence per mode: a `live` clock ticking seconds needs a 1s
 // timer, `slow` only needs to move once a minute, and `untimed` / `not-started`
@@ -10,6 +10,13 @@ const TICK_MS = {
     slow: 60000,
 };
 
+// The numeral (or the words that replace it) on the clock card. No box of its
+// own any more: the card is the surface, and this only owns what is counted -
+// see ClockCard.jsx for the eyebrow, the manager and the progress bar.
+//
+// The three non-counting modes deliberately render text where the numeral
+// would be rather than a `0:00` computed off arithmetic that has no meaning
+// for them.
 const PickClock = ({ draft }) => {
     const mode = pickClockMode(draft);
     const [, forceTick] = useState(0);
@@ -23,51 +30,31 @@ const PickClock = ({ draft }) => {
         return () => clearInterval(timer);
     }, [mode]);
 
-    const WRAPPER = 'border border-line rounded-[5px] bg-raised px-3 py-2';
+    const STATIC_TEXT = {
+        'not-started': "Draft hasn't started",
+        complete: 'Draft complete',
+        untimed: 'Untimed draft',
+    };
 
-    if (mode === 'not-started') {
-        return (
-            <div className={WRAPPER}>
-                <p className="text-ink-muted text-sm">Draft hasn&apos;t started</p>
-            </div>
-        );
+    if (STATIC_TEXT[mode]) {
+        return <p className="text-ink-muted m-0 shrink-0 text-right text-[15px] font-medium">{STATIC_TEXT[mode]}</p>;
     }
 
-    if (mode === 'complete') {
-        // A finished draft still carries a real `last_picked` and a real
-        // `pick_timer`, so the arithmetic produces a deadline that expired
-        // when the draft did. Saying so beats counting down to it.
-        return (
-            <div className={WRAPPER}>
-                <p className="text-ink-muted text-sm">Draft complete</p>
-            </div>
-        );
-    }
-
-    if (mode === 'untimed') {
-        // Never render a countdown here - there is no deadline to count down
-        // to, and rendering the raw arithmetic anyway is exactly how a bare
-        // `0:00` or `NaN` would leak onto an untimed draft's screen.
-        return (
-            <div className={WRAPPER}>
-                <p className="text-ink-muted text-sm">Untimed draft</p>
-            </div>
-        );
-    }
-
-    const deadline = pickDeadline(draft);
-    const msLeft = deadline - Date.now();
-    // Deliberately not "until autopick": whether an expired pick is
-    // auto-made depends on league settings nobody here has verified.
-    const label = 'Time left';
+    const msLeft = pickDeadline(draft) - Date.now();
+    const urgent = msLeft <= URGENT_MS;
+    // 34px is the design's figure for a `M:SS` countdown. "Time expired" and
+    // the coarse `1d 4h` of a slow draft are words, not a numeral, and at 34px
+    // they collide with the manager's name beside them.
+    const large = mode === 'live' && msLeft > 0;
 
     return (
-        <div className={WRAPPER}>
-            <p className="text-ink text-sm">
-                <span className="text-ink-muted">{label}: </span>
-                <span className="font-semibold tabular-nums">{formatTimeLeft(msLeft, mode)}</span>
-            </p>
-        </div>
+        <p
+            className={`m-0 shrink-0 text-right font-mono font-medium tracking-[-0.02em] tabular-nums ${
+                large ? 'text-[34px]' : 'text-[20px]'
+            } ${urgent ? 'text-danger' : 'text-ink'}`}
+        >
+            {formatTimeLeft(msLeft, mode)}
+        </p>
     );
 };
 

--- a/src/Components/Popover.jsx
+++ b/src/Components/Popover.jsx
@@ -1,0 +1,147 @@
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+
+// Gap between the trigger and the panel, and the margin the panel keeps from
+// the viewport edge when it would otherwise hang off it.
+const OFFSET_PX = 6;
+const EDGE_PX = 8;
+
+// The floating layer: a small panel anchored under its trigger, with no scrim
+// of its own - which is exactly why it is the one thing in the system that
+// earns a shadow (`shadow-float`, see theme.css).
+//
+// Rendered into a portal on `document.body` and positioned from the trigger's
+// own rect, rather than absolutely inside the trigger's parent. Both places
+// this is used sit inside a clipping ancestor - the Ranks chip row is
+// `overflow-x-auto` so it can scroll sideways, and the sheet's body is
+// `overflow-y-auto` - and an absolutely positioned popover inside either is
+// cut off at that box's edge. The Ranks one lost everything below its first
+// row that way.
+//
+// Rendered at every viewport width, not just `md` and up. The Ranks FILTERS
+// control used to be two trees - an anchored popover behind `hidden md:block`
+// plus a bottom Sheet below it - and the hidden half was still mounted on a
+// phone, still listening on `document` for a `mousedown` outside itself. Every
+// tap on a control inside the Sheet counted as "outside" and closed the whole
+// thing on mousedown, before the click that would have toggled the filter ever
+// landed. One popover at all widths is both the design (see the handoff's
+// frames 6 and 7, which show a popover on the phone too) and the fix.
+//
+// Escape is captured and stopped rather than left to bubble: a popover opened
+// from inside a Sheet shares the document with the Sheet's own Escape handler,
+// and one keystroke must close the popover only. Same reasoning as
+// RankListSwitcher's, which is the third instance of this shape.
+const Popover = ({ triggerRef, onClose, label, width = 252, children }) => {
+    const popoverRef = useRef(null);
+    const [position, setPosition] = useState(null);
+
+    const reposition = useCallback(() => {
+        const trigger = triggerRef.current;
+        if (!trigger) {
+            return;
+        }
+        const rect = trigger.getBoundingClientRect();
+        const clampedWidth = Math.min(width, window.innerWidth - EDGE_PX * 2);
+        // Right-aligned to the trigger, then pulled back inside the viewport -
+        // the Ranks chip lives at the right end of a row that can itself be
+        // scrolled off-screen, so neither edge can be assumed to be in view.
+        const left = Math.min(Math.max(EDGE_PX, rect.right - clampedWidth), window.innerWidth - clampedWidth - EDGE_PX);
+
+        // Flip above the trigger when there is not room below it. The sheet's
+        // FILTERS chip sits two thirds of the way down a phone screen, so
+        // "below" leaves the last two options and Reset off the bottom - and
+        // an internally scrolling popover hides that there is anything there.
+        // Height is only known from the second pass onward (the panel has to
+        // exist to be measured); the first pass places it below, and both
+        // passes run in a layout effect, so nothing is painted in between.
+        // `scrollHeight`, not the rendered box: the box is already clamped by
+        // last pass's maxHeight, so measuring it would report "it fits" about
+        // the very constraint that made it fit and never flip.
+        const natural = popoverRef.current?.scrollHeight ?? 0;
+        const spaceBelow = window.innerHeight - (rect.bottom + OFFSET_PX) - EDGE_PX;
+        const spaceAbove = rect.top - OFFSET_PX - EDGE_PX;
+        const placeAbove = natural > spaceBelow && spaceAbove > spaceBelow;
+        const top = placeAbove ? Math.max(EDGE_PX, rect.top - OFFSET_PX - natural) : rect.bottom + OFFSET_PX;
+        const maxHeight = placeAbove ? spaceAbove : spaceBelow;
+
+        setPosition((previous) =>
+            previous &&
+            previous.top === top &&
+            previous.left === left &&
+            previous.width === clampedWidth &&
+            previous.maxHeight === maxHeight
+                ? previous
+                : { top, left, width: clampedWidth, maxHeight },
+        );
+    }, [triggerRef, width]);
+
+    // Layout effect, so the panel is never painted at the wrong place first.
+    // It re-runs on `position` as well, which is the second pass described in
+    // reposition - and settles immediately, because reposition returns the
+    // previous object unchanged once nothing moves.
+    useLayoutEffect(reposition, [reposition, position]);
+
+    useEffect(() => {
+        popoverRef.current?.focus();
+        const trigger = triggerRef.current;
+        return () => {
+            trigger?.focus();
+        };
+        // Mount/unmount only, same as Sheet's own focus effect.
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    useEffect(() => {
+        const onKeyDown = (event) => {
+            if (event.key === 'Escape') {
+                event.stopPropagation();
+                onClose();
+            }
+        };
+        const onPointerDown = (event) => {
+            const popover = popoverRef.current;
+            const trigger = triggerRef.current;
+            if (popover && !popover.contains(event.target) && trigger && !trigger.contains(event.target)) {
+                onClose();
+            }
+        };
+        document.addEventListener('keydown', onKeyDown, true);
+        document.addEventListener('mousedown', onPointerDown);
+        // `true` so a scroll inside the sheet's own scroller re-anchors this,
+        // not only a scroll of the page.
+        window.addEventListener('scroll', reposition, true);
+        window.addEventListener('resize', reposition);
+        return () => {
+            document.removeEventListener('keydown', onKeyDown, true);
+            document.removeEventListener('mousedown', onPointerDown);
+            window.removeEventListener('scroll', reposition, true);
+            window.removeEventListener('resize', reposition);
+        };
+    }, [onClose, triggerRef, reposition]);
+
+    if (!position) {
+        return null;
+    }
+
+    return createPortal(
+        <div
+            ref={popoverRef}
+            role="dialog"
+            aria-label={label}
+            tabIndex={-1}
+            style={{
+                position: 'fixed',
+                top: `${position.top}px`,
+                left: `${position.left}px`,
+                width: `${position.width}px`,
+                maxHeight: `${position.maxHeight}px`,
+            }}
+            className="border-line bg-raised-2 shadow-float z-[1000] box-border overflow-y-auto rounded-xl border p-1.5 outline-none"
+        >
+            {children}
+        </div>,
+        document.body,
+    );
+};
+
+export default Popover;

--- a/src/Components/Sheet.jsx
+++ b/src/Components/Sheet.jsx
@@ -1,5 +1,23 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useBodyScrollLock } from '../useBodyScrollLock.js';
+
+// How far down the header has to travel before letting go dismisses the sheet
+// (or collapses an expanded one), and how far up before it expands. Down needs
+// the larger figure: dismissing loses whatever the sheet was showing, while
+// expanding is free to undo.
+const DISMISS_PX = 90;
+const EXPAND_PX = 40;
+
+// Two heights, so a drag up has somewhere to go. The collapsed one is the
+// design's `max-height: 560px`; the expanded one leaves the top bar visible so
+// the sheet still reads as a sheet rather than a page.
+const COLLAPSED_MAX_H = '560px';
+const EXPANDED_MAX_H = 'calc(100dvh - var(--tab-bar-h) - 56px)';
+
+// Elements inside the header that own their own taps - the close button, the
+// rank-list switcher pill. A drag that starts on one of those must stay a
+// click, so the gesture never begins there.
+const HEADER_CONTROL_SELECTOR = 'button, a, input, select, textarea, [role="dialog"]';
 
 // Focusable elements worth trapping Tab within - close enough to the real
 // definition for a sheet's contents (rows, chips, an input, buttons) without
@@ -22,8 +40,71 @@ const FOCUSABLE_SELECTOR =
 // the set of focusable things in any of these three callers is short.
 const Sheet = ({ title, subtitle, onClose, triggerRef, centerOnDesktop = false, headerAction, children }) => {
     const panelRef = useRef(null);
+    const [expanded, setExpanded] = useState(false);
+    // Live finger offset while a drag is in progress, null the rest of the
+    // time - which is also what tells the transition below whether to animate
+    // (it must not, while the sheet is tracking a finger).
+    const [dragY, setDragY] = useState(null);
+    const dragStartY = useRef(0);
 
     useBodyScrollLock();
+
+    // Pointer events rather than touch events: one code path covers a finger,
+    // a trackpad drag and a mouse, and pointer capture means the gesture keeps
+    // being delivered here even once the finger leaves the header - which it
+    // does immediately, since the header is what is moving.
+    const onPointerDown = (event) => {
+        // Scoped to the header, because `closest` walks all the way up: the
+        // sheet's own panel carries `role="dialog"`, so an unscoped match
+        // would find it from anywhere in the header and no drag could ever
+        // start. What this is really asking is "did the gesture begin on a
+        // control the header owns" - a popover open inside the header counts,
+        // the panel wrapping it does not.
+        const control = event.target.closest(HEADER_CONTROL_SELECTOR);
+        if (control && event.currentTarget.contains(control)) {
+            return;
+        }
+        // A `centerOnDesktop` sheet is a centred panel above `md`, held there
+        // by a translate of its own - dragging it would fight that transform
+        // rather than move a sheet, and there is no bottom edge to drag it
+        // towards anyway.
+        if (centerOnDesktop && window.matchMedia?.('(min-width: 768px)').matches) {
+            return;
+        }
+        dragStartY.current = event.clientY;
+        setDragY(0);
+        event.currentTarget.setPointerCapture?.(event.pointerId);
+    };
+
+    const onPointerMove = (event) => {
+        if (dragY === null) {
+            return;
+        }
+        const delta = event.clientY - dragStartY.current;
+        // Upward travel is resisted once there is nowhere further to expand
+        // to, so the sheet never detaches from the bottom of the screen.
+        setDragY(delta < 0 && expanded ? delta / 4 : delta);
+    };
+
+    const endDrag = (event) => {
+        if (dragY === null) {
+            return;
+        }
+        event.currentTarget.releasePointerCapture?.(event.pointerId);
+        const delta = dragY;
+        setDragY(null);
+        if (delta > DISMISS_PX) {
+            // An expanded sheet collapses first: a single flick should not be
+            // able to take it from full height to gone.
+            if (expanded) {
+                setExpanded(false);
+            } else {
+                onClose();
+            }
+        } else if (delta < -EXPAND_PX) {
+            setExpanded(true);
+        }
+    };
 
     useEffect(() => {
         panelRef.current?.focus();
@@ -76,13 +157,32 @@ const Sheet = ({ title, subtitle, onClose, triggerRef, centerOnDesktop = false, 
                 aria-modal="true"
                 aria-label={title}
                 tabIndex={-1}
-                className={`border-line bg-raised fixed inset-x-0 bottom-[var(--tab-bar-h)] flex max-h-[560px] flex-col rounded-t-[16px] border-t outline-none ${
+                style={{
+                    maxHeight: expanded ? EXPANDED_MAX_H : COLLAPSED_MAX_H,
+                    // Only ever pushed *down* by a drag; upward travel is what
+                    // the max-height swap above expresses, so translating up
+                    // as well would double-count it.
+                    transform: dragY > 0 ? `translateY(${dragY}px)` : undefined,
+                    transition: dragY === null ? 'transform 180ms ease-out, max-height 180ms ease-out' : 'none',
+                }}
+                className={`border-line bg-raised fixed inset-x-0 bottom-[var(--tab-bar-h)] flex flex-col rounded-t-[16px] border-t outline-none ${
                     centerOnDesktop
                         ? 'md:rounded-card md:inset-x-auto md:top-1/2 md:bottom-auto md:left-1/2 md:w-[420px] md:max-w-[calc(100vw-2rem)] md:-translate-x-1/2 md:-translate-y-1/2 md:border'
                         : ''
                 }`}
             >
-                <div className="border-line-mid flex shrink-0 flex-col border-b px-4 pt-3.5 pb-3">
+                {/* The whole header is the grab area, not just the 36px handle
+                    - the handle is too small a target to be the only way in,
+                    and the design's affordance reads as "the top of the sheet
+                    moves". `touch-none` is what stops the browser claiming the
+                    gesture as a page scroll before the handlers below see it. */}
+                <div
+                    onPointerDown={onPointerDown}
+                    onPointerMove={onPointerMove}
+                    onPointerUp={endDrag}
+                    onPointerCancel={endDrag}
+                    className="border-line-mid flex shrink-0 touch-none flex-col border-b px-4 pt-3.5 pb-3"
+                >
                     <div
                         className={`bg-mark mx-auto mb-3 h-[3px] w-9 rounded-full ${centerOnDesktop ? 'md:hidden' : ''}`}
                     />

--- a/src/Components/Sheet.test.jsx
+++ b/src/Components/Sheet.test.jsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { useRef } from 'react';
 import Sheet from './Sheet';
@@ -127,5 +127,71 @@ describe('Sheet', () => {
         renderSheet({ centerOnDesktop: true });
 
         expect(screen.getByRole('dialog', { name: 'Best available' })).toBeInTheDocument();
+    });
+});
+
+// Dragging the top of a sheet is the gesture every bottom sheet on a phone
+// implies and this one did not have: pulling down dismissed nothing, pushing
+// up expanded nothing, so the grab handle was decoration.
+//
+// jsdom has no PointerEvent constructor and no pointer capture, so these drive
+// the React handlers directly with fireEvent.pointerDown/Move/Up and a plain
+// clientY. That tests the state machine, not the browser's gesture routing -
+// which is the half that can regress silently.
+describe('Sheet drag gesture', () => {
+    const header = () => screen.getByText('Best available').closest('div[class*="border-b"]');
+    const panel = () => screen.getByRole('dialog');
+
+    const drag = (distance) => {
+        const grip = header();
+        fireEvent.pointerDown(grip, { clientY: 400, pointerId: 1 });
+        fireEvent.pointerMove(grip, { clientY: 400 + distance, pointerId: 1 });
+        fireEvent.pointerUp(grip, { clientY: 400 + distance, pointerId: 1 });
+    };
+
+    it('closes on a drag down past the dismiss threshold', () => {
+        const { onClose } = renderSheet();
+
+        drag(160);
+
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('stays open on a short drag that never reaches the threshold', () => {
+        const { onClose } = renderSheet();
+
+        drag(20);
+
+        expect(onClose).not.toHaveBeenCalled();
+        expect(panel()).toBeInTheDocument();
+    });
+
+    it('expands on a drag up, and the first drag down then only collapses it', () => {
+        const { onClose } = renderSheet();
+
+        const collapsedMaxHeight = panel().style.maxHeight;
+        drag(-80);
+        expect(panel().style.maxHeight).not.toBe(collapsedMaxHeight);
+
+        // A single flick must not take an expanded sheet from full height
+        // straight to gone.
+        drag(160);
+        expect(onClose).not.toHaveBeenCalled();
+        expect(panel().style.maxHeight).toBe(collapsedMaxHeight);
+
+        drag(160);
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('leaves a drag that starts on a header control alone, so the control still works', () => {
+        const { onClose } = renderSheet();
+
+        const close = screen.getByRole('button', { name: 'Close' });
+        fireEvent.pointerDown(close, { clientY: 400, pointerId: 1 });
+        fireEvent.pointerMove(close, { clientY: 560, pointerId: 1 });
+        fireEvent.pointerUp(close, { clientY: 560, pointerId: 1 });
+
+        // No drag ran, so nothing was dismissed by the gesture itself.
+        expect(onClose).not.toHaveBeenCalled();
     });
 });

--- a/src/Panels/DraftPanel.jsx
+++ b/src/Panels/DraftPanel.jsx
@@ -1,15 +1,17 @@
 import { useState, useEffect, useRef } from 'react';
-import Button from '../Components/Button';
 import SegmentedControl from '../Components/SegmentedControl';
 import PickFeed from './PickFeed';
 import DraftGrid from './DraftGrid';
 import Sheet from '../Components/Sheet';
 import BestAvailable, { countAvailable } from '../Components/BestAvailable';
 import BestAvailableHandle from '../Components/BestAvailableHandle';
-import PickClock from '../Components/PickClock';
+import ClockCard from '../Components/ClockCard';
+import DraftSourceSheet, { readLastMock, writeLastMock } from './DraftSourceSheet';
+import { managerLabel, pickNumberLabel } from './pickLabels.js';
 import { SLEEPER_API_URLS } from '../urls';
 import { syncLiveDraft } from '../lib/liveDraft.js';
 import { pollIntervalMs } from '../lib/draftClock.js';
+import { nextUnpickedPick, picksUntilMine } from '../lib/onTheClock.js';
 import { useSeenPicks } from '../useSeenPicks.js';
 import { usePublishSyncStatus } from '../SyncStatus.jsx';
 const { DRAFT, PICKS, TRADED_PICKS } = SLEEPER_API_URLS;
@@ -33,10 +35,19 @@ const DraftPanel = ({ leagueData, playerInfo, rosterInfo, rankingPlayersIdsList,
     // shouldn't change what people already sync a draft against.
     const [boardView, setBoardView] = useState('feed');
     const [isBestAvailableOpen, setIsBestAvailableOpen] = useState(false);
+    const [isSourceOpen, setIsSourceOpen] = useState(false);
+    // Read once at mount rather than on every render: this is a per-league
+    // memory of the last mock, and only this component writes it.
+    const [lastMockId, setLastMockId] = useState(() => readLastMock(currentDraft.draft_id));
     const bestAvailableHandleRef = useRef(null);
+    const sourceButtonRef = useRef(null);
 
+    // Keyed on the draft actually being read, not the league's own: switching
+    // to a mock and back must not flood the feed with "NEW" flags for picks
+    // that were already seen on the real draft (useSeenPicks keeps one
+    // snapshot per id, so this is the whole of that behaviour).
     const { newPickKeys, markSeen } = useSeenPicks({
-        draftId: currentDraft.draft_id,
+        draftId: currentDraftId,
         builtDraft: currentDraft.built_draft,
     });
 
@@ -44,6 +55,23 @@ const DraftPanel = ({ leagueData, playerInfo, rosterInfo, rankingPlayersIdsList,
         setCurrentDraftId(val);
         setDraftPath(DRAFT + val + '/');
     };
+
+    const selectDraftSource = (draftId) => {
+        updateDraftID(draftId);
+        if (draftId !== currentDraft.draft_id) {
+            writeLastMock(currentDraft.draft_id, draftId);
+            setLastMockId(draftId);
+        }
+        setIsSourceOpen(false);
+    };
+
+    const onTheClock = nextUnpickedPick(currentDraft.built_draft);
+    const onTheClockName = onTheClock
+        ? managerLabel({ pick: onTheClock.pick, rosterData, myDisplayName, markYours: false })
+        : 'No pick on the clock';
+    const pickLabel = onTheClock
+        ? `Pick ${pickNumberLabel(onTheClock.round, onTheClock.pick)} · Round ${onTheClock.round.round}`
+        : `${currentDraft.season ?? ''} ${currentDraft.player_pool ?? ''}`.trim();
 
     // `changedKey` is only ever passed when the round object came from a
     // manual pick (see PickFeed.selectPlayer) - the live sync path below
@@ -134,41 +162,44 @@ const DraftPanel = ({ leagueData, playerInfo, rosterInfo, rankingPlayersIdsList,
 
     return (
         <div>
-            <div className="overflow-hidden pt-[5px] pr-[15px] pb-[15px] pl-[15px] max-md:w-[95%] max-md:p-[5px]">
-                <p>
-                    <b>Draft ID</b>
-                </p>
-                <input
-                    type="text"
-                    className="border-line text-ink caret-ink-muted m-0 rounded-[10px] border-2 bg-transparent"
-                    value={currentDraftId}
-                    onChange={(e) => updateDraftID(e.target.value)}
+            <ClockCard
+                draft={currentDraft}
+                onTheClockName={onTheClockName}
+                pickLabel={pickLabel}
+                picksUntilMine={picksUntilMine({
+                    builtDraft: currentDraft.built_draft,
+                    rosterData,
+                    myDisplayName,
+                })}
+                sourceLabel={`…${String(currentDraftId).slice(-4)}`}
+                sourceRef={sourceButtonRef}
+                isSourceOpen={isSourceOpen}
+                onOpenSource={() => setIsSourceOpen((open) => !open)}
+                isSyncing={isSyncing}
+                onToggleSync={() => setIsSyncing(!isSyncing)}
+            />
+            {isSourceOpen && (
+                <DraftSourceSheet
+                    leagueDraft={currentDraft}
+                    currentDraftId={currentDraftId}
+                    lastMockId={lastMockId}
+                    onSelect={selectDraftSource}
+                    onClose={() => setIsSourceOpen(false)}
+                    triggerRef={sourceButtonRef}
                 />
-                <div className="mt-2">
-                    <Button text="Update" btnStyle="primary" onClick={getLiveDraft} />
-                </div>
-                <p>
-                    <b>{`${currentDraft.season} ${currentDraft.player_pool} Draft`}</b>
-                </p>
-                <p>Status: {currentDraft.status}</p>
-                <PickClock draft={currentDraft} />
-                <div className="mt-2">
-                    <Button
-                        text={!isSyncing ? 'Sync draft' : 'Stop sync'}
-                        btnStyle={isSyncing ? 'primary-large active' : 'primary-large'}
-                        onClick={() => setIsSyncing(!isSyncing)}
-                    />
-                </div>
-            </div>
+            )}
             <div className="max-h-[600px] overflow-x-visible overflow-y-scroll">
                 {currentDraft.built_draft && (
                     <>
-                        <SegmentedControl
-                            label="Draft board view"
-                            options={VIEW_OPTIONS}
-                            value={boardView}
-                            onChange={setBoardView}
-                        />
+                        <div className="flex items-center justify-between gap-3 px-3.5 pb-2">
+                            <span className="text-ink text-[15px] font-semibold">Picks</span>
+                            <SegmentedControl
+                                label="Draft board view"
+                                options={VIEW_OPTIONS}
+                                value={boardView}
+                                onChange={setBoardView}
+                            />
+                        </div>
                         {boardView === 'feed' ? (
                             <PickFeed
                                 builtDraft={currentDraft.built_draft}

--- a/src/Panels/DraftPanel.test.jsx
+++ b/src/Panels/DraftPanel.test.jsx
@@ -103,6 +103,16 @@ const settle = async (ms) => {
 };
 
 const button = (name) => screen.getByRole('button', { name });
+
+// One sync tick and no more. The panel's old one-shot "Update" button went
+// with the redesigned clock card - the draft id is edited in the Draft source
+// sheet now and the card carries only the sync toggle - so a single tick is
+// switching sync on and stopping before the next one is due.
+const syncOnce = async () => {
+    await click(button('Sync draft'));
+    await settle(0);
+    await click(button('Stop sync'));
+};
 const urlsFetched = () => global.fetch.mock.calls.map((call) => call[0]);
 
 describe('DraftPanel', () => {
@@ -173,8 +183,7 @@ describe('DraftPanel', () => {
     it('hands updateDraftBoard a reducer rather than a finished board when syncing', async () => {
         const { updateDraftBoard } = renderPanel();
 
-        await click(button('Update'));
-        await settle(0);
+        await syncOnce();
 
         expect(updateDraftBoard).toHaveBeenCalledTimes(1);
         const reducer = updateDraftBoard.mock.calls[0][0];
@@ -246,8 +255,7 @@ describe('DraftPanel', () => {
         global.fetch = failing(livePicksFail);
         const { updateDraftBoard } = renderPanel();
 
-        await click(button('Update'));
-        await settle(0);
+        await syncOnce();
 
         expect(updateDraftBoard).toHaveBeenCalledTimes(1);
         const next = updateDraftBoard.mock.calls[0][0](pristineBoard());
@@ -266,8 +274,7 @@ describe('DraftPanel', () => {
         global.fetch = failing((url) => url.includes('traded_picks'));
         const { updateDraftBoard } = renderPanel();
 
-        await click(button('Update'));
-        await settle(0);
+        await syncOnce();
 
         expect(updateDraftBoard).toHaveBeenCalledTimes(1);
         const next = updateDraftBoard.mock.calls[0][0](pristineBoard());
@@ -314,18 +321,19 @@ describe('DraftPanel', () => {
         );
     });
 
-    it('syncs against the draft id typed into the input rather than the original one', async () => {
+    it('syncs against the draft id pasted into the source sheet rather than the original one', async () => {
         renderPanel();
 
+        await click(button(`Draft source: …${DRAFT_ID.slice(-4)}`));
         await act(async () => {
-            fireEvent.change(screen.getByDisplayValue(DRAFT_ID), { target: { value: 'other456' } });
+            fireEvent.change(screen.getByLabelText('Mock draft ID'), { target: { value: '123456' } });
         });
+        await click(button('Use'));
 
-        await click(button('Update'));
-        await settle(0);
+        await syncOnce();
 
         expect(urlsFetched().length).toBeGreaterThan(0);
-        expect(urlsFetched().every((url) => url.includes('other456'))).toBe(true);
+        expect(urlsFetched().every((url) => url.includes('123456'))).toBe(true);
         expect(urlsFetched().some((url) => url.includes(DRAFT_ID))).toBe(false);
     });
 

--- a/src/Panels/DraftSourceSheet.jsx
+++ b/src/Panels/DraftSourceSheet.jsx
@@ -1,0 +1,148 @@
+import { useState } from 'react';
+import Sheet from '../Components/Sheet';
+
+// Sleeper draft ids are numeric strings. Validated on `Use` rather than while
+// typing, so a half-pasted id isn't flagged as wrong mid-paste.
+const isValidDraftId = (value) => /^\d+$/.test(value.trim());
+
+const lastFour = (draftId) => (draftId ? `…${String(draftId).slice(-4)}` : '—');
+
+/** Where the last mock used for this draft is remembered between visits. */
+export const mockStorageKey = (leagueDraftId) => `sleeper-app:last-mock-draft:${leagueDraftId}`;
+
+export function readLastMock(leagueDraftId) {
+    try {
+        return localStorage.getItem(mockStorageKey(leagueDraftId));
+    } catch {
+        // Private-mode Safari throws on localStorage rather than returning
+        // null. A remembered mock is a convenience; losing it is not worth
+        // taking the sheet down for.
+        return null;
+    }
+}
+
+export function writeLastMock(leagueDraftId, draftId) {
+    try {
+        localStorage.setItem(mockStorageKey(leagueDraftId), draftId);
+    } catch {
+        /* see readLastMock */
+    }
+}
+
+const SourceRow = ({ active, name, detail, flag, onClick }) => (
+    <button
+        type="button"
+        onClick={onClick}
+        className={`rounded-row flex w-full items-center gap-2.5 px-3 py-2.5 text-left ${active ? 'bg-mine-row' : ''}`}
+    >
+        <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${active ? 'bg-mine' : 'bg-transparent'}`} />
+        <span className="flex min-w-0 flex-col">
+            <span className={`truncate text-[15px] font-semibold ${active ? 'text-ink' : 'text-ink-muted'}`}>
+                {name}
+            </span>
+            <span className="text-ink-quiet truncate font-mono text-[11px]">{detail}</span>
+        </span>
+        {flag && (
+            <span className="text-live ml-auto shrink-0 font-mono text-[10px] font-semibold tracking-[.1em]">
+                {flag}
+            </span>
+        )}
+    </button>
+);
+
+/**
+ * Point sync at any draft id - the league's own, the last mock used, or a
+ * freshly pasted one. This is where the panel's old raw "Draft ID" input went;
+ * the id itself still lives in DraftPanel as `currentDraftId` and still drives
+ * the same poll, only the place it is edited has moved.
+ *
+ * A mock inherits the league's roster settings, player pool and draft slot,
+ * because none of those are re-fetched when the id changes - only the picks
+ * are. That is the property the explainer line promises, and it holds by
+ * construction rather than by anything this sheet does.
+ */
+const DraftSourceSheet = ({ leagueDraft, currentDraftId, lastMockId, onSelect, onClose, triggerRef }) => {
+    const [pasted, setPasted] = useState('');
+    const [error, setError] = useState(null);
+
+    const leagueDraftId = leagueDraft.draft_id;
+    const onLeagueDraft = currentDraftId === leagueDraftId;
+
+    const use = () => {
+        const value = pasted.trim();
+        if (!isValidDraftId(value)) {
+            setError('That doesn’t look like a Sleeper draft ID — they are digits only.');
+            return;
+        }
+        setError(null);
+        onSelect(value);
+    };
+
+    const leagueDetail = [leagueDraft.season, leagueDraft.player_pool].filter(Boolean).join(' ');
+
+    return (
+        <Sheet
+            title="Draft source"
+            subtitle="Sync reads picks from this draft"
+            onClose={onClose}
+            triggerRef={triggerRef}
+            centerOnDesktop
+        >
+            <div className="flex flex-col gap-0.5 px-2 py-2.5">
+                <SourceRow
+                    active={onLeagueDraft}
+                    name="League draft"
+                    detail={`${leagueDetail} · ${lastFour(leagueDraftId)}`}
+                    flag={leagueDraft.status === 'drafting' ? 'LIVE' : null}
+                    onClick={() => onSelect(leagueDraftId)}
+                />
+                {lastMockId && (
+                    <SourceRow
+                        active={currentDraftId === lastMockId}
+                        name="Mock · last used"
+                        detail={lastFour(lastMockId)}
+                        onClick={() => onSelect(lastMockId)}
+                    />
+                )}
+                {!onLeagueDraft && currentDraftId !== lastMockId && (
+                    <SourceRow active name="Mock draft" detail={lastFour(currentDraftId)} onClick={() => {}} />
+                )}
+            </div>
+
+            <div className="border-line-mid flex flex-col gap-2.5 border-t px-4 py-3.5">
+                <p className="text-ink-quiet m-0 font-mono text-[10px] font-semibold tracking-[.12em]">
+                    PASTE A MOCK DRAFT ID
+                </p>
+                <div className="flex items-center gap-2.5">
+                    <input
+                        type="text"
+                        inputMode="numeric"
+                        aria-label="Mock draft ID"
+                        placeholder="1312088290526003201"
+                        value={pasted}
+                        onChange={(event) => setPasted(event.target.value)}
+                        className="border-line bg-raised-2 text-ink caret-ink-muted rounded-row min-w-0 flex-1 border px-3 py-2.5 font-mono text-[13px]"
+                    />
+                    <button
+                        type="button"
+                        onClick={use}
+                        disabled={pasted.trim().length === 0}
+                        className="bg-mine text-ground shrink-0 rounded-full px-4 py-2 text-[13px] font-semibold disabled:opacity-50"
+                    >
+                        Use
+                    </button>
+                </div>
+                {error && (
+                    <p role="alert" className="text-danger m-0 font-mono text-[11px]">
+                        {error}
+                    </p>
+                )}
+                <p className="text-ink-quiet m-0 font-mono text-[11px]">
+                    A mock keeps this league’s roster settings and your draft slot. Your lineup and ranks are untouched.
+                </p>
+            </div>
+        </Sheet>
+    );
+};
+
+export default DraftSourceSheet;

--- a/src/Panels/DraftSourceSheet.test.jsx
+++ b/src/Panels/DraftSourceSheet.test.jsx
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import DraftSourceSheet, { mockStorageKey, readLastMock, writeLastMock } from './DraftSourceSheet';
+
+// The sheet that replaced the panel's raw "Draft ID" input. What matters here
+// is that every route to a new id ends in one `onSelect` with that id, and
+// that a typo never becomes one: the poll starts against whatever this hands
+// back, so an invalid id is a sync that quietly fetches nothing.
+
+const LEAGUE_DRAFT = {
+    draft_id: '1312088290526003200',
+    season: '2026',
+    player_pool: 'Rookie',
+    status: 'drafting',
+};
+
+const MOCK_ID = '9999999999999998847';
+
+function renderSheet(overrides = {}) {
+    const onSelect = vi.fn();
+    const onClose = vi.fn();
+    render(
+        <DraftSourceSheet
+            leagueDraft={LEAGUE_DRAFT}
+            currentDraftId={LEAGUE_DRAFT.draft_id}
+            lastMockId={null}
+            onSelect={onSelect}
+            onClose={onClose}
+            {...overrides}
+        />,
+    );
+    return { onSelect, onClose };
+}
+
+describe('DraftSourceSheet', () => {
+    afterEach(() => {
+        localStorage.clear();
+    });
+
+    it('marks the league draft as the live source when that is what sync is reading', () => {
+        renderSheet();
+
+        const leagueRow = screen.getByRole('button', { name: /League draft/ });
+        expect(leagueRow).toHaveTextContent('2026 Rookie');
+        // Last four only - the full id is 19 digits and says nothing at a glance.
+        expect(leagueRow).toHaveTextContent('…3200');
+        expect(leagueRow).toHaveTextContent('LIVE');
+    });
+
+    it('switches back to the league draft in one tap from a mock', async () => {
+        const user = userEvent.setup();
+        const { onSelect } = renderSheet({ currentDraftId: MOCK_ID, lastMockId: MOCK_ID });
+
+        await user.click(screen.getByRole('button', { name: /League draft/ }));
+
+        expect(onSelect).toHaveBeenCalledWith(LEAGUE_DRAFT.draft_id);
+    });
+
+    it('offers the last mock used as its own row', async () => {
+        const user = userEvent.setup();
+        const { onSelect } = renderSheet({ lastMockId: MOCK_ID });
+
+        await user.click(screen.getByRole('button', { name: /Mock · last used/ }));
+
+        expect(onSelect).toHaveBeenCalledWith(MOCK_ID);
+    });
+
+    it('accepts a pasted numeric id, trimming it', async () => {
+        const user = userEvent.setup();
+        const { onSelect } = renderSheet();
+
+        await user.type(screen.getByLabelText('Mock draft ID'), '  1234567890  ');
+        await user.click(screen.getByRole('button', { name: 'Use' }));
+
+        expect(onSelect).toHaveBeenCalledWith('1234567890');
+    });
+
+    it('refuses a non-numeric id and says why rather than syncing against it', async () => {
+        const user = userEvent.setup();
+        const { onSelect } = renderSheet();
+
+        await user.type(screen.getByLabelText('Mock draft ID'), 'https://sleeper.com/draft/nfl/123');
+        await user.click(screen.getByRole('button', { name: 'Use' }));
+
+        expect(onSelect).not.toHaveBeenCalled();
+        expect(screen.getByRole('alert')).toHaveTextContent(/digits only/);
+    });
+
+    it('will not submit an empty field at all', () => {
+        renderSheet();
+
+        expect(screen.getByRole('button', { name: 'Use' })).toBeDisabled();
+    });
+});
+
+describe('last mock persistence', () => {
+    afterEach(() => {
+        localStorage.clear();
+    });
+
+    it('round-trips per league draft, so two leagues do not share a mock', () => {
+        writeLastMock('leagueA', '111');
+        writeLastMock('leagueB', '222');
+
+        expect(readLastMock('leagueA')).toBe('111');
+        expect(readLastMock('leagueB')).toBe('222');
+        expect(readLastMock('leagueC')).toBeNull();
+        expect(localStorage.getItem(mockStorageKey('leagueA'))).toBe('111');
+    });
+
+    it('survives a storage backend that throws instead of returning null', () => {
+        const getItem = vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+            throw new Error('SecurityError: private mode');
+        });
+        const setItem = vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+            throw new Error('SecurityError: private mode');
+        });
+
+        // Losing the remembered mock is a shrug; taking the draft screen down
+        // over it is not.
+        expect(() => writeLastMock('leagueA', '111')).not.toThrow();
+        expect(readLastMock('leagueA')).toBeNull();
+
+        getItem.mockRestore();
+        setItem.mockRestore();
+    });
+});

--- a/src/Panels/LineupPanel.jsx
+++ b/src/Panels/LineupPanel.jsx
@@ -3,6 +3,7 @@ import SlotRow from './SlotRow';
 import { slotAccessibleName, slotOccupantLabel } from './lineupLabels.js';
 import Sheet from '../Components/Sheet';
 import BestAvailable, { filterBestAvailable } from '../Components/BestAvailable';
+import { DEFAULT_OWNERSHIP } from '../Components/OwnershipFilters';
 import BestAvailableHandle from '../Components/BestAvailableHandle';
 import ListRow from '../Components/ListRow';
 import PositionTag from '../Components/PositionTag';
@@ -32,6 +33,11 @@ const LineupPanel = ({
     // null means "the live session list" (rankingPlayersIdsList); otherwise a
     // saved list's route_name, resolved against savedRankLists below.
     const [rankListId, setRankListId] = useState(null);
+    // Held here rather than inside BestAvailable because the sheet is mounted
+    // only while open: a scope kept in the sheet would silently reset itself
+    // every time it was reopened, so switching "Other rosters" on would never
+    // last longer than one visit.
+    const [ownership, setOwnership] = useState(DEFAULT_OWNERSHIP);
     // Only meaningful for the handle entry point - Sheet returns focus to it
     // on close. A slot-tap entry has no single stable trigger element to
     // return to (each SlotRow button is one of many, re-rendered on every
@@ -87,7 +93,14 @@ const LineupPanel = ({
     // tracking BestAvailable's own internal chip clicks, which this
     // component has no view into once the chip row is live.
     const subtitleEligibleSlots = scope ? [scope.label] : openSlotLabels;
-    const subtitleCount = filterBestAvailable({ entries, playerInfo, eligibleSlots: subtitleEligibleSlots }).length;
+    const subtitleCount = filterBestAvailable({
+        entries,
+        playerInfo,
+        eligibleSlots: subtitleEligibleSlots,
+        ownership,
+        rosterInfo,
+        myDisplayName,
+    }).length;
 
     const occupantSlot = scope ? rosterSlots[scope.index] : null;
     const occupantPlayer = occupantSlot?.playerId ? playerInfo[occupantSlot.playerId] : null;
@@ -205,6 +218,8 @@ const LineupPanel = ({
                         myDisplayName={myDisplayName}
                         eligibleSlots={sheetEligibleSlots}
                         initialActiveChip={scope ? scope.label : null}
+                        ownership={ownership}
+                        onOwnershipChange={setOwnership}
                         onSelect={handleSelect}
                     />
                 </Sheet>

--- a/src/Panels/LineupPanel.test.jsx
+++ b/src/Panels/LineupPanel.test.jsx
@@ -354,3 +354,133 @@ describe('LineupPanel rank-list switcher', () => {
         expect(screen.getByRole('button', { name: 'Paste a new list' })).toBeInTheDocument();
     });
 });
+
+// The sheet's job is "who can I put here?", and by default that means your own
+// players plus anything unowned. Before the FILTERS chip existed it listed
+// every ranked player eligible for the slot, including ones locked on other
+// managers' rosters, marked "Taken" - visible but unusable, and the majority of
+// a real list mid-season.
+describe('LineupPanel ownership filters', () => {
+    const MINE_WR = { id: '13279', name: 'Carnell Tate' }; // roster 1 - ryangh, rookie
+    const OTHERS_WR = { id: '13294', name: 'Makai Lemon' }; // roster 2
+    const FREE_WR = { id: '536', name: 'Antonio Brown' }; // unowned, 12 years exp
+
+    const openWrSheet = async (user, overrides = {}) => {
+        renderLineup({
+            rankingPlayersIdsList: [rankEntry(MINE_WR.id, 1), rankEntry(OTHERS_WR.id, 2), rankEntry(FREE_WR.id, 3)],
+            ...overrides,
+        });
+        await user.click(screen.getByRole('button', { name: 'WR, empty' }));
+        return screen.getByRole('dialog', { name: 'Fill WR' });
+    };
+
+    const openFilters = async (user) => user.click(screen.getByRole('button', { name: /^FILTERS/ }));
+
+    it('hides players on other managers rosters by default, and counts the two live buckets', async () => {
+        const user = userEvent.setup();
+        const dialog = await openWrSheet(user);
+
+        expect(within(dialog).getByText(MINE_WR.name)).toBeInTheDocument();
+        expect(within(dialog).getByText(FREE_WR.name)).toBeInTheDocument();
+        // The whole point: not shown at all, not shown-and-greyed.
+        expect(within(dialog).queryByText(OTHERS_WR.name)).toBeNull();
+        expect(within(dialog).queryByText('Taken')).toBeNull();
+
+        expect(within(dialog).getByRole('button', { name: 'FILTERS · 2' })).toBeInTheDocument();
+    });
+
+    it('shows other rosters once asked, and says so in the chip count', async () => {
+        const user = userEvent.setup();
+        const dialog = await openWrSheet(user);
+
+        await openFilters(user);
+        await user.click(screen.getByRole('checkbox', { name: /Other rosters/ }));
+
+        expect(within(dialog).getByText(OTHERS_WR.name)).toBeInTheDocument();
+        expect(within(dialog).getByText('Taken')).toBeInTheDocument();
+        expect(within(dialog).getByRole('button', { name: 'FILTERS · 3' })).toBeInTheDocument();
+    });
+
+    // Same shape as the bug reported on the Ranks section: a control that
+    // dismissed its own container on mousedown, so the click that would have
+    // toggled it never landed. Two toggles in a row is what proves the popover
+    // survived the first.
+    it('keeps the popover open across successive toggles rather than dismissing itself', async () => {
+        const user = userEvent.setup();
+        await openWrSheet(user);
+
+        await openFilters(user);
+        await user.click(screen.getByRole('checkbox', { name: /Other rosters/ }));
+
+        expect(screen.getByRole('checkbox', { name: /Other rosters/ })).toHaveAttribute('aria-checked', 'true');
+
+        await user.click(screen.getByRole('checkbox', { name: /My players/ }));
+
+        expect(screen.getByRole('checkbox', { name: /My players/ })).toHaveAttribute('aria-checked', 'false');
+        expect(screen.queryByText(MINE_WR.name)).toBeNull();
+    });
+
+    it('drops veterans when rookies only is on, and puts everything back on reset', async () => {
+        const user = userEvent.setup();
+        const dialog = await openWrSheet(user);
+
+        await openFilters(user);
+        await user.click(screen.getByRole('switch', { name: 'Rookies only' }));
+
+        expect(within(dialog).queryByText(FREE_WR.name)).toBeNull();
+        expect(within(dialog).getByText(MINE_WR.name)).toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: 'Reset to default' }));
+
+        expect(within(dialog).getByText(FREE_WR.name)).toBeInTheDocument();
+        expect(within(dialog).getByRole('button', { name: 'FILTERS · 2' })).toBeInTheDocument();
+    });
+
+    // Ownership is held by LineupPanel, not by the sheet, precisely because the
+    // sheet is unmounted on close - a scope kept inside it would silently
+    // reset itself every time.
+    it('remembers the scope across closing and reopening the sheet', async () => {
+        const user = userEvent.setup();
+        await openWrSheet(user);
+
+        await openFilters(user);
+        await user.click(screen.getByRole('checkbox', { name: /Other rosters/ }));
+        await user.keyboard('{Escape}'); // closes the popover
+        await user.click(screen.getByRole('button', { name: 'Close' }));
+
+        await user.click(screen.getByRole('button', { name: 'WR, empty' }));
+        const reopened = screen.getByRole('dialog', { name: 'Fill WR' });
+
+        expect(within(reopened).getByText(OTHERS_WR.name)).toBeInTheDocument();
+        expect(within(reopened).getByRole('button', { name: 'FILTERS · 3' })).toBeInTheDocument();
+    });
+});
+
+// The slot chips narrow the list to one slot's eligible positions. This is the
+// other half of "who can I put here?" - FLX admits RB/WR/TE, SFLX adds QB, and
+// a named position slot admits only itself.
+describe('LineupPanel slot chip filtering', () => {
+    const FREE_WR = { id: '536', name: 'Antonio Brown' };
+
+    it('filters to the tapped slot position, and widens again on ALL', async () => {
+        const user = userEvent.setup();
+        renderLineup({
+            rankingPlayersIdsList: [rankEntry(FREE_AGENT_QB.id, 1), rankEntry(FREE_WR.id, 2)],
+        });
+
+        await user.click(screen.getByRole('button', { name: 'WR, empty' }));
+        const dialog = screen.getByRole('dialog', { name: 'Fill WR' });
+
+        expect(within(dialog).getByText(FREE_WR.name)).toBeInTheDocument();
+        expect(within(dialog).queryByText(FREE_AGENT_QB.name)).toBeNull();
+
+        // ALL drops the position filter but keeps the list and the ownership
+        // scope - the QB is only reachable through the other open slot.
+        await user.click(within(dialog).getByRole('button', { name: 'ALL' }));
+        expect(within(dialog).getByText(FREE_AGENT_QB.name)).toBeInTheDocument();
+
+        await user.click(within(dialog).getByRole('button', { name: 'QB' }));
+        expect(within(dialog).getByText(FREE_AGENT_QB.name)).toBeInTheDocument();
+        expect(within(dialog).queryByText(FREE_WR.name)).toBeNull();
+    });
+});

--- a/src/Panels/RanksPanel.jsx
+++ b/src/Panels/RanksPanel.jsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Popover from '../Components/Popover';
 import SearchFilterButton from '../Components/SearchFilterButton';
 import OnFocusButton from '../Components/OnFocusButton';
 import PlayerInfoItem from '../Components/PlayerInfoItem';
@@ -46,12 +47,12 @@ const positionChipClass = (active, position) =>
         active ? positionClass(position) : 'border-line text-ink-dim border'
     }`;
 
-// The FILTERS chip's popover/sheet body - toggles plus the ADP type control.
-// Rendered twice by RanksPanel (an anchored desktop popover and a phone
-// Sheet - see the "filters" section below for why), so it's factored out
-// once here rather than kept in sync by hand in two places.
+// The FILTERS chip's popover body - toggles plus the ADP type control. Kept
+// out of the render below purely for legibility now; it used to be factored
+// out because RanksPanel rendered it twice, which is the thing Popover.jsx
+// exists to have stopped.
 const FiltersBody = ({ filters, updateFilters, adpType, setADPType }) => (
-    <div className="flex flex-col gap-4 p-4">
+    <div className="flex flex-col gap-4 p-2.5">
         <div className="flex flex-row flex-wrap gap-1.5">
             {FLAG_TOGGLES.map((filter) => (
                 <SearchFilterButton
@@ -65,62 +66,15 @@ const FiltersBody = ({ filters, updateFilters, adpType, setADPType }) => (
         </div>
         <div className="flex flex-col gap-2">
             <p className="text-ink-dim m-0 font-mono text-[11px] tracking-[.08em]">ADP TYPE</p>
-            <SegmentedControl label="ADP type" options={ADP_TYPE_OPTIONS} value={adpType} onChange={setADPType} />
+            {/* Four segments do not fit the popover's width on a phone, and a
+                segmented control that wraps stops reading as one control -
+                the pill shape ends up around two rows. It scrolls instead. */}
+            <div className="no-scrollbar -mx-0.5 overflow-x-auto px-0.5">
+                <SegmentedControl label="ADP type" options={ADP_TYPE_OPTIONS} value={adpType} onChange={setADPType} />
+            </div>
         </div>
     </div>
 );
-
-// The desktop half of the FILTERS control: anchored under the chip rather
-// than centred like Sheet, so it gets its own small close-on-Escape/
-// outside-click/focus-return handling instead of reusing Sheet's (which is
-// built around the bottom-sheet/centred-modal shape, not an anchored one).
-const FiltersDesktopPopover = ({ triggerRef, onClose, children }) => {
-    const popoverRef = useRef(null);
-
-    useEffect(() => {
-        popoverRef.current?.focus();
-        const trigger = triggerRef.current;
-        return () => {
-            trigger?.focus();
-        };
-        // Mount/unmount only, same as Sheet's own focus effect.
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
-
-    useEffect(() => {
-        const onKeyDown = (event) => {
-            if (event.key === 'Escape') {
-                onClose();
-            }
-        };
-        const onPointerDown = (event) => {
-            const popover = popoverRef.current;
-            const trigger = triggerRef.current;
-            if (popover && !popover.contains(event.target) && trigger && !trigger.contains(event.target)) {
-                onClose();
-            }
-        };
-        document.addEventListener('keydown', onKeyDown);
-        document.addEventListener('mousedown', onPointerDown);
-        return () => {
-            document.removeEventListener('keydown', onKeyDown);
-            document.removeEventListener('mousedown', onPointerDown);
-        };
-    }, [onClose, triggerRef]);
-
-    return (
-        <div
-            ref={popoverRef}
-            role="dialog"
-            aria-modal="true"
-            aria-label="Filters"
-            tabIndex={-1}
-            className="border-line bg-raised rounded-card shadow-float absolute top-full right-0 z-50 mt-2 hidden w-[260px] border outline-none md:block"
-        >
-            {children}
-        </div>
-    );
-};
 
 const RanksPanel = ({
     isLoading,
@@ -418,15 +372,20 @@ const RanksPanel = ({
                             >
                                 FILTERS{nonDefaultFilterCount > 0 ? ` · ${nonDefaultFilterCount}` : ''}
                             </button>
-                            {/* Rendered as two trees (anchored popover for md
-                                and up, Sheet for below it) rather than one
-                                repositioned element - the same "both exist,
-                                only one is visible" shape AppShell already
-                                uses for its section nav vs tab bar. */}
+                            {/* One anchored popover at every width, not a
+                                desktop popover plus a phone Sheet. The two-tree
+                                version left the hidden desktop half mounted on
+                                a phone, where its outside-click listener saw
+                                every tap inside the Sheet as "outside" and
+                                closed the whole control on mousedown - before
+                                the click that would have toggled a filter could
+                                land. See Popover.jsx. */}
                             {filtersOpen && (
-                                <FiltersDesktopPopover
+                                <Popover
                                     triggerRef={filtersChipRef}
                                     onClose={() => setFiltersOpen(false)}
+                                    label="Filters"
+                                    width={280}
                                 >
                                     <FiltersBody
                                         filters={filters}
@@ -434,24 +393,10 @@ const RanksPanel = ({
                                         adpType={adpType}
                                         setADPType={setADPType}
                                     />
-                                </FiltersDesktopPopover>
+                                </Popover>
                             )}
                         </div>
                     </div>
-
-                    {filtersOpen && (
-                        // No `centerOnDesktop`, so Sheet already carries its
-                        // own `md:hidden` - this is the phone half of the
-                        // control; FiltersDesktopPopover above is the other.
-                        <Sheet title="Filters" onClose={() => setFiltersOpen(false)} triggerRef={filtersChipRef}>
-                            <FiltersBody
-                                filters={filters}
-                                updateFilters={updateFilters}
-                                adpType={adpType}
-                                setADPType={setADPType}
-                            />
-                        </Sheet>
-                    )}
 
                     {showPasteSheet && (
                         <Sheet

--- a/src/Panels/RanksPanel.test.jsx
+++ b/src/Panels/RanksPanel.test.jsx
@@ -82,11 +82,12 @@ const openPasteSheet = async (user) => {
 };
 
 // The four flag toggles (Taken/My players/Only rookies/All players) and the
-// ADP type control both moved into the FILTERS popover (step 6e), which
-// renders as two trees at once - an anchored desktop popover and a phone
-// Sheet, both always in the DOM together the same way AppShell's section nav
-// and tab bar are (see RanksPanel.jsx's comment on FiltersDesktopPopover) -
-// so every query against something inside it comes back twice. `openFilters`
+// ADP type control both live in the FILTERS popover (step 6e). That used to
+// render as two trees at once - an anchored desktop popover plus a phone Sheet
+// - which is why the queries below take the first match; it is one popover at
+// every width now (see Popover.jsx and the regression test at the bottom of
+// this file), and the `getAllBy...[0]` form is kept only so this stays robust
+// to that shape rather than asserting on how many copies exist. `openFilters`
 // is idempotent (checks before clicking) so tests can call it before more
 // than one toggle in the same case without accidentally closing it again.
 const openFilters = async (user) => {
@@ -269,5 +270,59 @@ describe('RanksPanel ADP type picker', () => {
         expect(screen.getAllByRole('button', { name: 'Rookie' })[0]).toHaveAttribute('aria-pressed', 'true');
         expect(screen.getAllByRole('button', { name: 'Startup' })[0]).toHaveAttribute('aria-pressed', 'false');
         expect(screen.getByRole('button', { name: 'FILTERS · 1' })).toBeTruthy();
+    });
+});
+
+// The reported bug: with the FILTERS popover open, tapping any control inside
+// it closed the whole thing and the toggle never applied. Cause was the
+// desktop-only popover staying mounted (behind `hidden md:block`) underneath
+// the phone Sheet, where its document-level outside-click listener counted
+// every tap inside the Sheet as "outside" and closed on mousedown - before the
+// click that would have toggled the filter could land.
+//
+// jsdom has no stylesheet, so `hidden md:block` never hid anything here and
+// both copies were always "visible" to a test - which is exactly why the whole
+// suite stayed green while the phone was broken. What this asserts instead is
+// the behaviour: the control still responds, and the popover is still there
+// afterwards.
+describe('RanksPanel FILTERS popover stays open while it is used', () => {
+    it('applies a toggle instead of dismissing itself, twice in a row', async () => {
+        const user = userEvent.setup();
+        renderPanel();
+
+        await user.click(screen.getByRole('button', { name: /^FILTERS/ }));
+        expect(screen.getAllByRole('checkbox', { name: 'Taken' })[0]).toBeInTheDocument();
+
+        await user.click(screen.getAllByRole('checkbox', { name: 'Taken' })[0]);
+
+        // Still open, and the toggle took.
+        expect(screen.getAllByRole('checkbox', { name: 'Taken' })[0].checked).toBe(true);
+
+        await user.click(screen.getAllByRole('checkbox', { name: 'Only rookies' })[0]);
+
+        expect(screen.getAllByRole('checkbox', { name: 'Only rookies' })[0].checked).toBe(true);
+        expect(screen.getAllByRole('checkbox', { name: 'Taken' })[0].checked).toBe(true);
+        expect(screen.getByRole('button', { name: 'FILTERS · 2' })).toBeInTheDocument();
+    });
+
+    it('closes on the chip, on Escape, and on a click outside it', async () => {
+        const user = userEvent.setup();
+        renderPanel();
+
+        const chip = () => screen.getByRole('button', { name: /^FILTERS/ });
+        const isOpen = () => screen.queryAllByRole('checkbox', { name: 'Taken' }).length > 0;
+
+        await user.click(chip());
+        expect(isOpen()).toBe(true);
+        await user.click(chip());
+        expect(isOpen()).toBe(false);
+
+        await user.click(chip());
+        await user.keyboard('{Escape}');
+        expect(isOpen()).toBe(false);
+
+        await user.click(chip());
+        await user.click(screen.getByRole('heading', { name: 'Ranks' }));
+        expect(isOpen()).toBe(false);
     });
 });

--- a/src/lib/draftClock.js
+++ b/src/lib/draftClock.js
@@ -143,6 +143,28 @@ export function formatTimeLeft(msLeft, mode) {
     return formatCoarse(msLeft);
 }
 
+/** Under this much time left, the clock card's bar and numeral go `danger`. */
+export const URGENT_MS = 30000;
+
+/**
+ * How much of the current pick's timer is gone, `0`..`1`, or `null` when there
+ * is no timer to be a fraction of (`not-started`, `complete`, `untimed`) -
+ * which is also the signal to render no progress bar at all rather than an
+ * empty one.
+ */
+export function pickProgress(draft, now = Date.now()) {
+    const deadline = pickDeadline(draft);
+    if (deadline === null) {
+        return null;
+    }
+    const total = (draft.settings?.pick_timer ?? 0) * 1000;
+    if (total <= 0) {
+        return null;
+    }
+    const elapsed = total - (deadline - now);
+    return Math.min(1, Math.max(0, elapsed / total));
+}
+
 /**
  * How often to re-poll the sync endpoint: fast for a live-paced draft, slow
  * otherwise. Hammering the endpoint every 3 seconds against a 24-hour clock

--- a/src/lib/draftClock.test.js
+++ b/src/lib/draftClock.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { pickClockMode, pickDeadline, formatTimeLeft, pollIntervalMs } from './draftClock';
+import { pickClockMode, pickDeadline, formatTimeLeft, pickProgress, pollIntervalMs } from './draftClock';
 
 const NOW = Date.UTC(2026, 6, 27, 12, 0, 0);
 
@@ -235,5 +235,33 @@ describe('pollIntervalMs', () => {
 
     it('polls every 30 seconds when not-started', () => {
         expect(pollIntervalMs({ status: 'pre_draft', start_time: null, last_picked: null, settings: {} })).toBe(30000);
+    });
+});
+
+describe('pickProgress', () => {
+    const NOW = Date.UTC(2026, 6, 27, 12, 0, 0);
+    const live = { status: 'drafting', start_time: NOW, last_picked: null, settings: { pick_timer: 100 } };
+
+    it('is the fraction of the pick timer already gone', () => {
+        expect(pickProgress(live, NOW)).toBe(0);
+        expect(pickProgress(live, NOW + 25000)).toBe(0.25);
+        expect(pickProgress(live, NOW + 100000)).toBe(1);
+    });
+
+    it('clamps rather than running past the ends, so the bar never overflows its track', () => {
+        expect(pickProgress(live, NOW + 500000)).toBe(1);
+        // A clock skew that puts "now" before the pick started must not give a
+        // negative width.
+        expect(pickProgress(live, NOW - 5000)).toBe(0);
+    });
+
+    it('is null wherever there is no timer to be a fraction of', () => {
+        expect(pickProgress({ status: 'pre_draft', start_time: null, last_picked: null, settings: {} })).toBeNull();
+        expect(
+            pickProgress({ status: 'complete', start_time: NOW, last_picked: NOW, settings: { pick_timer: 90 } }),
+        ).toBeNull();
+        expect(
+            pickProgress({ status: 'drafting', start_time: NOW, last_picked: null, settings: { pick_timer: 0 } }),
+        ).toBeNull();
     });
 });

--- a/src/lib/onTheClock.js
+++ b/src/lib/onTheClock.js
@@ -1,0 +1,63 @@
+/**
+ * Who the board says is picking right now, and how far away your own next pick
+ * is. Pure reads over the built draft - no React, no fetching - so the clock
+ * card can be a dumb renderer and this can be tested without mounting it.
+ *
+ * "On the clock" is derived from the board rather than from any field Sleeper
+ * sends, because the board is the thing the app already keeps in sync: the
+ * first pick in draft order with no `player_id` on it is the one being waited
+ * on. That stays true for a manually-entered pick as much as a synced one.
+ */
+
+/** The rosters' owner display name for a pick, or null when unattributed. */
+function ownerName(pick, rosterData) {
+    if (!pick.owner_id) {
+        return null;
+    }
+    return rosterData.find((roster) => roster.roster_id === pick.owner_id)?.manager_display_name ?? null;
+}
+
+/**
+ * `{ round, pick }` for the first unmade pick in draft order, or null when the
+ * board is full (or absent). Rounds are walked in the order the board holds
+ * them, and picks within a round likewise - `buildDraftRounds` already
+ * reverses even rounds for a snake draft, so draft order *is* array order here
+ * and this must not re-sort it.
+ */
+export function nextUnpickedPick(builtDraft) {
+    for (const round of builtDraft || []) {
+        for (const pick of round.picks) {
+            if (!pick.player_id) {
+                return { round, pick };
+            }
+        }
+    }
+    return null;
+}
+
+/**
+ * How many picks are made before yours: `0` when you are on the clock now,
+ * `null` when you have no pick left on the board (or there is nothing to
+ * count, e.g. no display name resolved yet). Counted from the pick currently
+ * on the clock, so it is "you in n", not "n picks into the draft".
+ */
+export function picksUntilMine({ builtDraft, rosterData, myDisplayName }) {
+    if (!myDisplayName || !rosterData) {
+        return null;
+    }
+    let distance = 0;
+    let started = false;
+    for (const round of builtDraft || []) {
+        for (const pick of round.picks) {
+            if (!started && pick.player_id) {
+                continue;
+            }
+            started = true;
+            if (ownerName(pick, rosterData) === myDisplayName) {
+                return distance;
+            }
+            distance += 1;
+        }
+    }
+    return null;
+}

--- a/src/lib/onTheClock.test.js
+++ b/src/lib/onTheClock.test.js
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import { nextUnpickedPick, picksUntilMine } from './onTheClock.js';
+
+// Both helpers walk the board in array order rather than sorting it:
+// buildDraftRounds has already put a snake draft's even rounds in reverse, and
+// re-deriving draft order here would be a second opinion about something the
+// board already settled.
+
+const pick = (pickNumber, rosterId, playerId = null) => ({
+    pick_number: pickNumber,
+    roster_id: rosterId,
+    owner_id: rosterId,
+    player_id: playerId,
+});
+
+const rosterData = [
+    { roster_id: 1, manager_display_name: 'ryangh' },
+    { roster_id: 2, manager_display_name: 'crbiehl' },
+    { roster_id: 3, manager_display_name: 'dkline' },
+];
+
+const board = [
+    { round: 1, picks: [pick(1, 2, 'p1'), pick(2, 3, 'p2'), pick(3, 1)] },
+    { round: 2, picks: [pick(1, 1), pick(2, 3), pick(3, 2)] },
+];
+
+describe('nextUnpickedPick', () => {
+    it('returns the first pick in board order with nobody in it', () => {
+        const next = nextUnpickedPick(board);
+
+        expect(next.round.round).toBe(1);
+        expect(next.pick.pick_number).toBe(3);
+    });
+
+    it('returns null for a board with every pick made, and for no board at all', () => {
+        const full = board.map((round) => ({
+            ...round,
+            picks: round.picks.map((entry) => ({ ...entry, player_id: 'someone' })),
+        }));
+
+        expect(nextUnpickedPick(full)).toBeNull();
+        expect(nextUnpickedPick(null)).toBeNull();
+        expect(nextUnpickedPick(undefined)).toBeNull();
+    });
+
+    it('walks the board in the order it is stored, not in pick_number order', () => {
+        // A contract test rather than a reproduction: buildDraftRounds
+        // renumbers a reversed snake round 1..n, so today the two orders
+        // always agree and a stray `.sort()` would be invisible. The board's
+        // own order is still the authority - it is what the feed renders in
+        // and what a snake's reversal is expressed as - so this pins it with a
+        // board where the two disagree.
+        const outOfOrder = [{ round: 1, picks: [pick(3, 3), pick(1, 1), pick(2, 2)] }];
+
+        expect(nextUnpickedPick(outOfOrder).pick.roster_id).toBe(3);
+        expect(picksUntilMine({ builtDraft: outOfOrder, rosterData, myDisplayName: 'ryangh' })).toBe(1);
+    });
+});
+
+describe('picksUntilMine', () => {
+    it('counts from the pick on the clock, not from the start of the board', () => {
+        // 1.3 is on the clock and is roster 1's - mine.
+        expect(picksUntilMine({ builtDraft: board, rosterData, myDisplayName: 'ryangh' })).toBe(0);
+    });
+
+    it('counts the picks in between when the next one is somebody else', () => {
+        // On the clock: 1.3 (roster 1), then 2.1 (roster 1) - so for dkline
+        // (roster 3) the next own pick is 2.2, two picks away.
+        expect(picksUntilMine({ builtDraft: board, rosterData, myDisplayName: 'dkline' })).toBe(2);
+    });
+
+    it('returns null when no pick left on the board is yours', () => {
+        expect(picksUntilMine({ builtDraft: board, rosterData, myDisplayName: 'nobody' })).toBeNull();
+    });
+
+    it('returns null rather than guessing when the display name has not resolved yet', () => {
+        expect(picksUntilMine({ builtDraft: board, rosterData, myDisplayName: null })).toBeNull();
+        expect(picksUntilMine({ builtDraft: board, rosterData: null, myDisplayName: 'ryangh' })).toBeNull();
+    });
+
+    it('attributes a traded pick to whoever owns it now, not who it came from', () => {
+        const traded = [{ round: 1, picks: [{ ...pick(1, 2), owner_id: 1, is_traded: true }, pick(2, 3)] }];
+
+        expect(picksUntilMine({ builtDraft: traded, rosterData, myDisplayName: 'ryangh' })).toBe(0);
+    });
+});

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -9,7 +9,9 @@ export default defineConfig({
         outDir: 'build',
     },
     server: {
-        port: 3000,
+        // Honours PORT so a second dev server can run alongside one already
+        // holding 3000; 3000 stays the default when nothing sets it.
+        port: Number(process.env.PORT) || 3000,
         open: true,
         // The player DB API allowlists only the deployed origin
         // (https://sleeper-player-db.web.app) for CORS, so a direct browser


### PR DESCRIPTION
Four things left over from the redesign, against `design_handoff_sleeper_redesign 2`.

**Draft screen top (frames 1 and 8).** It was still the pre-redesign header — a raw `Draft ID` input, an `Update` button, a bordered clock box, a season/status stack. Now the clock card: `ON THE CLOCK`, the manager, `Pick 2.05 · Round 2`, `YOU IN n`, the countdown, the progress bar (danger under 30s), and the sync action. The draft id moved behind the card's source pill into a **Draft source** sheet, which keeps the league draft one tap away, remembers the last mock per league, and validates on `Use`. `useSeenPicks` now keys on the draft being read, so switching to a mock and back does not flood the feed with false `NEW` flags.

**Lineup sheet filters (frame 6).** New `FILTERS · n` chip, defaulting to *My players* + *Free agents & waivers* with *Other rosters* **off**, plus a rookies-only toggle and a reset. The scope lives in `LineupPanel`, not the sheet, so it survives closing and reopening. The slot chips already filtered by eligible position (`FLX` → RB/WR/TE, `SFLX` → +QB) — that path is now covered by tests.

**Ranks FILTERS bug.** Tapping any control inside the open panel closed it without applying. The desktop popover stayed mounted behind `hidden md:block` on a phone, underneath the phone `Sheet`, and its document-level outside-click listener counted every tap inside that Sheet as "outside" — closing on `mousedown`, before the click that would have toggled the filter. jsdom applies no stylesheet, so both copies looked visible to the suite and it stayed green. There is one `Popover` at every width now (which is also what the design shows), portaled to `body` so neither the horizontally scrolling chip row nor the sheet's scroller clips it, and flipped above the trigger when there is no room below.

**Drag on bottom sheets.** The grab handle was decoration. The whole sheet header is a drag area now: down past 90px dismisses, up past 40px expands, and an expanded sheet collapses on the first drag down rather than going straight to gone. Drags that start on a header control (close, the rank-list pill) stay clicks.

Also: `vite.config.mjs` honours `PORT`, so a second dev server can run beside one already on 3000.

## Verified

Six gates green, 370 → 408 tests. Driven in the browser at 375×812 and 1280: the Ranks toggle now applies with a real mousedown/mouseup/click and the popover stays open; the lineup sheet shows 0 eligible by default against a list of players rostered elsewhere, and 2 once *Other rosters* is on; drag up expands, drag down collapses then dismisses. Sabotage-checked — reverting the ownership default, the dismiss threshold, the outside-click guard, the id validation and the board walk order each fails the tests that cover it.

## Not in scope

The Ranks section keeps its own `Taken / My players / Only rookies / All players` set rather than adopting the shared ownership model; the doc wants one component for both, but that changes the Ranks default, which was not part of this ask.