### PR TITLE
Rebuild the grid at one density, and pin the rank-list pull-up to the tabs

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -446,6 +446,7 @@ class App extends React.Component {
                     rosterInfo={rosterInfoValue}
                     myDisplayName={myDisplayName}
                     eligibleSlots={eligibleSlots}
+                    lineupSet={activeId === 'lineup' ? buildLineupSet(rosterSlots) : undefined}
                     onSelect={activeId === 'lineup' ? this.addToRoster : null}
                 />
             </div>
@@ -568,6 +569,7 @@ class App extends React.Component {
                                                 savedRankLists={savedRankLists}
                                                 savedRankListsLoading={savedRankListsLoading}
                                                 signedIn={signedIn}
+                                                lineupSet={lineupSet}
                                             />
                                         );
                                     }}

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -616,10 +616,13 @@ describe('App', () => {
 
         const renderAndSettle = async () => {
             render(<App />);
-            // The clock card renders from currentDraft regardless of whether a
-            // board could be built, so its eyebrow is the signal that the load
-            // chain ran to completion rather than throwing partway.
-            return await screen.findByText('On the clock', {}, { timeout: 5000 });
+            // The clock card's draft-source pill renders from currentDraft
+            // regardless of whether a board could be built, so it is the signal
+            // that the load chain ran to completion rather than throwing
+            // partway. (Its eyebrow is not: that reads `ON THE CLOCK` only
+            // while a clock is counting, and a draft with no `settings` is
+            // untimed, so the eyebrow becomes the season instead.)
+            return await screen.findByRole('button', { name: SOURCE_PILL }, { timeout: 5000 });
         };
 
         it('renders the panels when the draft response has no settings', async () => {
@@ -714,9 +717,9 @@ describe('App', () => {
         });
 
         // The clock card renders whether or not a board could be built, so its
-        // eyebrow is the signal the load chain finished.
+        // draft-source pill is the signal the load chain finished.
         render(<App />);
-        await screen.findByText('On the clock', {}, { timeout: 5000 });
+        await screen.findByRole('button', { name: SOURCE_PILL }, { timeout: 5000 });
 
         expect(screen.queryAllByRole('button', { name: /^Round \d+, pick \d+/ }).length).toBe(0);
         expect(screen.queryByRole('status')).toBeNull();

--- a/src/Components/BestAvailable.jsx
+++ b/src/Components/BestAvailable.jsx
@@ -4,7 +4,7 @@ import PositionTag from './PositionTag';
 import OwnershipFilters, { DEFAULT_OWNERSHIP, matchesOwnership } from './OwnershipFilters';
 import { playerAccessibleName } from './playerInfoLabels.js';
 import { eligiblePositionsForSlot } from '../lib/roster.js';
-import { isTaken, rosteredBy } from '../lib/rosterInfo.js';
+import { isInLineup, isTaken, rosteredBy } from '../lib/rosterInfo.js';
 
 const playerId = (entry) => entry.match_results[0][0];
 
@@ -87,6 +87,7 @@ const BestAvailable = ({
     initialActiveChip = null,
     ownership: controlledOwnership,
     onOwnershipChange,
+    lineupSet,
     onSelect,
 }) => {
     const [activeChip, setActiveChip] = useState(initialActiveChip);
@@ -104,10 +105,16 @@ const BestAvailable = ({
     // who hasn't pasted anything yet), not an edge case of an otherwise-full
     // list - so it gets its own plain message rather than an empty list under
     // a chip row that filters nothing.
+    //
+    // It no longer tells the reader to go somewhere else, because it no longer
+    // has to: the sheet's own header carries the rank-list switcher, so
+    // choosing a saved list or starting a new one both happen from here. The
+    // old copy ("paste one in the Ranks section") was written when this sheet
+    // could not be opened at all without a list already loaded.
     if (entries.length === 0) {
         return (
             <p className="text-ink-muted m-0 flex min-h-11 items-center px-4 text-sm">
-                No rank list yet - paste one in the Ranks section to see who is still left.
+                No rank list selected - pick one from the switcher above, or paste a new one.
             </p>
         );
     }
@@ -191,7 +198,15 @@ const BestAvailable = ({
                     // (`!taken || isMine`). On the draft sheet this changes
                     // nothing, because that sheet passes no onSelect at all.
                     const unavailable = taken && !isMine;
-                    const accessibleName = playerAccessibleName({ player, taken, rosteredByName, isMine });
+                    // Already filling one of your slots. Adding them again
+                    // would silently move them out of the slot they are in -
+                    // the fill path writes the id into the tapped slot without
+                    // checking the rest of the lineup - so the row says so and
+                    // offers nothing to tap. `lineupSet` is optional: the
+                    // draft's read-only sheet has no lineup to compare against
+                    // and passes none.
+                    const started = Boolean(lineupSet) && isInLineup(lineupSet, id);
+                    const accessibleName = playerAccessibleName({ player, taken, rosteredByName, isMine, started });
 
                     return (
                         <li key={id}>
@@ -222,10 +237,11 @@ const BestAvailable = ({
                                             onSelect && (
                                                 <button
                                                     type="button"
+                                                    disabled={started}
                                                     onClick={() => onSelect(player)}
-                                                    className="bg-mine-chip text-mine shrink-0 rounded-full px-[11px] py-1.5 font-mono text-[11px] font-semibold"
+                                                    className="bg-mine-chip text-mine shrink-0 rounded-full px-[11px] py-1.5 font-mono text-[11px] font-semibold disabled:opacity-50"
                                                 >
-                                                    Add
+                                                    {started ? 'Started' : 'Add'}
                                                 </button>
                                             )
                                         )}

--- a/src/Components/BestAvailable.test.jsx
+++ b/src/Components/BestAvailable.test.jsx
@@ -94,11 +94,16 @@ describe('BestAvailable', () => {
         expect(within(theirs).getByText('Taken')).toBeInTheDocument();
     });
 
-    it('renders an empty state when there is no rank list at all', () => {
+    // The copy points at the sheet's own switcher, not at another section: the
+    // handle opens this sheet with no list loaded now, and choosing or starting
+    // a list both happen from its header. Telling the reader to go to Ranks was
+    // written when this state was unreachable.
+    it('renders an empty state that points at the switcher above it', () => {
         renderBestAvailable({ entries: [] });
 
-        expect(screen.getByText(/No rank list yet/)).toBeInTheDocument();
-        expect(screen.getByText(/Ranks section/)).toBeInTheDocument();
+        expect(screen.getByText(/No rank list selected/)).toBeInTheDocument();
+        expect(screen.getByText(/switcher above/)).toBeInTheDocument();
+        expect(screen.queryByText(/Ranks section/)).toBeNull();
     });
 
     it('skips an entry whose id is absent from playerInfo rather than rendering a hole', () => {

--- a/src/Components/BestAvailableHandle.jsx
+++ b/src/Components/BestAvailableHandle.jsx
@@ -2,13 +2,23 @@
 // (not a div wearing an onClick) so it carries a natural aria-expanded and
 // keyboard activation for free - the thing BestAvailableSheet's old toggle
 // already got right and this keeps.
+//
+// Pinned above the tab bar rather than sitting wherever the section's content
+// happens to end. In flow it drifted up the screen the moment a board was
+// shorter than the viewport - on a four-round draft it landed halfway up,
+// reading as a stray strip in the middle of the page rather than as the bottom
+// edge of the screen. It shares its anchor (`--tab-bar-h`) with the sheet it
+// opens, so the sheet now rises from exactly where the handle sat.
+//
+// Panels that render one have to leave `--handle-h` of clearance at the bottom
+// of their scrolling content, or the last row sits underneath it.
 const BestAvailableHandle = ({ isExpanded, onClick, subtitle, buttonRef }) => (
     <button
         ref={buttonRef}
         type="button"
         aria-expanded={isExpanded}
         onClick={onClick}
-        className="border-line bg-raised flex min-h-11 w-full items-center justify-between border-t px-4 py-3 md:hidden"
+        className="border-line bg-raised fixed inset-x-0 bottom-[var(--tab-bar-h)] z-10 flex h-[var(--handle-h)] w-full items-center justify-between border-t px-4 md:hidden"
     >
         <span className="flex flex-col items-start">
             <span className="text-ink text-[14px] font-semibold">Best available</span>

--- a/src/Components/ClockCard.jsx
+++ b/src/Components/ClockCard.jsx
@@ -1,20 +1,33 @@
 import PickClock from './PickClock';
-import { pickProgress, pickDeadline, URGENT_MS } from '../lib/draftClock.js';
+import { pickClockMode, pickProgress, pickDeadline, URGENT_MS } from '../lib/draftClock.js';
 
-// The one always-elevated surface on the draft screen (the other is a sheet).
-// Everything the old panel header said in a stack of paragraphs and a bordered
-// clock box - whose turn it is, which pick, how long is left, and where sync is
-// reading from - reads across three rows here.
+// The clock's four modes collapse into two card shapes. A `live`/`slow` draft
+// is counting something down, so it gets the eyebrow, the countdown numeral,
+// the progress bar and a primary sync action. The other three - complete,
+// untimed, not-yet-started - have nothing to count, and dressing them in the
+// countdown's chrome is what produced the card Ryan screenshotted: `ON THE
+// CLOCK` over `No pick on the clock`, saying the same non-fact twice, under a
+// full-width violet button competing with a board that had already finished.
 //
-// The draft-source pill is the only way to point sync somewhere else now: the
-// raw "Draft ID" text input that used to sit at the top of the panel body moved
-// behind it (see DraftSourceSheet.jsx), so a mock draft id is still one tap
-// away without a bare id field on the main screen.
+// So in those modes the eyebrow becomes the draft's own identity (`2026
+// ROOKIE`), the headline is the state itself (`Draft complete`), the subtitle
+// counts what there is to count (`48 picks · synced 2m ago`), and sync drops to
+// a secondary outlined pill.
+const isCountingDown = (mode) => mode === 'live' || mode === 'slow';
+
+const STATE_HEADLINE = {
+    complete: 'Draft complete',
+    untimed: 'Untimed draft',
+    'not-started': "Draft hasn't started",
+};
+
 const ClockCard = ({
     draft,
     onTheClockName,
     pickLabel,
     picksUntilMine,
+    picksMade,
+    syncedLabel,
     sourceLabel,
     sourceRef,
     isSourceOpen,
@@ -22,21 +35,39 @@ const ClockCard = ({
     isSyncing,
     onToggleSync,
 }) => {
-    const progress = pickProgress(draft);
+    const mode = pickClockMode(draft);
+    const counting = isCountingDown(mode);
+    const progress = counting ? pickProgress(draft) : null;
     const deadline = pickDeadline(draft);
-    const urgent = deadline !== null && deadline - Date.now() <= URGENT_MS;
+    const urgent = counting && deadline !== null && deadline - Date.now() <= URGENT_MS;
 
     // "YOU IN 0" is nonsense for the case that matters most, so zero gets its
     // own words. `null` (no pick of yours left on the board, or no display
-    // name yet) shows nothing at all rather than a guess.
+    // name yet) shows nothing at all rather than a guess. A draft that is not
+    // counting down has nobody on the clock, so it never applies.
     const yourTurnLabel =
-        picksUntilMine === null ? null : picksUntilMine === 0 ? 'YOUR PICK' : `YOU IN ${picksUntilMine}`;
+        !counting || picksUntilMine === null ? null : picksUntilMine === 0 ? 'YOUR PICK' : `YOU IN ${picksUntilMine}`;
+
+    const seasonLabel = [draft.season, draft.player_pool].filter(Boolean).join(' ');
+    const eyebrow = counting ? 'On the clock' : seasonLabel || 'Draft';
+
+    // `48 picks · synced 2m ago` - the two things still worth knowing once
+    // there is no clock. The sync half is omitted until a sync has actually
+    // landed, rather than claiming "never".
+    const restingSubtitle = [
+        picksMade === null ? null : `${picksMade} ${picksMade === 1 ? 'pick' : 'picks'}`,
+        syncedLabel,
+    ]
+        .filter(Boolean)
+        .join(' · ');
+
+    const syncLabel = isSyncing ? 'Stop sync' : 'Sync draft';
 
     return (
         <div className="bg-raised border-line rounded-card m-3.5 flex flex-col gap-3.5 border p-4">
             <div className="flex items-center gap-2.5">
                 <span className="text-ink-quiet font-mono text-[10px] font-semibold tracking-[.14em] uppercase">
-                    On the clock
+                    {eyebrow}
                 </span>
                 <span className="ml-auto flex items-center gap-2.5">
                     {yourTurnLabel && (
@@ -64,11 +95,33 @@ const ClockCard = ({
             <div className="flex items-end justify-between gap-3">
                 <span className="flex min-w-0 flex-col">
                     <span className="text-ink truncate text-[19px] font-semibold tracking-[-0.02em]">
-                        {onTheClockName}
+                        {counting ? onTheClockName : STATE_HEADLINE[mode]}
                     </span>
-                    {pickLabel && <span className="text-ink-quiet font-mono text-[12px]">{pickLabel}</span>}
+                    {counting
+                        ? pickLabel && <span className="text-ink-quiet font-mono text-[12px]">{pickLabel}</span>
+                        : restingSubtitle && (
+                              <span className="text-ink-quiet font-mono text-[12px]">{restingSubtitle}</span>
+                          )}
                 </span>
-                <PickClock draft={draft} />
+                {counting ? (
+                    <PickClock draft={draft} />
+                ) : (
+                    // Secondary, and beside the headline rather than under it:
+                    // on a finished draft, re-syncing is a thing you might do,
+                    // not the thing to do.
+                    <button
+                        type="button"
+                        onClick={onToggleSync}
+                        // The pill reads `SYNC`, but the action is the same one
+                        // the counting-down card spells out in full - so it
+                        // keeps that name rather than making a screen reader
+                        // (or a test) treat the two shapes as two features.
+                        aria-label={syncLabel}
+                        className="border-line text-ink-muted min-h-11 shrink-0 rounded-full border px-3 font-mono text-[11px] font-semibold tracking-[.08em] uppercase"
+                    >
+                        <span aria-hidden="true">{isSyncing ? 'Stop' : 'Sync'}</span>
+                    </button>
+                )}
             </div>
 
             {progress !== null && (
@@ -80,15 +133,17 @@ const ClockCard = ({
                 </div>
             )}
 
-            <button
-                type="button"
-                onClick={onToggleSync}
-                className={`min-h-11 w-full rounded-full text-[13px] font-semibold ${
-                    isSyncing ? 'border-line text-ink-muted border' : 'bg-mine text-ground'
-                }`}
-            >
-                {isSyncing ? 'Stop sync' : 'Sync draft'}
-            </button>
+            {counting && (
+                <button
+                    type="button"
+                    onClick={onToggleSync}
+                    className={`min-h-11 w-full rounded-full text-[13px] font-semibold ${
+                        isSyncing ? 'border-line text-ink-muted border' : 'bg-mine text-ground'
+                    }`}
+                >
+                    {syncLabel}
+                </button>
+            )}
         </div>
     );
 };

--- a/src/Components/ClockCard.test.jsx
+++ b/src/Components/ClockCard.test.jsx
@@ -134,3 +134,101 @@ describe('ClockCard', () => {
         expect(onOpenSource).toHaveBeenCalledTimes(1);
     });
 });
+
+// A draft that isn't counting anything down gets a different card, not the
+// countdown's card with its numeral swapped for a word. What Ryan
+// screenshotted was the latter: `ON THE CLOCK` over `No pick on the clock`,
+// which says the same non-fact twice, above a full-width violet Sync button on
+// a board that had already finished.
+describe('ClockCard at rest', () => {
+    const completeDraft = {
+        status: 'complete',
+        season: '2026',
+        player_pool: 'Rookie',
+        start_time: NOW - 86400000,
+        last_picked: NOW - 3600000,
+        settings: { pick_timer: 43200 },
+    };
+
+    const renderResting = (overrides = {}) =>
+        render(
+            <ClockCard
+                draft={completeDraft}
+                onTheClockName="No pick on the clock"
+                pickLabel="2026 Rookie"
+                picksUntilMine={null}
+                picksMade={48}
+                syncedLabel="synced 2m ago"
+                sourceLabel="…3201"
+                onOpenSource={vi.fn()}
+                onToggleSync={vi.fn()}
+                {...overrides}
+            />,
+        );
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(NOW);
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('leads with the state, and never repeats it as a headline under an On-the-clock eyebrow', () => {
+        renderResting();
+
+        expect(screen.getByText('Draft complete')).toBeVisible();
+        expect(screen.queryByText('On the clock')).toBeNull();
+        expect(screen.queryByText('No pick on the clock')).toBeNull();
+    });
+
+    it('takes its eyebrow from the draft itself', () => {
+        renderResting();
+
+        // Rendered uppercase by CSS; the text stays as written.
+        expect(screen.getByText('2026 Rookie')).toBeVisible();
+    });
+
+    it('counts the picks and says when sync last landed', () => {
+        renderResting();
+
+        expect(screen.getByText('48 picks · synced 2m ago')).toBeVisible();
+    });
+
+    it('omits the sync half until a sync has actually landed', () => {
+        renderResting({ syncedLabel: null });
+
+        expect(screen.getByText('48 picks')).toBeVisible();
+        expect(screen.queryByText(/synced/)).toBeNull();
+    });
+
+    it('drops sync to a secondary pill that still answers to the same name', () => {
+        const onToggleSync = vi.fn();
+        renderResting({ onToggleSync });
+
+        // Reads SYNC, named "Sync draft" - the same action the counting-down
+        // card spells out, so neither a screen reader nor a test sees two
+        // different features.
+        const sync = screen.getByRole('button', { name: 'Sync draft' });
+        // Exactly "Sync", not "Sync draft": `toHaveTextContent` is a substring
+        // match, so it passes on the counting-down card's full-width button too
+        // and proves nothing about which shape rendered.
+        expect(sync.textContent).toBe('Sync');
+        sync.click();
+        expect(onToggleSync).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders no countdown and no progress bar', () => {
+        const { container } = renderResting();
+
+        expect(screen.queryByText(/Time expired/)).toBeNull();
+        expect(container.querySelector('[class*="bg-line-mid"]')).toBeNull();
+    });
+
+    it('never claims a turn is coming on a draft with no clock', () => {
+        renderResting({ picksUntilMine: 2 });
+
+        expect(screen.queryByText(/YOU IN/)).toBeNull();
+    });
+});

--- a/src/Components/playerInfoLabels.js
+++ b/src/Components/playerInfoLabels.js
@@ -17,7 +17,19 @@ export const playerAvailabilityText = ({ taken, rosteredByName }) => (taken ? ro
 // convention pickLabels.js uses for your own picks. Replacing the name with a
 // bare "you" would have dropped the identity that the league-switch
 // attribution test in App.test.jsx exists to prove.
-export const playerAccessibleName = ({ player, taken, rosteredByName, isMine = false, lowConfidenceMatch = false }) => {
+// `started` marks a player who already fills one of your lineup slots. It is
+// encoded visibly as a disabled pill reading "Started", which is exactly the
+// kind of state a disabled control announces inconsistently, so it goes in the
+// name too. Appended last, after the optional low-confidence part, so every
+// existing name is unchanged when it is absent.
+export const playerAccessibleName = ({
+    player,
+    taken,
+    rosteredByName,
+    isMine = false,
+    lowConfidenceMatch = false,
+    started = false,
+}) => {
     let availability = 'free agent';
     if (taken) {
         availability = isMine ? `taken by ${rosteredByName} · you` : `taken by ${rosteredByName}`;
@@ -25,6 +37,9 @@ export const playerAccessibleName = ({ player, taken, rosteredByName, isMine = f
     const nameParts = [player.full_name, player.position, availability];
     if (lowConfidenceMatch) {
         nameParts.push('low confidence match');
+    }
+    if (started) {
+        nameParts.push('already started');
     }
     return nameParts.join(', ');
 };

--- a/src/Panels/DraftGrid.jsx
+++ b/src/Panels/DraftGrid.jsx
@@ -1,17 +1,24 @@
-import { useState, useMemo, useRef } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import ManualPickModal from './ManualPickModal';
-import SegmentedControl from '../Components/SegmentedControl';
 import { applyManualPick } from '../lib/liveDraft.js';
 import { managerLabel, pickAccessibleName, pickNumberLabel, positionFillClass } from './pickLabels.js';
 
-const ZOOM_OPTIONS = [
-    { value: 'overview', label: 'Overview' },
-    { value: 'readable', label: 'Readable' },
-];
+// The four positions the key row explains. K and DEF carry no hue anywhere in
+// the system, so they get the neutral dot positionFillClass falls back to and
+// no key entry - there is nothing to decode.
+const KEY_POSITIONS = ['QB', 'RB', 'WR', 'TE'];
+
+const COLUMN_W = 108;
+// 30px of rail plus the board's own 14px left inset. The inset lives inside
+// the rail rather than as padding on the board, because the rail is pinned to
+// the scroll container's left edge: with the padding on the board, the rail
+// jumped 14px leftwards the moment the board was scrolled sideways - sticky
+// pins to the scrollport, which knows nothing about an inner element's padding.
+const RAIL_W = 44;
 
 // First-initial + surname, e.g. "Jordan Love" -> "J.Love". A multi-word
 // surname (a suffix, "St. Brown") keeps everything after the first token as
-// one piece - this only has to fit a 75px cell, not read as a full name.
+// one piece - this only has to fit a 108px cell, not read as a full name.
 const shortPlayerName = (fullName) => {
     const [first, ...rest] = fullName.trim().split(' ');
     return rest.length === 0 ? first : `${first[0]}.${rest.join(' ')}`;
@@ -29,9 +36,19 @@ const buildTeamColumns = (builtDraft) =>
 
 const findPick = (round, boardSpot) => round.picks.find((pick) => pick.board_spot === boardSpot);
 
+const PositionDot = ({ position }) => (
+    <span aria-hidden="true" className={`h-[5px] w-[5px] shrink-0 rounded-full ${positionFillClass(position)}`} />
+);
+
 // One cell of the board: a button carrying the same accessible name PickRow
 // builds for the feed, so the same pick reads identically in either view.
-const GridCell = ({ round, pick, playerInfo, rosterData, myDisplayName, zoom, onSelect }) => {
+//
+// Definition comes from the cell's own fill and hairline, never from a lattice
+// of table rules - which is also why this is a grid of blocks rather than the
+// <table> it used to be. Each cell's accessible name already spells out round,
+// pick, manager and player, so nothing is lost by dropping the <th scope>
+// associations a table gave: the name never depended on them.
+const GridCell = ({ round, pick, playerInfo, rosterData, myDisplayName, onSelect }) => {
     const player = pick.player_id ? playerInfo[pick.player_id] : null;
     const owner = pick.owner_id ? rosterData.find((roster) => roster.roster_id === pick.owner_id) : null;
     const isMine = Boolean(owner?.manager_display_name) && owner.manager_display_name === myDisplayName;
@@ -39,63 +56,47 @@ const GridCell = ({ round, pick, playerInfo, rosterData, myDisplayName, zoom, on
     const accessibleName = pickAccessibleName({ round, pick, player, manager });
     const isMade = Boolean(pick.player_id);
 
-    // A made pick fills with the position colour. Near-black text (`text-ground`)
-    // reads on all four skill-position fills - measured 5.55:1 (QB), 7.92:1
-    // (RB), 6.07:1 (WR), 6.93:1 (TE) against the design's raw hex values, all
-    // clearing AA and all but QB/WR clearing AAA. K/DEF (and any pick missing
-    // a position) fall back to `positionFillClass`'s neutral `bg-line`, which
-    // `text-ground` measured at only 1.36:1 on - so that one case takes
-    // `text-ink` instead, measured at 12.6:1.
-    //
-    // An unmade cell used to be a dashed, unfilled box; that reads as an
-    // "empty slot" everywhere else in the app via a quiet tint instead
-    // (`--raw-empty`, literally "a hint of a row, not a dashed box" in
-    // theme.css), so this cell uses the same token rather than its own
-    // one-off dashed treatment. Either way it stays visibly distinct from a
-    // made cell's saturated fill, even at a glance in overview mode.
-    const hasHueFill = ['QB', 'RB', 'WR', 'TE'].includes(player?.position);
-    const stateClasses = isMade
-        ? `${hasHueFill ? 'text-ground' : 'text-ink'} ${positionFillClass(player?.position)}`
-        : 'bg-empty border border-line-quiet text-ink-muted';
-
-    // Violet marks "yours" as an outline, not a fill, so the position colour
-    // underneath a made pick still shows through. `!` because outline and
-    // border/background utilities can otherwise be reordered by Tailwind's
-    // group-based stylesheet output rather than by where they read here.
-    const mineClasses = isMine ? 'outline! outline-2! outline-mine! outline-offset-[-2px]!' : '';
-
     return (
-        <td className="p-0">
-            <button
-                type="button"
-                aria-label={accessibleName}
-                onClick={onSelect}
-                className={`flex h-[var(--cell-h)] w-[var(--cell-w)] flex-col items-center justify-center overflow-hidden p-0.5 text-[10px] leading-tight ${stateClasses} ${mineClasses}`}
-            >
-                {/* Overview is position colour only, no text at all - that is
-                    the whole point of the zoom level, so nothing renders here
-                    when zoom !== 'readable'. */}
-                {zoom === 'readable' && (
-                    <>
-                        <span className="w-full truncate text-center font-semibold">
-                            {isMade ? (player ? shortPlayerName(player.full_name) : `#${pick.player_id}`) : ''}
-                        </span>
-                        <span className="w-full truncate text-center text-[9px] opacity-80">
-                            {isMade
-                                ? `${player?.team ?? '—'} · ${pickNumberLabel(round, pick)}`
-                                : pickNumberLabel(round, pick)}
-                        </span>
-                    </>
-                )}
-            </button>
-        </td>
+        <button
+            type="button"
+            aria-label={accessibleName}
+            onClick={onSelect}
+            style={{ width: `${COLUMN_W}px` }}
+            className={`rounded-row flex flex-col gap-[3px] border px-[9px] py-2 text-left ${
+                isMine ? 'bg-mine-row border-mine-edge' : 'bg-grid-cell border-grid-line'
+            }`}
+        >
+            <span className="flex min-w-0 items-center gap-1.5">
+                {isMade && <PositionDot position={player?.position} />}
+                <span
+                    className={`min-w-0 truncate text-[13px] font-semibold tracking-[-0.01em] ${
+                        isMine ? 'text-ink' : 'text-ink-soft'
+                    }`}
+                >
+                    {isMade ? (player ? shortPlayerName(player.full_name) : `#${pick.player_id}`) : ''}
+                </span>
+            </span>
+            {/* Indented to sit under the name rather than under the dot -
+                11px is the dot plus its gap. An unmade cell has no dot, so
+                its pick number carries the same indent for the column to
+                stay straight down the board. */}
+            <span className="text-ink-dim pl-[11px] font-mono text-[10px] tabular-nums">
+                {isMade ? `${player?.team ?? '—'} · ${pickNumberLabel(round, pick)}` : pickNumberLabel(round, pick)}
+            </span>
+        </button>
     );
 };
 
-// The grid view of the draft board: teams across the top, rounds down the
-// side, both frozen so a cell scrolled into the middle of the board is still
-// identifiable. See the PR description for why this layout (not the
-// transposed one) and why two zoom stops (not four).
+// The grid view of the draft board: managers across the top, rounds down the
+// side, both pinned so a cell scrolled into the middle of the board is still
+// identifiable.
+//
+// One density. The old overview zoom stop - 23px colour blocks with no text -
+// is deleted rather than restyled: it answered nothing the feed didn't answer
+// better, and it was the only place a position hue appeared as a solid fill
+// wide enough to compete with the violet that means "yours". The dot is the
+// grid's tag form now, and the key row above the board is what makes it
+// legible.
 const DraftGrid = ({
     builtDraft,
     playerInfo,
@@ -105,7 +106,6 @@ const DraftGrid = ({
     myDisplayName,
     onPickChange,
 }) => {
-    const [zoom, setZoom] = useState('overview');
     const [activePick, setActivePick] = useState(null);
     // See PickFeed's identical comment - Sheet returns focus to whichever
     // cell button was open when it closes.
@@ -129,97 +129,65 @@ const DraftGrid = ({
         closeModal();
     };
 
-    const teamLabel = (rosterId) => {
-        const roster = rosterData.find((r) => r.roster_id === rosterId);
-        return roster?.manager_display_name ?? `Unassigned ${rosterId}`;
-    };
-
-    const headerCellClasses =
-        'border-line-quiet bg-ground text-ink-muted sticky top-0 z-10 border p-1 font-mono text-[11px] font-semibold tracking-[.08em] uppercase truncate';
-    const gutterCellClasses =
-        'border-line-quiet bg-ground text-ink-muted sticky left-0 z-10 w-10 border p-1 font-mono text-[11px] font-semibold tracking-[.08em] uppercase';
+    const managerFor = (rosterId) => rosterData.find((roster) => roster.roster_id === rosterId);
 
     return (
         <div>
-            <SegmentedControl label="Zoom level" options={ZOOM_OPTIONS} value={zoom} onChange={setZoom} />
-            {/* This scroll container is the containing block every sticky cell
-                below travels within. The table must NOT be told to fill it
-                (no w-full, no flex-1) - it needs its own natural, wider-than-
-                the-container width for the sticky round gutter and team
-                header to have anywhere to travel to as the container scrolls. */}
+            {/* The only place a position hue appears outside a tag or a filter
+                chip. In the grid the dot *is* the tag, so the board needs one
+                row that says which hue is which. */}
+            <div className="flex items-center gap-3.5 px-3.5 pb-3">
+                {KEY_POSITIONS.map((position) => (
+                    <span key={position} className="flex items-center gap-1.5">
+                        <PositionDot position={position} />
+                        <span className="text-ink-dim font-mono text-[10px] font-semibold tracking-[.1em]">
+                            {position}
+                        </span>
+                    </span>
+                ))}
+                <span className="text-mine ml-auto font-mono text-[10px] font-semibold tracking-[.1em]">YOU</span>
+            </div>
+
+            {/* This scroll container is the containing block every pinned cell
+                below travels within, so the board must keep its own natural
+                width (`w-max`) rather than being told to fill it - otherwise
+                the round rail and manager header have nowhere to travel to. */}
             <div className="max-h-[70vh] overflow-auto">
-                {/* table-layout: fixed only truly ignores cell content - a long
-                    manager name, in particular - when the table ALSO has an
-                    explicit width rather than 'auto'. Verified directly: with
-                    `width: auto`, Chrome still expands columns to fit content
-                    even though computed tableLayout reads 'fixed' and a
-                    <colgroup> sets 23px columns; only pinning the table's own
-                    width (here, gutter + one `--cell-w` per team, via calc())
-                    made columns actually hold their specified width. That is
-                    also what keeps overview's "never scrolls horizontally"
-                    guarantee true regardless of how long a manager's display
-                    name is. calc() re-reads `--cell-w` live, so the table
-                    width updates by itself on a zoom switch. */}
-                <table
-                    data-zoom={zoom}
-                    className="draft-grid table-fixed border-collapse"
-                    style={{ width: `calc(2.5rem + ${teamColumns.length} * var(--cell-w))` }}
+                <div
+                    className="grid w-max gap-1 pr-3.5 pb-2"
+                    style={{ gridTemplateColumns: `${RAIL_W}px repeat(${teamColumns.length}, ${COLUMN_W}px)` }}
                 >
-                    <colgroup>
-                        <col className="w-10" />
-                        {teamColumns.map((team) => (
-                            <col key={team.boardSpot} className="w-[var(--cell-w)]" />
-                        ))}
-                    </colgroup>
-                    <thead>
-                        <tr>
-                            <th scope="col" className={`${gutterCellClasses} left-0 z-20`}>
-                                Rd
-                            </th>
-                            {teamColumns.map((team) => (
-                                <th key={team.boardSpot} scope="col" className={headerCellClasses}>
-                                    {teamLabel(team.rosterId)}
-                                </th>
-                            ))}
-                        </tr>
-                    </thead>
-                    <tbody>
-                        {builtDraft.map((round) => (
-                            <tr key={round.round}>
-                                {/* Visibly just the number - the column is 40px
-                                    wide - but named in full, so a screen reader
-                                    announcing the row says "Round 2" rather than
-                                    "2". */}
-                                <th scope="row" aria-label={`Round ${round.round}`} className={gutterCellClasses}>
-                                    {round.round}
-                                </th>
-                                {teamColumns.map((team) => {
-                                    const pick = findPick(round, team.boardSpot);
-                                    if (!pick) {
-                                        return (
-                                            <td
-                                                key={team.boardSpot}
-                                                className="border-line-quiet h-[var(--cell-h)] w-[var(--cell-w)] border"
-                                            />
-                                        );
-                                    }
-                                    return (
-                                        <GridCell
-                                            key={team.boardSpot}
-                                            round={round}
-                                            pick={pick}
-                                            playerInfo={playerInfo}
-                                            rosterData={rosterData}
-                                            myDisplayName={myDisplayName}
-                                            zoom={zoom}
-                                            onSelect={() => openPick(round, pick)}
-                                        />
-                                    );
-                                })}
-                            </tr>
-                        ))}
-                    </tbody>
-                </table>
+                    {/* The corner has to out-stack both pinned strips, since it
+                        is the one cell that is in both of them. */}
+                    <span className="bg-ground sticky top-0 left-0 z-30" />
+                    {teamColumns.map((team) => {
+                        const manager = managerFor(team.rosterId);
+                        const isMine =
+                            Boolean(manager?.manager_display_name) && manager.manager_display_name === myDisplayName;
+                        return (
+                            <span
+                                key={team.boardSpot}
+                                className={`bg-ground sticky top-0 z-20 truncate px-2.5 pb-1.5 font-mono text-[10px] tracking-[.1em] uppercase ${
+                                    isMine ? 'text-mine font-semibold' : 'text-ink-dim font-medium'
+                                }`}
+                            >
+                                {manager?.manager_display_name ?? `Unassigned ${team.rosterId}`}
+                            </span>
+                        );
+                    })}
+
+                    {builtDraft.map((round) => (
+                        <Round
+                            key={round.round}
+                            round={round}
+                            teamColumns={teamColumns}
+                            playerInfo={playerInfo}
+                            rosterData={rosterData}
+                            myDisplayName={myDisplayName}
+                            onOpenPick={openPick}
+                        />
+                    ))}
+                </div>
             </div>
             {activePick && (
                 <ManualPickModal
@@ -236,5 +204,38 @@ const DraftGrid = ({
         </div>
     );
 };
+
+// A fragment rather than a row element: the cells are direct children of the
+// CSS grid above, so wrapping each round in a box of its own would break the
+// column alignment the whole board depends on.
+const Round = ({ round, teamColumns, playerInfo, rosterData, myDisplayName, onOpenPick }) => (
+    <>
+        {/* Visibly just `R2` - the rail is 30px wide - but named in full, so a
+            screen reader reaching it says "Round 2" rather than "R2". */}
+        <span
+            aria-label={`Round ${round.round}`}
+            className="bg-ground text-ink-dim sticky left-0 z-10 flex items-center pl-3.5 font-mono text-[10px] font-semibold tracking-[.06em]"
+        >
+            R{round.round}
+        </span>
+        {teamColumns.map((team) => {
+            const pick = findPick(round, team.boardSpot);
+            if (!pick) {
+                return <span key={team.boardSpot} />;
+            }
+            return (
+                <GridCell
+                    key={team.boardSpot}
+                    round={round}
+                    pick={pick}
+                    playerInfo={playerInfo}
+                    rosterData={rosterData}
+                    myDisplayName={myDisplayName}
+                    onSelect={() => onOpenPick(round, pick)}
+                />
+            );
+        })}
+    </>
+);
 
 export default DraftGrid;

--- a/src/Panels/DraftGrid.test.jsx
+++ b/src/Panels/DraftGrid.test.jsx
@@ -8,10 +8,15 @@ import rosterFlagsFixture from '../lib/__fixtures__/roster-flags-2026.json';
 import goldenDraft from '../lib/__fixtures__/golden-draft-output.json';
 
 // DraftGrid is the second view of the same board PickFeed already covers, so
-// this file only asserts what's specific to the grid: every pick shows up as
-// a cell at both zoom stops, the accessible name matches the feed's builder
-// exactly (both read off pickLabels.js, so they cannot drift), "mine" marking,
-// unmade-vs-made, and that a cell opens the same modal.
+// this file only asserts what's specific to the grid: every pick shows up as a
+// cell, the accessible name matches the feed's builder exactly (both read off
+// pickLabels.js, so they cannot drift), "mine" marking, unmade-vs-made, column
+// identity on a snake board, and that a cell opens the same modal.
+//
+// There is one density. The overview zoom stop - 23px colour blocks with no
+// text - is deleted rather than restyled, so the tests that used to switch
+// between the two are gone with it; what replaced them is the key row, which is
+// what makes a 5px dot legible now that the dot is the grid's whole tag.
 
 const { rosterDataRaw, managerData, playerInfo, builtDraft } = rosterFlagsFixture;
 
@@ -58,24 +63,9 @@ const expectedNameFor = (pick) => {
     return pickAccessibleName({ round, pick, player, manager });
 };
 
-const setZoom = async (user, label) => {
-    await user.click(screen.getByRole('button', { name: label }));
-};
-
 describe('DraftGrid cell coverage', () => {
-    it('renders every pick in the round as a cell in overview mode', () => {
+    it('renders every pick in the round as a cell', () => {
         renderGrid();
-
-        round.picks.forEach((pick) => {
-            expect(screen.getByRole('button', { name: expectedNameFor(pick) })).toBeInTheDocument();
-        });
-    });
-
-    it('renders every pick in the round as a cell in readable mode too', async () => {
-        const user = userEvent.setup();
-        renderGrid();
-
-        await setZoom(user, 'Readable');
 
         round.picks.forEach((pick) => {
             expect(screen.getByRole('button', { name: expectedNameFor(pick) })).toBeInTheDocument();
@@ -91,10 +81,33 @@ describe('DraftGrid cell coverage', () => {
         expect(unmadePick.player_id).toBeNull();
         expect(screen.getByRole('button', { name: 'Round 1, pick 1, HEFFinAround305' })).toBeInTheDocument();
     });
+
+    it('names every manager column, and the round rail in full rather than as R1', () => {
+        renderGrid();
+
+        expect(screen.getByText('HEFFinAround305')).toBeVisible();
+        // Visibly "R1" - the rail is 30px wide - but named "Round 1", so a
+        // screen reader reaching it says something useful.
+        expect(screen.getByLabelText('Round 1')).toHaveTextContent('R1');
+    });
+});
+
+describe('DraftGrid position key', () => {
+    // The grid is the only place a position hue appears outside a tag or a
+    // filter chip, so it is the only place that needs a key. Without it a 5px
+    // coloured dot is undecodable.
+    it('explains all four hued positions, and marks which column is yours', () => {
+        renderGrid();
+
+        ['QB', 'RB', 'WR', 'TE'].forEach((position) => {
+            expect(screen.getByText(position)).toBeVisible();
+        });
+        expect(screen.getByText('YOU')).toBeVisible();
+    });
 });
 
 describe('DraftGrid your-pick marking', () => {
-    it('outlines my own pick and leaves everyone else unmarked', () => {
+    it('marks my own cell and leaves everyone else unmarked', () => {
         renderGrid();
 
         const myPick = round.picks.find((pick) => pick.pick_number === 3);
@@ -103,16 +116,22 @@ describe('DraftGrid your-pick marking', () => {
         const myCell = screen.getByRole('button', { name: expectedNameFor(myPick) });
         const othersCell = screen.getByRole('button', { name: expectedNameFor(othersPick) });
 
-        expect(myCell.className).toMatch(/outline-mine/);
-        expect(othersCell.className).not.toMatch(/outline-mine/);
+        // Yours is a violet fill plus a violet edge now, not an inset outline
+        // over a saturated position fill - there is no position fill left to
+        // show through.
+        expect(myCell.className).toMatch(/border-mine-edge/);
+        expect(othersCell.className).not.toMatch(/border-mine-edge/);
+
+        // The visual encoding is colour-only, so the meaning also has to be in
+        // the name - which it is, via managerLabel's "· you".
+        expect(myCell.getAttribute('aria-label')).toContain('· you');
+        expect(othersCell.getAttribute('aria-label')).not.toContain('· you');
     });
 });
 
 describe('DraftGrid unmade vs made picks', () => {
-    it('renders an unmade pick as empty in readable mode rather than as a made pick', async () => {
-        const user = userEvent.setup();
+    it('renders an unmade pick as its pick number alone rather than as a made pick', () => {
         renderGrid();
-        await setZoom(user, 'Readable');
 
         const unmadePick = round.picks.find((pick) => pick.pick_number === 1);
         const cell = screen.getByRole('button', { name: expectedNameFor(unmadePick) });
@@ -126,19 +145,18 @@ describe('DraftGrid unmade vs made picks', () => {
         expect(cell.textContent).not.toContain('—');
     });
 
-    it('renders a made pick with the player visible in readable mode', async () => {
-        const user = userEvent.setup();
+    it('renders a made pick as a short name over its team and pick', () => {
         const filledRound = {
             ...round,
             picks: round.picks.map((pick) => (pick.pick_number === 1 ? { ...pick, player_id: FREE_AGENT.id } : pick)),
         };
         renderGrid({ builtDraft: [filledRound] });
-        await setZoom(user, 'Readable');
 
         const filledPick = filledRound.picks.find((pick) => pick.pick_number === 1);
         const cell = screen.getByRole('button', { name: expectedNameFor(filledPick) });
 
         expect(within(cell).getByText('M.Klein')).toBeInTheDocument();
+        expect(within(cell).getByText(`${playerInfo[FREE_AGENT.id].team} · 1.01`)).toBeInTheDocument();
     });
 });
 
@@ -150,8 +168,13 @@ describe('DraftGrid column identity on a snake board', () => {
     const snakeBoard = goldenDraft.snake.built_draft;
     const snakeRound2 = snakeBoard[1];
 
-    it('puts a pick in its board_spot column, not its pick_number column', async () => {
-        const user = userEvent.setup();
+    // Note what this does and does not pin down. Round 1 of a snake is not
+    // reversed, so `buildTeamColumns` (which reads round 1) produces the same
+    // column order whether it sorts by board_spot or pick_number - that half is
+    // not observable here. What is observable is the lookup: finding each
+    // round's pick by pick_number instead of board_spot puts round 2's picks in
+    // the wrong columns, which is what this asserts.
+    it('puts a pick in its board_spot column, not its pick_number column', () => {
         render(
             <DraftGrid
                 builtDraft={snakeBoard}
@@ -163,19 +186,20 @@ describe('DraftGrid column identity on a snake board', () => {
                 onPickChange={vi.fn()}
             />,
         );
-        await setZoom(user, 'Readable');
 
         const reversed = snakeRound2.picks.find((pick) => pick.pick_number === 1);
         expect(reversed.board_spot).not.toBe(reversed.pick_number);
 
-        const row = screen.getByRole('rowheader', { name: 'Round 2' }).closest('tr');
-        const cells = within(row).getAllByRole('button');
+        // The board is a CSS grid rather than a table now, so the row's cells
+        // are read off their own names in DOM order - which is column order,
+        // since the columns are built sorted by board_spot.
+        const rowCells = screen.getAllByRole('button', { name: /^Round 2,/ });
         const columnIndex = snakeBoard[0].picks
             .map((pick) => pick.board_spot)
             .sort((a, b) => a - b)
             .indexOf(reversed.board_spot);
 
-        expect(cells[columnIndex].getAttribute('aria-label')).toContain('pick 1,');
+        expect(rowCells[columnIndex].getAttribute('aria-label')).toContain('pick 1,');
     });
 });
 
@@ -191,21 +215,12 @@ describe('DraftGrid modal', () => {
     });
 });
 
-describe('DraftGrid zoom control', () => {
-    it('starts in overview, where cells carry no visible player text', () => {
+describe('DraftGrid zoom stops are gone', () => {
+    it('offers no density control at all', () => {
         renderGrid();
 
-        expect(screen.getByRole('button', { name: 'Overview' })).toHaveAttribute('aria-pressed', 'true');
-        expect(screen.getByRole('button', { name: 'Readable' })).toHaveAttribute('aria-pressed', 'false');
-    });
-
-    it('switches to readable mode on click', async () => {
-        const user = userEvent.setup();
-        renderGrid();
-
-        await setZoom(user, 'Readable');
-
-        expect(screen.getByRole('button', { name: 'Readable' })).toHaveAttribute('aria-pressed', 'true');
-        expect(screen.getByRole('button', { name: 'Overview' })).toHaveAttribute('aria-pressed', 'false');
+        expect(screen.queryByRole('button', { name: 'Overview' })).toBeNull();
+        expect(screen.queryByRole('button', { name: 'Readable' })).toBeNull();
+        expect(screen.queryByRole('group', { name: 'Zoom level' })).toBeNull();
     });
 });

--- a/src/Panels/DraftPanel.jsx
+++ b/src/Panels/DraftPanel.jsx
@@ -7,11 +7,13 @@ import BestAvailable, { countAvailable } from '../Components/BestAvailable';
 import BestAvailableHandle from '../Components/BestAvailableHandle';
 import ClockCard from '../Components/ClockCard';
 import DraftSourceSheet, { readLastMock, writeLastMock } from './DraftSourceSheet';
+import RankListSwitcher from '../Components/RankListSwitcher';
 import { managerLabel, pickNumberLabel } from './pickLabels.js';
 import { SLEEPER_API_URLS } from '../urls';
 import { syncLiveDraft } from '../lib/liveDraft.js';
 import { pollIntervalMs } from '../lib/draftClock.js';
 import { nextUnpickedPick, picksUntilMine } from '../lib/onTheClock.js';
+import { agoLabel } from '../lib/relativeTime.js';
 import { useSeenPicks } from '../useSeenPicks.js';
 import { usePublishSyncStatus } from '../SyncStatus.jsx';
 const { DRAFT, PICKS, TRADED_PICKS } = SLEEPER_API_URLS;
@@ -21,7 +23,17 @@ const VIEW_OPTIONS = [
     { value: 'grid', label: 'Grid' },
 ];
 
-const DraftPanel = ({ leagueData, playerInfo, rosterInfo, rankingPlayersIdsList, myDisplayName, updateDraftBoard }) => {
+const DraftPanel = ({
+    leagueData,
+    playerInfo,
+    rosterInfo,
+    rankingPlayersIdsList,
+    myDisplayName,
+    updateDraftBoard,
+    savedRankLists,
+    savedRankListsLoading,
+    signedIn,
+}) => {
     const { currentDraft, rosterData } = leagueData;
     const draftPath = DRAFT + currentDraft.draft_id + '/';
     const [isSyncing, setIsSyncing] = useState(false);
@@ -39,6 +51,15 @@ const DraftPanel = ({ leagueData, playerInfo, rosterInfo, rankingPlayersIdsList,
     // Read once at mount rather than on every render: this is a per-league
     // memory of the last mock, and only this component writes it.
     const [lastMockId, setLastMockId] = useState(() => readLastMock(currentDraft.draft_id));
+    // When the last sync landed, for the resting clock card's "synced 2m ago".
+    // Set from the sync itself rather than from the poll's schedule, so a tick
+    // that failed does not claim to have refreshed anything.
+    const [lastSyncedAt, setLastSyncedAt] = useState(null);
+    // null means "whatever list the session currently has"
+    // (rankingPlayersIdsList); otherwise a saved list's route_name. Local to
+    // this panel on purpose - the draft sheet can be reading a different list
+    // than the Ranks section is editing, same as the Lineup sheet's.
+    const [rankListId, setRankListId] = useState(null);
     const bestAvailableHandleRef = useRef(null);
     const sourceButtonRef = useRef(null);
 
@@ -64,6 +85,16 @@ const DraftPanel = ({ leagueData, playerInfo, rosterInfo, rankingPlayersIdsList,
         }
         setIsSourceOpen(false);
     };
+
+    const entries =
+        rankListId && savedRankLists?.[rankListId] ? savedRankLists[rankListId].rank_list : rankingPlayersIdsList;
+
+    const picksMade = currentDraft.built_draft
+        ? currentDraft.built_draft.reduce(
+              (total, round) => total + round.picks.filter((pick) => pick.player_id).length,
+              0,
+          )
+        : null;
 
     const onTheClock = nextUnpickedPick(currentDraft.built_draft);
     const onTheClockName = onTheClock
@@ -122,6 +153,14 @@ const DraftPanel = ({ leagueData, playerInfo, rosterInfo, rankingPlayersIdsList,
                     tradedPicks: tradedPicks || [],
                 }).built_draft,
         );
+
+        // Only when something actually came back. Both fetches swallow their
+        // own failures above, so a tick where the network was down still
+        // reaches this line - and stamping it then would let the card claim a
+        // fresh sync off a request that returned nothing.
+        if (livePicks || tradedPicks) {
+            setLastSyncedAt(Date.now());
+        }
     };
 
     const getLiveDraftRef = useRef(getLiveDraft);
@@ -171,6 +210,8 @@ const DraftPanel = ({ leagueData, playerInfo, rosterInfo, rankingPlayersIdsList,
                     rosterData,
                     myDisplayName,
                 })}
+                picksMade={picksMade}
+                syncedLabel={agoLabel(lastSyncedAt) ? `synced ${agoLabel(lastSyncedAt)}` : null}
                 sourceLabel={`…${String(currentDraftId).slice(-4)}`}
                 sourceRef={sourceButtonRef}
                 isSourceOpen={isSourceOpen}
@@ -188,7 +229,15 @@ const DraftPanel = ({ leagueData, playerInfo, rosterInfo, rankingPlayersIdsList,
                     triggerRef={sourceButtonRef}
                 />
             )}
-            <div className="max-h-[600px] overflow-x-visible overflow-y-scroll">
+            {/* No inner scroll box. This used to be a `max-h-[600px]`
+                overflow-y-scroll region, which on a phone clipped the board
+                partway down the screen and left the rest of the viewport
+                empty - and it was the reason the best-available handle sat in
+                the middle of the page rather than at the bottom of it. The
+                page is the scroller now; the handle is pinned above the tab
+                bar and this leaves its height clear at the end of the
+                content. */}
+            <div className="pb-[var(--handle-h)] md:pb-0">
                 {currentDraft.built_draft && (
                     <>
                         <div className="flex items-center justify-between gap-3 px-3.5 pb-2">
@@ -222,56 +271,60 @@ const DraftPanel = ({ leagueData, playerInfo, rosterInfo, rankingPlayersIdsList,
                                 onPickChange={handlePickChange}
                             />
                         )}
-                        {/* Phone only - the aside covers `md` and up (see
-                            AppShell's SECTIONS_WITH_ASIDE / App's renderAside).
-                            Read-only: unlike Lineup's sheet, there is no
-                            unambiguous pick to attach a tap here to, so this
-                            never records anything - see DraftPanel's own
-                            comment on that near the top of the file for why. */}
-                        {rankingPlayersIdsList.length > 0 ? (
-                            <>
-                                <BestAvailableHandle
-                                    buttonRef={bestAvailableHandleRef}
-                                    isExpanded={isBestAvailableOpen}
-                                    onClick={() => setIsBestAvailableOpen((open) => !open)}
-                                    subtitle={`${countAvailable({
-                                        entries: rankingPlayersIdsList,
-                                        playerInfo,
-                                        rosterInfo,
-                                        eligibleSlots: null,
-                                    })} left`}
-                                />
-                                {isBestAvailableOpen && (
-                                    <Sheet
-                                        title="Best available"
-                                        subtitle={`${rankingPlayersIdsList.length} ranked`}
-                                        onClose={() => setIsBestAvailableOpen(false)}
-                                        triggerRef={bestAvailableHandleRef}
-                                    >
-                                        <BestAvailable
-                                            entries={rankingPlayersIdsList}
-                                            playerInfo={playerInfo}
-                                            rosterInfo={rosterInfo}
-                                            myDisplayName={myDisplayName}
-                                            eligibleSlots={null}
-                                            onSelect={null}
-                                        />
-                                    </Sheet>
-                                )}
-                            </>
-                        ) : (
-                            <div className="border-line bg-raised border-t md:hidden">
-                                <BestAvailable
-                                    entries={[]}
-                                    playerInfo={playerInfo}
-                                    rosterInfo={rosterInfo}
-                                    eligibleSlots={null}
-                                />
-                            </div>
-                        )}
                     </>
                 )}
             </div>
+            {/* Phone only - the aside covers `md` and up (see AppShell's
+                SECTIONS_WITH_ASIDE / App's renderAside). Read-only: unlike
+                Lineup's sheet, there is no unambiguous pick to attach a tap
+                here to, so this never records anything.
+
+                Rendered whether or not a list is loaded. It used to be an
+                either/or - a handle when there were entries, and otherwise a
+                flat strip carrying "paste one in the Ranks section" - which
+                left a signed-in user with saved lists no way to reach them
+                from this screen at all. The sheet's own switcher is that way,
+                so the handle has to open even when there is nothing in it yet. */}
+            <BestAvailableHandle
+                buttonRef={bestAvailableHandleRef}
+                isExpanded={isBestAvailableOpen}
+                onClick={() => setIsBestAvailableOpen((open) => !open)}
+                subtitle={
+                    entries.length > 0
+                        ? `${countAvailable({ entries, playerInfo, rosterInfo, eligibleSlots: null })} left`
+                        : 'Paste a rank list'
+                }
+            />
+            {isBestAvailableOpen && (
+                <Sheet
+                    title="Best available"
+                    subtitle={entries.length > 0 ? `${entries.length} ranked` : 'No list selected'}
+                    onClose={() => setIsBestAvailableOpen(false)}
+                    triggerRef={bestAvailableHandleRef}
+                    headerAction={
+                        <RankListSwitcher
+                            savedRankLists={savedRankLists}
+                            savedRankListsLoading={savedRankListsLoading}
+                            signedIn={signedIn}
+                            rankListId={rankListId}
+                            onSelect={setRankListId}
+                            onPasteNew={() => {
+                                window.location.hash = '#/ranks';
+                            }}
+                            sessionCount={rankingPlayersIdsList.length}
+                        />
+                    }
+                >
+                    <BestAvailable
+                        entries={entries}
+                        playerInfo={playerInfo}
+                        rosterInfo={rosterInfo}
+                        myDisplayName={myDisplayName}
+                        eligibleSlots={null}
+                        onSelect={null}
+                    />
+                </Sheet>
+            )}
         </div>
     );
 };

--- a/src/Panels/DraftPanel.test.jsx
+++ b/src/Panels/DraftPanel.test.jsx
@@ -426,13 +426,14 @@ describe('DraftPanel board view toggle', () => {
 
         expect(screen.queryByRole('list', { name: 'Round 1' })).toBeNull();
         expect(button('Grid')).toHaveAttribute('aria-pressed', 'true');
-        // The grid's own zoom control is now on screen alongside the toggle.
-        expect(button('Overview')).toBeInTheDocument();
+        // The grid has one density and no sub-toggle, so what proves it is on
+        // screen is the position key it carries instead.
+        expect(screen.getByText('YOU')).toBeVisible();
 
         await click(button('Feed'));
 
         expect(screen.getByRole('list', { name: 'Round 1' })).toBeInTheDocument();
-        expect(screen.queryByRole('button', { name: 'Overview' })).toBeNull();
+        expect(screen.queryByText('YOU')).toBeNull();
     });
 });
 
@@ -496,11 +497,45 @@ describe('DraftPanel best-available sheet', () => {
         expect(within(dialog).queryByRole('button', { name: 'Add' })).toBeNull();
     });
 
-    it('shows the plain empty-list message, not a handle, when there is no rank list yet', () => {
+    // The handle used to be swapped out for a flat message strip when there
+    // was no list, which left a signed-in user with saved lists no way to
+    // reach one from this screen - the switcher that reaches them is inside
+    // the sheet the handle opens.
+    it('still opens, with a rank-list switcher inside, when no list is selected yet', async () => {
+        const user = userEvent.setup();
         renderPanel({ rankingPlayersIdsList: [] });
 
-        expect(screen.queryByRole('button', { name: /Best available/ })).toBeNull();
-        expect(screen.getByText(/No rank list yet/)).toBeInTheDocument();
+        const handle = screen.getByRole('button', { name: /Best available/ });
+        expect(handle).toHaveTextContent('Paste a rank list');
+
+        await user.click(handle);
+        const dialog = screen.getByRole('dialog', { name: 'Best available' });
+
+        expect(within(dialog).getByRole('button', { name: /^Rank list/ })).toBeInTheDocument();
+        expect(within(dialog).getByText(/No rank list selected/)).toBeInTheDocument();
+    });
+
+    it('reads a saved list picked from the switcher rather than the empty session list', async () => {
+        const user = userEvent.setup();
+        renderPanel({
+            rankingPlayersIdsList: [],
+            signedIn: true,
+            savedRankLists: {
+                default: { pretty_name: '-- Select saved ranks list', route_name: 'default' },
+                my_ranks: {
+                    pretty_name: 'My Rankings',
+                    route_name: 'my_ranks',
+                    rank_list: [rankEntry(FREE_AGENT.id)],
+                },
+            },
+        });
+
+        await user.click(screen.getByRole('button', { name: /Best available/ }));
+        await user.click(screen.getByRole('button', { name: /^Rank list/ }));
+        await user.click(screen.getByRole('button', { name: /^My Rankings/ }));
+
+        const dialog = screen.getByRole('dialog', { name: 'Best available' });
+        expect(within(dialog).getByText(FREE_AGENT.name)).toBeInTheDocument();
     });
 });
 

--- a/src/Panels/LeaguePanel.jsx
+++ b/src/Panels/LeaguePanel.jsx
@@ -17,6 +17,7 @@ const LeaguePanel = ({
     savedRankLists,
     savedRankListsLoading,
     signedIn,
+    lineupSet,
     view,
 }) => {
     return (
@@ -43,6 +44,7 @@ const LeaguePanel = ({
                             savedRankLists={savedRankLists}
                             savedRankListsLoading={savedRankListsLoading}
                             signedIn={signedIn}
+                            lineupSet={lineupSet}
                         />
                     )}
                     {view === 'draft' && (
@@ -53,6 +55,9 @@ const LeaguePanel = ({
                             rankingPlayersIdsList={rankingPlayersIdsList}
                             myDisplayName={myDisplayName}
                             updateDraftBoard={updateDraftBoard}
+                            savedRankLists={savedRankLists}
+                            savedRankListsLoading={savedRankListsLoading}
+                            signedIn={signedIn}
                         />
                     )}
                 </>

--- a/src/Panels/LineupPanel.jsx
+++ b/src/Panels/LineupPanel.jsx
@@ -21,6 +21,7 @@ const LineupPanel = ({
     savedRankLists,
     savedRankListsLoading,
     signedIn,
+    lineupSet,
 }) => {
     const emptyCount = rosterSlots.filter((slot) => !slot.playerId).length;
     const [isSheetOpen, setIsSheetOpen] = useState(false);
@@ -130,7 +131,9 @@ const LineupPanel = ({
                     </span>
                 )}
             </h4>
-            <ul className="flex flex-col gap-0.5 px-2 py-1">
+            {/* Leaves the pinned handle's height clear at the end of the list,
+                or its last slot row sits underneath it. */}
+            <ul className="flex flex-col gap-0.5 px-2 py-1 pb-[var(--handle-h)] md:pb-1">
                 {rosterSlots.map((slot, i) => (
                     <SlotRow
                         key={`${slot.label}-${i}`}
@@ -142,29 +145,24 @@ const LineupPanel = ({
                 ))}
             </ul>
             {/* Phone only - the aside covers `md` and up with the desktop
-                rail instead (see AppShell / App's renderAside). This strip is
-                the bottom-handle entry point specifically; every slot row
-                above opens the same sheet directly regardless of whether
-                there is a rank list to show in it (BestAvailable's own empty
-                state covers that), so this block is not the only way in. */}
-            {openSlotLabels.length > 0 &&
-                (rankingPlayersIdsList.length > 0 ? (
-                    <BestAvailableHandle
-                        buttonRef={bestAvailableHandleRef}
-                        isExpanded={isSheetOpen && !scope}
-                        onClick={openFromHandle}
-                        subtitle={`fills ${openSlotLabels.join(', ')}`}
-                    />
-                ) : (
-                    <div className="border-line bg-raised border-t md:hidden">
-                        <BestAvailable
-                            entries={[]}
-                            playerInfo={playerInfo}
-                            rosterInfo={rosterInfo}
-                            eligibleSlots={openSlotLabels}
-                        />
-                    </div>
-                ))}
+                rail instead (see AppShell / App's renderAside). This handle is
+                the bottom entry point specifically; every slot row above opens
+                the same sheet directly.
+
+                It opens whether or not a list is loaded. The either/or it
+                replaced showed a flat "paste one in the Ranks section" strip
+                instead of the handle, so a signed-in user with saved lists had
+                no way to reach them from this screen - and the switcher that
+                is the way to reach them lives inside the sheet the handle
+                opens. */}
+            {openSlotLabels.length > 0 && (
+                <BestAvailableHandle
+                    buttonRef={bestAvailableHandleRef}
+                    isExpanded={isSheetOpen && !scope}
+                    onClick={openFromHandle}
+                    subtitle={entries.length > 0 ? `fills ${openSlotLabels.join(', ')}` : 'Paste a rank list'}
+                />
+            )}
             {isSheetOpen && (
                 <Sheet
                     title={title}
@@ -220,6 +218,7 @@ const LineupPanel = ({
                         initialActiveChip={scope ? scope.label : null}
                         ownership={ownership}
                         onOwnershipChange={setOwnership}
+                        lineupSet={lineupSet}
                         onSelect={handleSelect}
                     />
                 </Sheet>

--- a/src/Panels/LineupPanel.test.jsx
+++ b/src/Panels/LineupPanel.test.jsx
@@ -16,6 +16,11 @@ const STARTER = {
     first_name: 'Germie',
     last_name: 'Bernard',
     position: 'WR',
+    // Needed for the eligibility filter, which reads `fantasy_positions`
+    // rather than `position` - a slot's admitted positions are checked against
+    // this list, so an occupant without one is eligible for nothing and never
+    // appears as a candidate at all.
+    fantasy_positions: ['WR'],
     team: 'LV',
 };
 
@@ -177,11 +182,20 @@ describe('LineupPanel best-available sheet', () => {
         expect(screen.queryByRole('button', { name: /Best available/ })).toBeNull();
     });
 
-    it('shows the plain empty-list message, not a handle, when there is no rank list yet', () => {
+    // Same reasoning as DraftPanel's: the handle opens whether or not a list
+    // is loaded, because the switcher that loads one lives inside the sheet.
+    it('still opens, with a rank-list switcher inside, when no list is selected yet', async () => {
+        const user = userEvent.setup();
         renderLineup({ rankingPlayersIdsList: [] });
 
-        expect(screen.queryByRole('button', { name: /Best available/ })).toBeNull();
-        expect(screen.getByText(/No rank list yet/)).toBeInTheDocument();
+        const handle = screen.getByRole('button', { name: /Best available/ });
+        expect(handle).toHaveTextContent('Paste a rank list');
+
+        await user.click(handle);
+        const dialog = screen.getByRole('dialog', { name: 'Best available' });
+
+        expect(within(dialog).getByRole('button', { name: /^Rank list/ })).toBeInTheDocument();
+        expect(within(dialog).getByText(/No rank list selected/)).toBeInTheDocument();
     });
 
     it('fills the first eligible open slot on Add, and the sheet stays open', async () => {
@@ -482,5 +496,76 @@ describe('LineupPanel slot chip filtering', () => {
         await user.click(within(dialog).getByRole('button', { name: 'QB' }));
         expect(within(dialog).getByText(FREE_AGENT_QB.name)).toBeInTheDocument();
         expect(within(dialog).queryByText(FREE_WR.name)).toBeNull();
+    });
+});
+
+// Adding a player who already fills another slot would silently move them:
+// fillSlot writes the id into the tapped slot and never checks the rest of the
+// lineup, so the same player would end up in two slots on screen and one of
+// them would be a lie. The list says so instead.
+describe('LineupPanel already-started players', () => {
+    const buildLineupSet = (slots) => new Set(slots.filter((slot) => slot.playerId).map((slot) => slot.playerId));
+
+    it('offers no Add for a player already in a slot, and says why in the name', async () => {
+        const user = userEvent.setup();
+        // STARTER is a WR sitting in the FLX slot of ROSTER_SLOTS, so opening
+        // the open WR slot lists him as a candidate for it.
+        renderLineup({
+            rankingPlayersIdsList: [rankEntry(STARTER.player_id, 1)],
+            lineupSet: buildLineupSet(ROSTER_SLOTS),
+        });
+
+        await user.click(screen.getByRole('button', { name: 'WR, empty' }));
+        const dialog = screen.getByRole('dialog', { name: 'Fill WR' });
+
+        const row = within(dialog).getByRole('button', { name: 'Started' });
+        expect(row).toBeDisabled();
+        expect(within(dialog).queryByRole('button', { name: 'Add' })).toBeNull();
+        // Disabled controls announce inconsistently, so the state is in the
+        // row's own name too.
+        expect(
+            within(dialog).getByText(STARTER.full_name).closest('[aria-label]').getAttribute('aria-label'),
+        ).toContain('already started');
+    });
+
+    it('leaves a player who is on your roster but not in the lineup addable', async () => {
+        const user = userEvent.setup();
+        renderLineup({
+            rankingPlayersIdsList: [rankEntry(STARTER.player_id, 1)],
+            // Same roster, nobody in a slot.
+            lineupSet: buildLineupSet([{ label: 'WR', playerId: null }]),
+        });
+
+        await user.click(screen.getByRole('button', { name: 'WR, empty' }));
+        const dialog = screen.getByRole('dialog', { name: 'Fill WR' });
+
+        expect(within(dialog).getByRole('button', { name: 'Add' })).toBeEnabled();
+    });
+
+    it('fills the slot when nothing is blocking it, proving the block above is not vacuous', async () => {
+        const user = userEvent.setup();
+        const { fillSlot } = renderLineup({
+            rankingPlayersIdsList: [rankEntry(STARTER.player_id, 1)],
+            lineupSet: new Set(),
+        });
+
+        await user.click(screen.getByRole('button', { name: 'WR, empty' }));
+        await user.click(screen.getByRole('button', { name: 'Add' }));
+
+        expect(fillSlot).toHaveBeenCalledWith(2, expect.objectContaining({ player_id: STARTER.player_id }));
+    });
+});
+
+// The handle is pinned above the tab bar rather than sitting where the content
+// happens to end - on a short lineup it was floating mid-screen. It shares its
+// anchor with the sheet it opens, so the two line up.
+describe('LineupPanel handle placement', () => {
+    it('anchors the handle to the tab bar, and leaves its height clear at the end of the list', () => {
+        renderLineup({ rankingPlayersIdsList: [rankEntry(FREE_AGENT_QB.id, 1)] });
+
+        const handle = screen.getByRole('button', { name: /Best available/ });
+        expect(handle.className).toMatch(/fixed/);
+        expect(handle.className).toMatch(/bottom-\[var\(--tab-bar-h\)\]/);
+        expect(screen.getByRole('list').className).toMatch(/pb-\[var\(--handle-h\)\]/);
     });
 });

--- a/src/lib/relativeTime.js
+++ b/src/lib/relativeTime.js
@@ -1,0 +1,32 @@
+const MINUTE = 60000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+/**
+ * How long ago something happened, in the shortest form that still says it:
+ * `just now`, `2m ago`, `3h ago`, `2d ago`. `null` in, `null` out - the caller
+ * that has never synced has nothing to render rather than a "never" to explain.
+ *
+ * Coarse on purpose. This labels the last completed sync on a card that only
+ * re-renders when something else changes, so a seconds-accurate figure would be
+ * a number that is quietly wrong most of the time; a minute-resolution one is
+ * right for a whole minute.
+ */
+export function agoLabel(timestamp, now = Date.now()) {
+    if (timestamp == null) {
+        return null;
+    }
+    const elapsed = now - timestamp;
+    // A clock that ran backwards (a device time change mid-draft) reads as
+    // "just now" rather than as a negative age.
+    if (elapsed < MINUTE) {
+        return 'just now';
+    }
+    if (elapsed < HOUR) {
+        return `${Math.floor(elapsed / MINUTE)}m ago`;
+    }
+    if (elapsed < DAY) {
+        return `${Math.floor(elapsed / HOUR)}h ago`;
+    }
+    return `${Math.floor(elapsed / DAY)}d ago`;
+}

--- a/src/lib/relativeTime.test.js
+++ b/src/lib/relativeTime.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { agoLabel } from './relativeTime.js';
+
+const NOW = Date.UTC(2026, 6, 29, 12, 0, 0);
+const MINUTE = 60000;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+describe('agoLabel', () => {
+    it('is null when nothing has happened yet, rather than the word never', () => {
+        expect(agoLabel(null, NOW)).toBeNull();
+        expect(agoLabel(undefined, NOW)).toBeNull();
+    });
+
+    it('reads "just now" for anything under a minute', () => {
+        expect(agoLabel(NOW, NOW)).toBe('just now');
+        expect(agoLabel(NOW - 59000, NOW)).toBe('just now');
+    });
+
+    it('steps up through minutes, hours and days, flooring rather than rounding', () => {
+        expect(agoLabel(NOW - MINUTE, NOW)).toBe('1m ago');
+        expect(agoLabel(NOW - 2 * MINUTE - 59000, NOW)).toBe('2m ago');
+        expect(agoLabel(NOW - HOUR, NOW)).toBe('1h ago');
+        expect(agoLabel(NOW - 23 * HOUR, NOW)).toBe('23h ago');
+        expect(agoLabel(NOW - DAY, NOW)).toBe('1d ago');
+        expect(agoLabel(NOW - 9 * DAY, NOW)).toBe('9d ago');
+    });
+
+    it('reads "just now" rather than a negative age when the clock ran backwards', () => {
+        // A device time change mid-draft. Rare, but "-3m ago" is worse than
+        // being a minute optimistic about a sync that definitely happened.
+        expect(agoLabel(NOW + 5 * MINUTE, NOW)).toBe('just now');
+    });
+});

--- a/src/styles/theme.css
+++ b/src/styles/theme.css
@@ -102,6 +102,29 @@
     /* The empty lineup slot's fill - a hint of a row, not a dashed box. */
     --raw-empty: rgba(154, 171, 189, 0.04);
 
+    /*
+     * The draft grid's cell. It is the one surface in the app that is neither
+     * ground nor one of the two elevated planes: a cell has to read as its own
+     * block on the ground plane without a lattice of table rules to define it,
+     * which is what the barely-there lift and the hairline below do together.
+     * `grid-line` is a shade under `line` on purpose - a full-strength
+     * hairline on 108 cells at once reads as the spreadsheet the design is
+     * explicitly not.
+     */
+    --raw-grid-cell: rgba(255, 255, 255, 0.022);
+    --raw-grid-line: #1a222c;
+
+    /* The violet edge on your own grid column - stronger than `mine-row`'s
+     * fill, weaker than `mine` itself, so a whole column of it marks
+     * ownership without shouting over the position dots inside it. */
+    --raw-mine-edge: rgba(139, 124, 247, 0.28);
+
+    /* A step brighter than `ink-muted` and a step under `ink`, for the grid
+     * cell's player name: 13px at 600 on a barely-lifted cell needs more than
+     * muted, but a whole board at full `ink` flattens the violet column that
+     * marks your own picks. */
+    --raw-ink-soft: #dfe6ee;
+
     /* The drawer's full-screen scrim. Named "heavy" because it is darker than
      * any surface tint above - it has to read as a modal backdrop rather than
      * a tint on the page behind it. */
@@ -164,6 +187,10 @@
     --color-pos-none-tint: var(--raw-pos-none-tint);
 
     --color-empty: var(--raw-empty);
+    --color-grid-cell: var(--raw-grid-cell);
+    --color-grid-line: var(--raw-grid-line);
+    --color-mine-edge: var(--raw-mine-edge);
+    --color-ink-soft: var(--raw-ink-soft);
     --color-scrim-heavy: var(--raw-scrim-heavy);
     --color-scrim: var(--raw-scrim);
 
@@ -220,15 +247,15 @@
          */
         --tab-bar-h: 60px;
         --top-bar-h: 56px;
+        /*
+         * The collapsed best-available handle. It is pinned above the tab bar
+         * rather than sitting wherever the section's content happens to end -
+         * on a short board it was floating in the middle of the screen - so
+         * anything scrolling behind it needs to know how much room to leave.
+         */
+        --handle-h: 58px;
     }
 
-    /*
-     * DraftGrid's two zoom stops. Cell size is runtime state (a click on the
-     * zoom control), not something a fixed set of utility classes can express -
-     * so it lives here as plain custom properties switched by the `data-zoom`
-     * attribute DraftGrid sets on its table root, and the component consumes
-     * them through arbitrary-value utilities (`w-[var(--cell-w)]` etc).
-     */
     /*
      * The chip rows scroll horizontally when they overflow, but the scrollbar
      * itself is chrome the design does not have - and on a 14px-tall strip of
@@ -240,15 +267,5 @@
 
     .no-scrollbar::-webkit-scrollbar {
         display: none;
-    }
-
-    .draft-grid[data-zoom='overview'] {
-        --cell-w: 23px;
-        --cell-h: 23px;
-    }
-
-    .draft-grid[data-zoom='readable'] {
-        --cell-w: 75px;
-        --cell-h: 38px;
     }
 }


### PR DESCRIPTION
Against `~/src/Fantasy Football App Redesign (3)/design_handoff_sleeper_redesign` — frame 2 is new, and the two `uploads/` screenshots are the current build for comparison.

## The grid (frame 2)

**The overview zoom stop is deleted, not restyled.** A colour-block board with no names answered nothing the feed answered better, and it was the only place a position hue appeared as a solid fill wide enough to compete with the violet that means "yours". One density: names always visible, managers on the horizontal scroll.

The `<table>` is gone with it. Cells are 108px blocks on the ground plane — 5px position dot + `J.Love` over a mono `GB · 1.01` — because definition now comes from a cell's own hairline and fill rather than a lattice of rules. A key row above the board (four dots + `QB RB WR TE`, and `YOU`) is what makes a 5px dot decodable, and it is the only place a position hue appears outside a tag or filter chip. The round rail is pinned left and the manager header pinned top.

Dropping the table drops its `<th scope>` associations; nothing is lost, because every cell's accessible name already spells out round, pick, manager, player and position (the same `pickLabels.js` builder the feed uses) and never depended on them.

**The clock card at rest** is specified by the same frame, and it is the card in `IMG_0700`: `ON THE CLOCK` over `No pick on the clock` — the same non-fact twice — above a full-width violet Sync button on a finished draft. When there is nothing to count down, the eyebrow becomes the draft's identity (`2026 ROOKIE`), the headline is the state (`Draft complete`), the subtitle counts what there is to count (`48 picks · synced 2m ago`), and sync becomes a secondary outlined pill. It keeps the accessible name `Sync draft` in both shapes, so it stays one feature.

## Three fixes

**The pull-up didn't snap to the bottom.** It was in normal flow, so on a four-round board it floated mid-screen (visible in both uploads). It is `fixed` above the tab bar now, on the same `--tab-bar-h` anchor as the sheet it opens, and the panels leave `--handle-h` clear at the end of their content. The `max-h-[600px]` inner scroll box that clipped the board partway down the screen went with it — the page is the scroller.

**You couldn't reach a rank list from either screen.** With nothing loaded the handle was swapped for a flat "paste one in the Ranks section" strip, and the switcher that would let you choose a saved list lives *inside* the sheet that strip replaced. The handle always opens now, the draft sheet gets the rank-list switcher the lineup sheet already had, and the empty copy points at it: `No rank list selected - pick one from the switcher above, or paste a new one.` The collapsed subtitle reads `Paste a rank list`.

**A player already in a slot could be selected for another one.** `fillSlot` writes the id into the tapped slot and never checks the rest of the lineup, so the same player would show in two slots and one of them would be a lie. Their pill is a disabled `Started`, and the row's accessible name carries `already started` since a disabled control announces inconsistently.

## Verified

Six gates green, 409 → 424 tests. Driven at 375×812 against the live league: a manual pick renders as a pink QB dot + `J.Love` / `GB · 1.01` and the card ticks to `1 pick`; the round rail holds at x=0 across a 400px horizontal scroll; the handle's bottom edge measures exactly the tab bar's top edge; the draft sheet opens with no list and shows the switcher; and adding a free agent to one WR slot flips him to a disabled `Started` in *both* open WR slots. Console clean.

Sabotage-checked: reverting the resting-card branch, the `board_spot` cell lookup, and the already-started guard each fails the tests covering them. Two assertions were tightened after a sabotage passed — `toHaveTextContent('Sync')` also matched `Sync draft`, and the snake-column test can't observe `buildTeamColumns`' own sort (round 1 is never reversed, so both sorts agree there); its comment now says what it does and does not pin down.

## Not verified

The manager header's vertical pinning. The real league is four rounds, so the board never scrolls vertically inside its own container — that one needs a 12+ round draft to exercise.