### PR TITLE
Give the draft's rank-list sheet the lineup's ownership filters

### DIFF
--- a/src/Components/BestAvailable.jsx
+++ b/src/Components/BestAvailable.jsx
@@ -52,11 +52,15 @@ export function filterBestAvailable({ entries, playerInfo, eligibleSlots, owners
 
 /**
  * How many eligible entries are still unrostered - the number a collapsed
- * handle shows as "{n} left". Distinct from the sheet's own row count once
- * it's open, which also lists taken players (marked "Taken", not hidden).
+ * handle shows as "{n} left".
+ *
+ * `ownership` is optional and only narrows further: an unrostered player is
+ * `available`, which every scope that has ever shipped has on, so passing the
+ * draft handle's scope changes this count only when a filter the user actually
+ * touched (rookies only) says it should.
  */
-export function countAvailable({ entries, playerInfo, rosterInfo, eligibleSlots }) {
-    return filterBestAvailable({ entries, playerInfo, eligibleSlots }).filter(
+export function countAvailable({ entries, playerInfo, rosterInfo, eligibleSlots, ownership, myDisplayName }) {
+    return filterBestAvailable({ entries, playerInfo, eligibleSlots, ownership, rosterInfo, myDisplayName }).filter(
         ({ entry }) => !isTaken(rosterInfo, playerId(entry)),
     ).length;
 }
@@ -68,10 +72,10 @@ const chipClasses = (active) =>
 
 // The rank-list content shared by the phone sheet and the desktop rail - the
 // two render identical rows, only the chrome around them differs (Sheet vs
-// AppShell's aside). `eligibleSlots` of null means the Draft use, which shows
-// the whole rank list unfiltered and carries no chip row at all; an array
-// (Lineup's open slot labels) filters to players eligible for at least one of
-// them and adds the chip row to narrow further to a single slot.
+// AppShell's aside). `eligibleSlots` of null means the Draft use, which ranks
+// the whole list and carries no slot chips; an array (Lineup's open slot
+// labels) filters to players eligible for at least one of them and adds the
+// chip row to narrow further to a single slot. Both carry the FILTERS chip.
 // `initialActiveChip` seeds which chip starts pressed - null (ALL) for the
 // bottom handle's "every open slot" entry point, a specific label for a
 // slot-tap entry that opens already scoped to the tapped slot. It only ever
@@ -121,67 +125,75 @@ const BestAvailable = ({
 
     const chipLabels = eligibleSlots ? [...new Set(eligibleSlots)] : [];
     const narrowedSlots = eligibleSlots && activeChip ? [activeChip] : eligibleSlots;
-    // The ownership scope only applies where the chip that controls it is
-    // rendered - the lineup's slot-scoped list. The draft's read-only sheet
-    // passes `eligibleSlots: null` and shows the whole ranked board, taken
-    // players included and marked, which is what it is for.
+    // The ownership scope applies to both uses. It used to be lineup-only -
+    // the draft sheet showed the whole ranked board with drafted players left
+    // in and marked `Taken` - but during a draft that is most of the list, and
+    // the question the sheet answers there is the same one it answers on the
+    // lineup: who can I still have? Yours plus unowned by default, everyone
+    // else's a checkbox away.
     const rows = filterBestAvailable({
         entries,
         playerInfo,
         eligibleSlots: narrowedSlots,
-        ownership: eligibleSlots ? ownership : undefined,
+        ownership,
         rosterInfo,
         myDisplayName,
     });
 
     return (
         <div className="flex flex-col gap-3">
-            {eligibleSlots && (
-                // Only the slot chips scroll. FILTERS is pinned to the end
-                // because it is how you get rows back when the list looks
-                // empty - it must not be the thing that has scrolled out of
-                // sight when that happens. A lineup with six distinct slot
-                // labels overflows any phone width, so wrapping the whole row
-                // instead just left the divider stranded mid-air.
-                <div className="flex items-stretch gap-2 px-2 pt-2">
-                    <div className="no-scrollbar flex min-w-0 flex-1 gap-2 overflow-x-auto">
-                        <button
-                            type="button"
-                            className={`shrink-0 ${chipClasses(activeChip === null)}`}
-                            onClick={() => setActiveChip(null)}
-                        >
-                            ALL
-                        </button>
-                        {chipLabels.map((label) => (
+            {/* Only the slot chips scroll, and only the lineup has any: the
+                draft list has no slot to be eligible for, so there this is the
+                FILTERS chip alone. FILTERS is pinned to the end because it is
+                how you get rows back when the list looks empty - it must not
+                be the thing that has scrolled out of sight when that happens.
+                A lineup with six distinct slot labels overflows any phone
+                width, so wrapping the whole row instead just left the divider
+                stranded mid-air. */}
+            <div className="flex items-stretch gap-2 px-2 pt-2">
+                {eligibleSlots && (
+                    <>
+                        <div className="no-scrollbar flex min-w-0 flex-1 gap-2 overflow-x-auto">
                             <button
-                                key={label}
                                 type="button"
-                                className={`shrink-0 ${chipClasses(activeChip === label)}`}
-                                onClick={() => setActiveChip(label)}
+                                className={`shrink-0 ${chipClasses(activeChip === null)}`}
+                                onClick={() => setActiveChip(null)}
                             >
-                                {label}
+                                ALL
                             </button>
-                        ))}
-                    </div>
-                    {/* Divided off from the slot chips because it filters a
-                        different axis: those narrow *where* a player could go,
-                        this narrows *whether you can have them*. */}
-                    <span className="bg-line my-0.5 w-px shrink-0" />
-                    <OwnershipFilters
-                        ownership={ownership}
-                        onChange={setOwnership}
-                        isOpen={filtersOpen}
-                        onToggle={() => setFiltersOpen((open) => !open)}
-                    />
-                </div>
-            )}
+                            {chipLabels.map((label) => (
+                                <button
+                                    key={label}
+                                    type="button"
+                                    className={`shrink-0 ${chipClasses(activeChip === label)}`}
+                                    onClick={() => setActiveChip(label)}
+                                >
+                                    {label}
+                                </button>
+                            ))}
+                        </div>
+                        {/* Divided off from the slot chips because it filters a
+                            different axis: those narrow *where* a player could
+                            go, this narrows *whether you can have them*. */}
+                        <span className="bg-line my-0.5 w-px shrink-0" />
+                    </>
+                )}
+                <OwnershipFilters
+                    ownership={ownership}
+                    onChange={setOwnership}
+                    isOpen={filtersOpen}
+                    onToggle={() => setFiltersOpen((open) => !open)}
+                />
+            </div>
             {/* Distinct from the "no rank list yet" message above: there is a
                 list, it just has nothing left in it once the chips and the
                 ownership scope are applied. Saying so beats an empty box under
                 a row of controls the user just touched. */}
             {rows.length === 0 && (
                 <p className="text-ink-muted m-0 flex min-h-11 items-center px-4 text-sm">
-                    Nothing in this list fits - try another slot chip, or widen FILTERS.
+                    {eligibleSlots
+                        ? 'Nothing in this list fits - try another slot chip, or widen FILTERS.'
+                        : 'Nothing in this list is left - widen FILTERS to see rostered players.'}
                 </p>
             )}
             <ul className="flex flex-col gap-0.5 px-2 py-2.5">

--- a/src/Components/BestAvailable.test.jsx
+++ b/src/Components/BestAvailable.test.jsx
@@ -44,6 +44,12 @@ const entries = [
     rankEntry(OTHER_FREE_AGENT.id, 4),
 ];
 
+// The rows every scope has always shown, plus other managers' - the default
+// scope hides those (see OwnershipFilters.DEFAULT_OWNERSHIP), so the cases
+// below that are about rendering a row rather than about the scope itself ask
+// for all three buckets explicitly.
+const SHOW_EVERYONE = { mine: true, available: true, others: true, rookiesOnly: false };
+
 const renderBestAvailable = (overrides = {}) =>
     render(
         <BestAvailable
@@ -59,7 +65,7 @@ const renderBestAvailable = (overrides = {}) =>
 
 describe('BestAvailable', () => {
     it('lists players in ranking order', () => {
-        renderBestAvailable();
+        renderBestAvailable({ ownership: SHOW_EVERYONE });
 
         const names = screen.getAllByRole('listitem').map((item) => item.textContent);
         expect(names[0]).toContain(TAKEN_BY_ME.name);
@@ -68,14 +74,22 @@ describe('BestAvailable', () => {
         expect(names[3]).toContain(OTHER_FREE_AGENT.name);
     });
 
-    it('shows a taken player marked Taken instead of excluding it', () => {
-        renderBestAvailable();
+    // Two behaviours in one case, because they are two halves of the same
+    // rule: the default scope is yours-plus-unowned, and a player on somebody
+    // else's roster is not hidden as a mistake - ask for them and they come
+    // back, marked. "Taken" means taken *from you*, so your own never carry it.
+    it("hides other managers' players by default and marks them Taken once asked for", () => {
+        const { unmount } = renderBestAvailable();
 
         expect(screen.getByText(FREE_AGENT.name)).toBeInTheDocument();
-        expect(screen.getByText(TAKEN_BY_OTHERS.name)).toBeInTheDocument();
         expect(screen.getByText(TAKEN_BY_ME.name)).toBeInTheDocument();
-        // Only the one on somebody else's roster. "Taken" means taken *from
-        // you* - see the next test.
+        expect(screen.queryByText(TAKEN_BY_OTHERS.name)).toBeNull();
+        expect(screen.queryAllByText('Taken')).toHaveLength(0);
+
+        unmount();
+        renderBestAvailable({ ownership: SHOW_EVERYONE });
+
+        expect(screen.getByText(TAKEN_BY_OTHERS.name)).toBeInTheDocument();
         expect(screen.getAllByText('Taken')).toHaveLength(1);
     });
 
@@ -84,7 +98,7 @@ describe('BestAvailable', () => {
     // out alongside every other manager's would make the sheet useless for its
     // main job. Same rule PlayerInfoItem has always used.
     it("keeps the action on your own rostered player and withholds it from someone else's", () => {
-        renderBestAvailable({ onSelect: vi.fn() });
+        renderBestAvailable({ onSelect: vi.fn(), ownership: SHOW_EVERYONE });
 
         const mine = screen.getByText(TAKEN_BY_ME.name).closest('li');
         const theirs = screen.getByText(TAKEN_BY_OTHERS.name).closest('li');
@@ -107,7 +121,7 @@ describe('BestAvailable', () => {
     });
 
     it('skips an entry whose id is absent from playerInfo rather than rendering a hole', () => {
-        renderBestAvailable({ entries: [...entries, rankEntry('999999', 5)] });
+        renderBestAvailable({ entries: [...entries, rankEntry('999999', 5)], ownership: SHOW_EVERYONE });
 
         expect(screen.getAllByRole('listitem')).toHaveLength(entries.length);
     });
@@ -133,10 +147,13 @@ describe('BestAvailable', () => {
             expect(screen.getByRole('button', { name: 'FLX' })).toBeInTheDocument();
         });
 
-        it('omits the chip row entirely when eligibleSlots is null', () => {
+        it('omits the slot chips when eligibleSlots is null, but keeps FILTERS', () => {
             renderBestAvailable({ eligibleSlots: null });
 
             expect(screen.queryByRole('button', { name: 'ALL' })).toBeNull();
+            // The draft list has no slot to be eligible for, but the same
+            // question - who can I still have? - and so the same chip.
+            expect(screen.getByRole('button', { name: /^FILTERS/ })).toBeInTheDocument();
         });
 
         it('narrows to a single slot on chip click, and ALL clears the narrowing', async () => {
@@ -176,7 +193,7 @@ describe('BestAvailable', () => {
         });
 
         it('never offers Add for a taken player, regardless of onSelect', () => {
-            renderBestAvailable({ onSelect: () => {} });
+            renderBestAvailable({ onSelect: () => {}, ownership: SHOW_EVERYONE });
 
             const row = screen.getByText(TAKEN_BY_OTHERS.name).closest('[role="group"]');
             expect(within(row).queryByRole('button', { name: 'Add' })).toBeNull();

--- a/src/Components/Popover.jsx
+++ b/src/Components/Popover.jsx
@@ -40,6 +40,18 @@ const Popover = ({ triggerRef, onClose, label, width = 252, children }) => {
         if (!trigger) {
             return;
         }
+        // A portal is not a DOM descendant of its trigger, so a trigger hidden
+        // by a media query takes its own subtree off the screen and leaves
+        // this floating over the page on its own. That is exactly what the
+        // draft/lineup sheets do at `md` and up (they are `md:hidden`, not
+        // unmounted), so crossing that width with a popover open stranded it
+        // in the top-left corner. `checkVisibility` is feature-detected rather
+        // than assumed: jsdom does not implement it, and every test would
+        // otherwise see every popover as hidden.
+        if (trigger.checkVisibility && !trigger.checkVisibility()) {
+            setPosition(null);
+            return;
+        }
         const rect = trigger.getBoundingClientRect();
         const clampedWidth = Math.min(width, window.innerWidth - EDGE_PX * 2);
         // Right-aligned to the trigger, then pulled back inside the viewport -

--- a/src/Components/Popover.test.jsx
+++ b/src/Components/Popover.test.jsx
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { useRef } from 'react';
+import Popover from './Popover';
+
+// jsdom has no layout, so placement itself (the flip above a trigger with no
+// room below, the clamped max-height) is browser-verified rather than asserted
+// here. What this file pins is the one piece of that logic with a real API
+// behind it: the visibility guard.
+
+const Harness = ({ onClose = () => {} }) => {
+    const triggerRef = useRef(null);
+    return (
+        <>
+            <button type="button" ref={triggerRef}>
+                Open
+            </button>
+            <Popover triggerRef={triggerRef} onClose={onClose} label="Filters">
+                <p>Body</p>
+            </Popover>
+        </>
+    );
+};
+
+afterEach(() => {
+    delete Element.prototype.checkVisibility;
+});
+
+describe('Popover', () => {
+    it('renders next to its trigger by default', () => {
+        render(<Harness />);
+
+        expect(screen.getByRole('dialog', { name: 'Filters' })).toBeInTheDocument();
+    });
+
+    // A portal is not a DOM descendant of its trigger, so a trigger hidden by
+    // a media query - which is what the draft and lineup sheets are at `md`
+    // and up, `md:hidden` rather than unmounted - leaves the popover floating
+    // over the page by itself. Seen in the browser, in the top-left corner.
+    it('renders nothing while its trigger has been hidden by a stylesheet', () => {
+        Element.prototype.checkVisibility = () => false;
+
+        render(<Harness />);
+
+        expect(screen.queryByRole('dialog', { name: 'Filters' })).toBeNull();
+    });
+
+    // The guard is feature-detected because jsdom does not implement
+    // checkVisibility: assuming it exists would have hidden every popover in
+    // every test in this suite, which is a failure mode worth a test of its own.
+    it('treats a trigger as visible where checkVisibility does not exist', () => {
+        expect(Element.prototype.checkVisibility).toBeUndefined();
+
+        render(<Harness />);
+
+        expect(screen.getByRole('dialog', { name: 'Filters' })).toBeInTheDocument();
+    });
+
+    it('closes on Escape without letting the keystroke reach anything else', async () => {
+        const onClose = vi.fn();
+        const outer = vi.fn();
+        document.addEventListener('keydown', outer, true);
+        render(<Harness onClose={onClose} />);
+
+        screen
+            .getByRole('dialog', { name: 'Filters' })
+            .dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+
+        expect(onClose).toHaveBeenCalledTimes(1);
+        document.removeEventListener('keydown', outer, true);
+    });
+});

--- a/src/Panels/DraftPanel.jsx
+++ b/src/Panels/DraftPanel.jsx
@@ -4,6 +4,7 @@ import PickFeed from './PickFeed';
 import DraftGrid from './DraftGrid';
 import Sheet from '../Components/Sheet';
 import BestAvailable, { countAvailable } from '../Components/BestAvailable';
+import { DEFAULT_OWNERSHIP } from '../Components/OwnershipFilters';
 import BestAvailableHandle from '../Components/BestAvailableHandle';
 import ClockCard from '../Components/ClockCard';
 import DraftSourceSheet, { readLastMock, writeLastMock } from './DraftSourceSheet';
@@ -60,6 +61,12 @@ const DraftPanel = ({
     // this panel on purpose - the draft sheet can be reading a different list
     // than the Ranks section is editing, same as the Lineup sheet's.
     const [rankListId, setRankListId] = useState(null);
+    // Held here rather than inside BestAvailable for the same reason
+    // LineupPanel holds its own: the sheet is mounted only while open, so a
+    // scope kept down there would reset every time it was reopened - and
+    // switching "Other rosters" on to check who has somebody would never
+    // survive closing the sheet.
+    const [ownership, setOwnership] = useState(DEFAULT_OWNERSHIP);
     const bestAvailableHandleRef = useRef(null);
     const sourceButtonRef = useRef(null);
 
@@ -329,7 +336,7 @@ const DraftPanel = ({
                 onClick={() => setIsBestAvailableOpen((open) => !open)}
                 subtitle={
                     entries.length > 0
-                        ? `${countAvailable({ entries, playerInfo, rosterInfo, eligibleSlots: null })} left`
+                        ? `${countAvailable({ entries, playerInfo, rosterInfo, eligibleSlots: null, ownership, myDisplayName })} left`
                         : 'Paste a rank list'
                 }
             />
@@ -359,6 +366,8 @@ const DraftPanel = ({
                         rosterInfo={rosterInfo}
                         myDisplayName={myDisplayName}
                         eligibleSlots={null}
+                        ownership={ownership}
+                        onOwnershipChange={setOwnership}
                         onSelect={null}
                     />
                 </Sheet>

--- a/src/Panels/DraftPanel.test.jsx
+++ b/src/Panels/DraftPanel.test.jsx
@@ -529,15 +529,23 @@ describe('DraftPanel best-available sheet', () => {
         expect(screen.getByRole('button', { name: /Best available/ })).toHaveTextContent('1 left');
     });
 
-    it('shows a taken player marked Taken rather than excluding it, and offers no action at all', async () => {
+    // The sheet answers the same question the lineup's does - who can I still
+    // have? - so it carries the same scope, defaulted the same way: yours plus
+    // unowned. During a draft, players on other rosters are most of a rank
+    // list, and scrolling past them was the point of the complaint.
+    it('hides players on other rosters by default, and brings them back marked when asked', async () => {
         const user = userEvent.setup();
         renderPanel({ rankingPlayersIdsList: [rankEntry(FREE_AGENT.id), rankEntry(TAKEN.id)] });
 
         await user.click(screen.getByRole('button', { name: /Best available/ }));
         const dialog = screen.getByRole('dialog', { name: 'Best available' });
 
-        // Both rows render - taken is marked, not hidden.
         expect(within(dialog).getByText(FREE_AGENT.name)).toBeInTheDocument();
+        expect(within(dialog).queryByText(TAKEN.name)).toBeNull();
+
+        await user.click(within(dialog).getByRole('button', { name: /^FILTERS/ }));
+        await user.click(screen.getByRole('checkbox', { name: /Other rosters/ }));
+
         expect(within(dialog).getByText(TAKEN.name)).toBeInTheDocument();
         expect(within(dialog).getByText('Taken')).toBeInTheDocument();
 
@@ -546,6 +554,26 @@ describe('DraftPanel best-available sheet', () => {
         // either - see DraftPanel's own comment on this near its BestAvailable
         // usage.
         expect(within(dialog).queryByRole('button', { name: 'Add' })).toBeNull();
+    });
+
+    // The scope is DraftPanel's state, not the sheet's: the sheet is mounted
+    // only while open, so a scope held inside it would forget every widening
+    // the moment the sheet was closed.
+    it('remembers a widened scope across a close and reopen', async () => {
+        const user = userEvent.setup();
+        renderPanel({ rankingPlayersIdsList: [rankEntry(FREE_AGENT.id), rankEntry(TAKEN.id)] });
+
+        const handle = () => screen.getByRole('button', { name: /Best available/ });
+        await user.click(handle());
+        await user.click(screen.getByRole('button', { name: /^FILTERS/ }));
+        await user.click(screen.getByRole('checkbox', { name: /Other rosters/ }));
+        await user.keyboard('{Escape}');
+        await user.click(handle());
+        await user.click(handle());
+
+        expect(
+            within(screen.getByRole('dialog', { name: 'Best available' })).getByText(TAKEN.name),
+        ).toBeInTheDocument();
     });
 
     // The handle used to be swapped out for a flat message strip when there


### PR DESCRIPTION
The draft's best-available sheet showed the whole ranked list with drafted players left in and marked `Taken`. Mid-draft that is most of the list. It now carries the same `FILTERS` chip the lineup sheet has, with the same default: **your players plus free agents and waivers**, other managers' rosters a checkbox away. Rookies-only was already part of that control and comes along with it.

- The chip and the scope are no longer gated on `eligibleSlots`. Only the *slot* chips (`ALL / FLX / TE …`) are lineup-only, since the draft list has no slot to be eligible for.
- The scope lives in `DraftPanel`, not in the sheet - the sheet is mounted only while open, so a scope held inside it would forget every widening on close. Same reasoning `LineupPanel` already had.
- The handle's `n left` takes the scope too. With any shipped default that is the same number as before (an unrostered player is `available`), so it moves only when a filter the user touched says it should.
- The desktop rail gets the chip on the same terms - it renders the same component.

**One bug fixed on the way,** found in the browser at 1440: a `Popover` is portaled to `body`, so it is not a DOM descendant of its trigger, and the draft/lineup sheets are `md:hidden` rather than unmounted. Crossing that width with the popover open left it stranded in the top-left corner over the desktop layout. It now renders nothing while its trigger has no box. `checkVisibility` is feature-detected, not assumed - jsdom does not implement it, and taking it for granted would have hidden every popover in every test.

Tests 449 → 453 (`Popover.test.jsx` is new); the `BestAvailable` cases that were about rendering a row rather than about the scope now ask for all three buckets explicitly. Browser-verified at 375 and 1440 against the real league: 5 of 15 ranked players by default, all 15 with `Other rosters` on and 10 of them marked `Taken`.