### PR TITLE
Default draft rank list to the draft's own player pool

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -25,6 +25,7 @@ import { checkErrors } from './lib/http.js';
 import { auth } from './firebase.js';
 import APP_DB_URLS, { SLEEPER_USER_ID } from './urls.js';
 import BestAvailable, { countAvailable } from './Components/BestAvailable';
+import { draftDefaultOwnership } from './Components/OwnershipFilters';
 
 const { APP_USERS, TYPE_PARAMS } = APP_DB_URLS;
 
@@ -415,6 +416,10 @@ class App extends React.Component {
             activeId === 'lineup'
                 ? [...new Set(rosterSlots.filter((slot) => !slot.playerId).map((slot) => slot.label))]
                 : null;
+        // Only the draft rail's resting scope cares which pool the board is
+        // drawn from - the lineup rail is never scoped to a specific draft.
+        const defaultOwnership =
+            activeId === 'lineup' ? undefined : draftDefaultOwnership(leagueData.currentDraft?.player_pool);
         const left = countAvailable({
             entries: rankingPlayersIdsList,
             playerInfo,
@@ -446,6 +451,7 @@ class App extends React.Component {
                     rosterInfo={rosterInfoValue}
                     myDisplayName={myDisplayName}
                     eligibleSlots={eligibleSlots}
+                    defaultOwnership={defaultOwnership}
                     lineupSet={activeId === 'lineup' ? buildLineupSet(rosterSlots) : undefined}
                     onSelect={activeId === 'lineup' ? this.addToRoster : null}
                 />

--- a/src/Components/BestAvailable.jsx
+++ b/src/Components/BestAvailable.jsx
@@ -88,6 +88,7 @@ const BestAvailable = ({
     rosterInfo,
     myDisplayName,
     eligibleSlots,
+    defaultOwnership = DEFAULT_OWNERSHIP,
     initialActiveChip = null,
     ownership: controlledOwnership,
     onOwnershipChange,
@@ -100,8 +101,10 @@ const BestAvailable = ({
     // working untouched; LineupPanel controls it instead, because its sheet is
     // mounted only while open and a scope held down here would reset every
     // time the sheet was reopened - which is precisely what "Reset to default"
-    // exists to do deliberately.
-    const [localOwnership, setLocalOwnership] = useState(DEFAULT_OWNERSHIP);
+    // exists to do deliberately. Seeded from `defaultOwnership` rather than the
+    // bare constant so an uncontrolled caller on a Rookie-flagged draft still
+    // starts scoped to rookies, same as DraftPanel's own controlled state does.
+    const [localOwnership, setLocalOwnership] = useState(defaultOwnership);
     const ownership = controlledOwnership ?? localOwnership;
     const setOwnership = onOwnershipChange ?? setLocalOwnership;
 
@@ -183,6 +186,7 @@ const BestAvailable = ({
                     onChange={setOwnership}
                     isOpen={filtersOpen}
                     onToggle={() => setFiltersOpen((open) => !open)}
+                    defaultOwnership={defaultOwnership}
                 />
             </div>
             {/* Distinct from the "no rank list yet" message above: there is a

--- a/src/Components/BestAvailable.test.jsx
+++ b/src/Components/BestAvailable.test.jsx
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import BestAvailable from './BestAvailable';
+import { draftDefaultOwnership } from './OwnershipFilters';
 import { buildRosterInfo, decorateRosters } from '../lib/rosterInfo.js';
 import rosterFlagsFixture from '../lib/__fixtures__/roster-flags-2026.json';
 
@@ -170,6 +171,44 @@ describe('BestAvailable', () => {
 
             await user.click(screen.getByRole('button', { name: 'ALL' }));
             expect(screen.getByText(TAKEN_BY_ME.name)).toBeInTheDocument();
+        });
+    });
+
+    describe('with defaultOwnership', () => {
+        // In the fixture, FREE_AGENT/TAKEN_BY_OTHERS/TAKEN_BY_ME (13307,
+        // 13294, 13274) are all years_exp 0 - rookies. OTHER_FREE_AGENT (289,
+        // Drew Brees) is years_exp 20 - the lone veteran. Uncontrolled here
+        // (no `ownership` override) so the component's own seeding from
+        // `defaultOwnership` is what's under test, same as an unopened draft
+        // sheet or the desktop rail.
+        it('starts scoped to rookies when seeded from a Rookie draft, hiding the one veteran', () => {
+            renderBestAvailable({ defaultOwnership: draftDefaultOwnership('Rookie') });
+
+            expect(screen.getByText(FREE_AGENT.name)).toBeInTheDocument();
+            expect(screen.getByText(TAKEN_BY_ME.name)).toBeInTheDocument();
+            expect(screen.queryByText(TAKEN_BY_OTHERS.name)).toBeNull();
+            expect(screen.queryByText(OTHER_FREE_AGENT.name)).toBeNull();
+        });
+
+        // The point of seeding rather than hard-filtering: the starting
+        // position is a default, not a floor, so it has to give back.
+        it('still lets Rookies only be switched back off from that starting point', async () => {
+            const user = userEvent.setup();
+            renderBestAvailable({ defaultOwnership: draftDefaultOwnership('Rookie') });
+
+            expect(screen.queryByText(OTHER_FREE_AGENT.name)).toBeNull();
+
+            await user.click(screen.getByRole('button', { name: /^FILTERS/ }));
+            await user.click(screen.getByRole('switch', { name: 'Rookies only' }));
+
+            expect(screen.getByText(OTHER_FREE_AGENT.name)).toBeInTheDocument();
+        });
+
+        it('leaves rookiesOnly off for a Veteran draft or when omitted, same as the ordinary default', () => {
+            renderBestAvailable({ defaultOwnership: draftDefaultOwnership('Veteran') });
+
+            expect(screen.getByText(OTHER_FREE_AGENT.name)).toBeInTheDocument();
+            expect(screen.getByText(FREE_AGENT.name)).toBeInTheDocument();
         });
     });
 

--- a/src/Components/OwnershipFilters.jsx
+++ b/src/Components/OwnershipFilters.jsx
@@ -19,6 +19,19 @@ export const DEFAULT_OWNERSHIP = {
     rookiesOnly: false,
 };
 
+/**
+ * The draft screen's resting scope: same as DEFAULT_OWNERSHIP, except a draft
+ * Sleeper has flagged Rookie-only (`currentDraft.player_pool`, from the
+ * draft's own `settings.player_type` - see lib/draft.js) starts with "Rookies
+ * only" already on, since every pick in it will be one anyway. The toggle
+ * stays touchable - this only moves where it rests, not whether it can be
+ * turned back off.
+ */
+export const draftDefaultOwnership = (playerPool) => ({
+    ...DEFAULT_OWNERSHIP,
+    rookiesOnly: playerPool === 'Rookie',
+});
+
 const OWNERSHIP_OPTIONS = [
     { name: 'mine', label: 'My players', explainer: 'on your roster' },
     { name: 'available', label: 'Free agents & waivers', explainer: 'available to add' },
@@ -33,9 +46,14 @@ const OWNERSHIP_OPTIONS = [
  */
 export const ownershipCount = (ownership) => OWNERSHIP_OPTIONS.filter((option) => ownership[option.name]).length;
 
-/** True when the scope is untouched - what makes the chip read as "at rest". */
-export const isDefaultOwnership = (ownership) =>
-    Object.keys(DEFAULT_OWNERSHIP).every((key) => ownership[key] === DEFAULT_OWNERSHIP[key]);
+/**
+ * True when the scope matches `defaultOwnership` - what makes the chip read
+ * as "at rest". `defaultOwnership` defaults to the module constant so every
+ * caller that doesn't have a context-specific resting scope (the lineup, and
+ * any test that calls this directly) keeps comparing against it unchanged.
+ */
+export const isDefaultOwnership = (ownership, defaultOwnership = DEFAULT_OWNERSHIP) =>
+    Object.keys(DEFAULT_OWNERSHIP).every((key) => ownership[key] === defaultOwnership[key]);
 
 /**
  * Whether one player survives the ownership scope. Split three ways by who
@@ -70,7 +88,7 @@ const Checkbox = ({ checked }) => (
  * and a reset. Exported separately from the chip so the same body can sit in
  * whatever container a caller has (the anchored popover below, or a panel).
  */
-export const OwnershipFiltersBody = ({ ownership, onChange }) => {
+export const OwnershipFiltersBody = ({ ownership, onChange, defaultOwnership = DEFAULT_OWNERSHIP }) => {
     const toggle = (name) => onChange({ ...ownership, [name]: !ownership[name] });
 
     return (
@@ -124,7 +142,7 @@ export const OwnershipFiltersBody = ({ ownership, onChange }) => {
             </button>
             <button
                 type="button"
-                onClick={() => onChange(DEFAULT_OWNERSHIP)}
+                onClick={() => onChange(defaultOwnership)}
                 className="text-mine w-full rounded-lg px-2.5 py-[9px] text-left text-[13px] font-semibold"
             >
                 Reset to default
@@ -138,9 +156,9 @@ export const OwnershipFiltersBody = ({ ownership, onChange }) => {
  * the scope is non-default, outlined at rest - the chip has to say that
  * something is being hidden without the popover being open to explain it.
  */
-const OwnershipFilters = ({ ownership, onChange, isOpen, onToggle }) => {
+const OwnershipFilters = ({ ownership, onChange, isOpen, onToggle, defaultOwnership = DEFAULT_OWNERSHIP }) => {
     const chipRef = useRef(null);
-    const active = isOpen || !isDefaultOwnership(ownership);
+    const active = isOpen || !isDefaultOwnership(ownership, defaultOwnership);
 
     return (
         <div className="relative inline-block shrink-0">
@@ -157,7 +175,11 @@ const OwnershipFilters = ({ ownership, onChange, isOpen, onToggle }) => {
             </button>
             {isOpen && (
                 <Popover triggerRef={chipRef} onClose={onToggle} label="Filters">
-                    <OwnershipFiltersBody ownership={ownership} onChange={onChange} />
+                    <OwnershipFiltersBody
+                        ownership={ownership}
+                        onChange={onChange}
+                        defaultOwnership={defaultOwnership}
+                    />
                 </Popover>
             )}
         </div>

--- a/src/Panels/DraftPanel.jsx
+++ b/src/Panels/DraftPanel.jsx
@@ -4,7 +4,7 @@ import PickFeed from './PickFeed';
 import DraftGrid from './DraftGrid';
 import Sheet from '../Components/Sheet';
 import BestAvailable, { countAvailable } from '../Components/BestAvailable';
-import { DEFAULT_OWNERSHIP } from '../Components/OwnershipFilters';
+import { draftDefaultOwnership } from '../Components/OwnershipFilters';
 import BestAvailableHandle from '../Components/BestAvailableHandle';
 import ClockCard from '../Components/ClockCard';
 import DraftSourceSheet, { readLastMock, writeLastMock } from './DraftSourceSheet';
@@ -65,8 +65,12 @@ const DraftPanel = ({
     // LineupPanel holds its own: the sheet is mounted only while open, so a
     // scope kept down there would reset every time it was reopened - and
     // switching "Other rosters" on to check who has somebody would never
-    // survive closing the sheet.
-    const [ownership, setOwnership] = useState(DEFAULT_OWNERSHIP);
+    // survive closing the sheet. `currentDraft.player_pool` is fixed for the
+    // life of this panel (it comes from the league's own draft, not from
+    // `currentDraftId`/mock switching - see the sync effects below), so
+    // computing it once here rather than through a ref is safe.
+    const ownershipDefault = draftDefaultOwnership(currentDraft.player_pool);
+    const [ownership, setOwnership] = useState(ownershipDefault);
     const bestAvailableHandleRef = useRef(null);
     const sourceButtonRef = useRef(null);
 
@@ -336,7 +340,14 @@ const DraftPanel = ({
                 onClick={() => setIsBestAvailableOpen((open) => !open)}
                 subtitle={
                     entries.length > 0
-                        ? `${countAvailable({ entries, playerInfo, rosterInfo, eligibleSlots: null, ownership, myDisplayName })} left`
+                        ? `${countAvailable({
+                              entries,
+                              playerInfo,
+                              rosterInfo,
+                              eligibleSlots: null,
+                              ownership,
+                              myDisplayName,
+                          })} left`
                         : 'Paste a rank list'
                 }
             />
@@ -366,6 +377,7 @@ const DraftPanel = ({
                         rosterInfo={rosterInfo}
                         myDisplayName={myDisplayName}
                         eligibleSlots={null}
+                        defaultOwnership={ownershipDefault}
                         ownership={ownership}
                         onOwnershipChange={setOwnership}
                         onSelect={null}


### PR DESCRIPTION
## Summary
- A draft Sleeper flags Rookie-only (`currentDraft.player_pool`, from `settings.player_type`) now starts the rank list's "Rookies only" toggle on, instead of showing veterans it can never actually hand out.
- Reuses the existing ownership FILTERS toggle rather than adding a separate filter - the toggle stays fully switchable from that starting point.

## Test plan
- [x] `npx vitest run` - 456 tests passing
- [x] `npx eslint` clean on touched files
- [x] Verified live against a real Rookie-flagged Sleeper dynasty draft: rank list starts with Rookies-only on, a pasted veteran is hidden by default, switching the toggle off reveals it (marked Taken once also rostered elsewhere)