### PR TITLE
Put leaguemate intel in the rank list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,10 @@ node_modules
 
 # TypeScript incremental build cache
 tsconfig.tsbuildinfo
+
+# Design handoff bundle - kept locally for reference, not source controlled
+/design
+
+# Leaguemate intel design docs - kept locally alongside /design, not source controlled
+/docs/leaguemate-intel.md
+/docs/leaguemate-intel-estimator.md

--- a/src/Components/BestAvailable.jsx
+++ b/src/Components/BestAvailable.jsx
@@ -1,12 +1,17 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import ListRow from './ListRow';
 import PositionTag from './PositionTag';
 import OwnershipFilters, { DEFAULT_OWNERSHIP, matchesOwnership } from './OwnershipFilters';
+import IntelDetail from './IntelDetail';
+import IntelKey from './IntelTermTip';
+import IntelPickSelector from './IntelPickSelector';
+import { survivalBand, survivalTone } from './intelGlossary.js';
 import { playerAccessibleName } from './playerInfoLabels.js';
 import { eligiblePositionsForSlot } from '../lib/roster.js';
 import { isInLineup, isTaken, rosteredBy } from '../lib/rosterInfo.js';
+import { defaultAnalyzedPick, survivalAt } from '../lib/availability.js';
 
-const playerId = (entry) => entry.match_results[0][0];
+export const playerId = (entry) => entry.match_results[0][0];
 
 // Eligibility expressed from the slot's side, not the player's: for each slot
 // label in `slots`, ask which real positions it admits
@@ -94,9 +99,21 @@ const BestAvailable = ({
     onOwnershipChange,
     lineupSet,
     onSelect,
+    // The /availability response, or undefined. Optional on purpose: intel is
+    // additive, so a caller with none (the Lineup sheet, or a failed fetch)
+    // renders exactly the list this component rendered before the feature
+    // existed. Only the draft passes it.
+    availability,
 }) => {
     const [activeChip, setActiveChip] = useState(initialActiveChip);
     const [filtersOpen, setFiltersOpen] = useState(false);
+    const [selectedTargetId, setSelectedTargetId] = useState(null);
+    // null means "follow the default", so the analyzed pick keeps tracking my
+    // next pick as the draft syncs; a number means the user chose one and it
+    // stays chosen. Chip taps are client-side - the response carries the whole
+    // byPick matrix, so re-answering the list against another pick on the
+    // board needs no refetch.
+    const [chosenPick, setChosenPick] = useState(null);
     // Uncontrolled by default so the draft sheet and the desktop rail keep
     // working untouched; LineupPanel controls it instead, because its sheet is
     // mounted only while open and a scope held down here would reset every
@@ -107,6 +124,19 @@ const BestAvailable = ({
     const [localOwnership, setLocalOwnership] = useState(defaultOwnership);
     const ownership = controlledOwnership ?? localOwnership;
     const setOwnership = onOwnershipChange ?? setLocalOwnership;
+
+    // Intel is joined onto the rows by player id rather than driving them: the
+    // rank list is the user's own ordering and the reason they pasted a list,
+    // so it keeps its order and the percent chip carries the comparison across
+    // rows. A player the corpus has never seen simply has no chip.
+    const targetsById = useMemo(
+        () => new Map((availability?.targets || []).map((target) => [target.id, target])),
+        [availability],
+    );
+
+    // Above hooks-order concerns, this must sit before the early return below.
+    const atPick =
+        chosenPick ?? defaultAnalyzedPick({ myPicks: availability?.myPicks, currentPick: availability?.currentPick });
 
     // No rank list at all is the normal state for a signed-out user (or one
     // who hasn't pasted anything yet), not an edge case of an otherwise-full
@@ -143,8 +173,50 @@ const BestAvailable = ({
         myDisplayName,
     });
 
+    // Pushed in place rather than opened as a second Sheet - on a phone this
+    // list is already inside one, and a sheet on a sheet reads as a
+    // replacement with no way back.
+    const selectedTarget = selectedTargetId && targetsById.get(selectedTargetId);
+    if (selectedTarget) {
+        return (
+            <IntelDetail
+                target={selectedTarget}
+                board={availability.board}
+                atPick={atPick}
+                threshold={availability.signalThreshold}
+                onBack={() => setSelectedTargetId(null)}
+            />
+        );
+    }
+
+    const hasIntel = Boolean(availability);
+    const hasReads = hasIntel && targetsById.size > 0;
+
     return (
         <div className="flex flex-col gap-3">
+            {hasIntel && (
+                <div className="flex flex-col gap-1.5 px-2 pt-2">
+                    <div className="flex items-center justify-between px-0.5">
+                        <span className="text-ink text-[13px] font-semibold">Still there at…</span>
+                        <IntelKey />
+                    </div>
+                    {hasReads ? (
+                        <IntelPickSelector
+                            board={availability.board}
+                            selected={atPick}
+                            onSelect={setChosenPick}
+                            currentPick={availability.currentPick}
+                        />
+                    ) : (
+                        // The deliberate "no reads yet" state (§3e): a 200 with
+                        // a resolved board and no targets. Not a failure, and
+                        // not something to render as one.
+                        <p className="text-ink-muted m-0 text-[13px] leading-snug">
+                            No reads yet — none of your leaguemates’ drafts have been seen for these players.
+                        </p>
+                    )}
+                </div>
+            )}
             {/* Only the slot chips scroll, and only the lineup has any: the
                 draft list has no slot to be eligible for, so there this is the
                 FILTERS chip alone. FILTERS is pinned to the end because it is
@@ -224,11 +296,24 @@ const BestAvailable = ({
                     const started = Boolean(lineupSet) && isInLineup(lineupSet, id);
                     const accessibleName = playerAccessibleName({ player, taken, rosteredByName, isMine, started });
 
+                    const target = targetsById.get(id);
+                    const survival = survivalAt(target, atPick);
+                    // The row only becomes tappable when there is something
+                    // behind the tap. `onSelect` rules it out too: that caller
+                    // (the Lineup sheet) puts an Add button inside the row, and
+                    // a button inside a button is invalid.
+                    const opensDetail = Boolean(target) && !onSelect;
+
                     return (
                         <li key={id}>
                             <ListRow
-                                as="div"
-                                label={accessibleName}
+                                as={opensDetail ? 'button' : 'div'}
+                                onClick={opensDetail ? () => setSelectedTargetId(id) : undefined}
+                                label={
+                                    opensDetail && survival != null
+                                        ? `${accessibleName}, ${Math.round(survival * 100)}% to last to pick ${atPick}`
+                                        : accessibleName
+                                }
                                 ordinal={entry.ranking}
                                 ordinalWidth="20px"
                                 ordinalClassName="text-right text-[12px] text-ink-muted"
@@ -244,6 +329,23 @@ const BestAvailable = ({
                                 }
                                 trailing={
                                     <>
+                                        {/* The one number worth comparing across
+                                            rows, so it stays a number. Absent
+                                            rather than defaulted when there is no
+                                            read - a confident 100% the data does
+                                            not support is the §3g bug. */}
+                                        {target &&
+                                            (survival == null ? (
+                                                <span className="text-ink-dim w-[52px] shrink-0 text-center font-mono text-[11px]">
+                                                    —
+                                                </span>
+                                            ) : (
+                                                <span
+                                                    className={`w-[52px] shrink-0 rounded-full py-1 text-center font-mono text-[12px] font-semibold tabular-nums ${survivalTone(survival)} ${survivalBand(survival)}`}
+                                                >
+                                                    {Math.round(survival * 100)}%
+                                                </span>
+                                            ))}
                                         <PositionTag position={player.position} />
                                         {unavailable ? (
                                             <span className="text-ink-quiet shrink-0 font-mono text-[11px] font-semibold">

--- a/src/Components/BestAvailable.test.jsx
+++ b/src/Components/BestAvailable.test.jsx
@@ -239,4 +239,187 @@ describe('BestAvailable', () => {
             expect(within(row).getByText('Taken')).toBeInTheDocument();
         });
     });
+
+    // Leaguemate intel (docs/leaguemate-intel.md §3 Frontend, §3g).
+    describe('with availability intel', () => {
+        // Deliberately a *subset* of the rank list: FREE_AGENT has reads and
+        // OTHER_FREE_AGENT does not, which is the normal case rather than an
+        // edge one - the corpus only knows players your leaguemates have
+        // actually drafted.
+        const target = {
+            id: FREE_AGENT.id,
+            name: FREE_AGENT.name,
+            position: 'TE',
+            leagueAdp: 33.9,
+            sd: 6.7,
+            n: 60,
+            marketPick: 34,
+            adpGap: -0.1,
+            perManager: [{ manager: 'baconstains', times: 5, of: 30, adp: 30.6, picks: ['3.1@25'] }],
+            notable: null,
+            byPick: {
+                35: { adjSurvival: 1, baseSurvival: 1, threats: [] },
+                37: {
+                    adjSurvival: 0.77,
+                    baseSurvival: 0.75,
+                    threats: [{ manager: 'atekipp', pick: 35, prob: 0.18, drafts: 3, tookCount: 0 }],
+                },
+                39: {
+                    adjSurvival: 0.59,
+                    baseSurvival: 0.56,
+                    threats: [
+                        { manager: 'atekipp', pick: 35, prob: 0.18, drafts: 3, tookCount: 0 },
+                        { manager: 'cja9689', pick: 36, prob: 0.22, drafts: 1, tookCount: 0 },
+                        { manager: 'baconstains', pick: 37, prob: 0.15, drafts: 30, tookCount: 5 },
+                    ],
+                },
+                40: { adjSurvival: 0.5, baseSurvival: 0.48, threats: [] },
+            },
+        };
+
+        const availability = (overrides = {}) => ({
+            currentPick: 35,
+            lastPick: 48,
+            myPicks: [39],
+            corpusDrafts: 70,
+            signalThreshold: { minDrafts: 8, minTimes: 3 },
+            board: [
+                { pick: 35, manager: 'atekipp', mine: false, drafts: 3 },
+                { pick: 36, manager: 'cja9689', mine: false, drafts: 1 },
+                { pick: 37, manager: 'baconstains', mine: false, drafts: 30 },
+                { pick: 39, manager: MY_DISPLAY_NAME, mine: true, drafts: 4 },
+            ],
+            targets: [target],
+            ...overrides,
+        });
+
+        const renderWithIntel = (overrides = {}) =>
+            renderBestAvailable({ ownership: SHOW_EVERYONE, availability: availability(), ...overrides });
+
+        it('keeps the rank list order rather than re-sorting by survival', () => {
+            // The ordering is the user's own judgment and the reason they
+            // pasted a list; the percent chip carries the comparison instead.
+            renderWithIntel();
+
+            const names = screen.getAllByRole('listitem').map((item) => item.textContent);
+            expect(names[0]).toContain(TAKEN_BY_ME.name);
+            expect(names[1]).toContain(FREE_AGENT.name);
+            expect(names[3]).toContain(OTHER_FREE_AGENT.name);
+        });
+
+        it('shows the survival chip against my next pick, and nothing for a player with no reads', () => {
+            renderWithIntel();
+
+            expect(screen.getByText('59%')).toBeInTheDocument();
+
+            const noReads = screen.getByText(OTHER_FREE_AGENT.name).closest('li');
+            expect(within(noReads).queryByText(/%$/)).toBeNull();
+        });
+
+        it('renders exactly as before when no availability is passed at all', () => {
+            // Intel is additive: a failed fetch or the Lineup sheet must get
+            // the list this component rendered before the feature existed.
+            renderBestAvailable({ ownership: SHOW_EVERYONE });
+
+            expect(screen.queryByText('59%')).toBeNull();
+            expect(screen.queryByText('Still there at…')).toBeNull();
+        });
+
+        describe('the pick selector (§3g gap 1)', () => {
+            it('defaults to my next pick and re-answers the list client-side when another is chosen', async () => {
+                const user = userEvent.setup();
+                renderWithIntel();
+
+                expect(screen.getByText('59%')).toBeInTheDocument();
+
+                await user.click(screen.getByRole('button', { name: 'Analyze pick 37, baconstains' }));
+
+                // No refetch: the response carries the whole byPick matrix.
+                expect(screen.getByText('77%')).toBeInTheDocument();
+                expect(screen.queryByText('59%')).toBeNull();
+            });
+
+            it('marks my own pick as mine, using the trade-resolved owner', () => {
+                renderWithIntel();
+
+                const myChip = screen.getByRole('button', { name: 'Analyze pick 39, yours' });
+                // Scoped to the chip: "YOU" is also the row flag on a player
+                // I already roster, so an unscoped query matches both.
+                expect(within(myChip).getByText('YOU')).toBeInTheDocument();
+                expect(within(myChip).getByText('39')).toBeInTheDocument();
+            });
+        });
+
+        // §3g gap 1b - a correctness bug, not an enhancement. "My next pick"
+        // used to resolve to the pick being made right now, so `between` was
+        // empty and every player read 100%: the feature went blank at exactly
+        // the moment it was most wanted.
+        describe('when I am on the clock (§3g gap 1b)', () => {
+            it('analyzes my FOLLOWING pick, not the one I am making', () => {
+                renderWithIntel({
+                    availability: availability({ currentPick: 39, myPicks: [39, 51] }),
+                });
+
+                // 51 has no byPick entry in this fixture, so the honest answer
+                // is a dash - emphatically not 100%.
+                expect(screen.queryByText('100%')).toBeNull();
+            });
+
+            it('says there are no picks left rather than rendering a number, when nothing follows', () => {
+                renderWithIntel({
+                    availability: availability({ currentPick: 48, myPicks: [48], board: [] }),
+                });
+
+                expect(screen.getByText('No picks left in this draft.')).toBeInTheDocument();
+                expect(screen.queryByText('100%')).toBeNull();
+            });
+        });
+
+        describe('the drill-down', () => {
+            it('pushes the detail in place and comes back, rather than opening a second sheet', async () => {
+                const user = userEvent.setup();
+                renderWithIntel();
+
+                await user.click(screen.getByRole('button', { name: new RegExp(FREE_AGENT.name) }));
+
+                expect(screen.getByText('probably there')).toBeInTheDocument();
+                expect(screen.getByText(/Who picks before 39/)).toBeInTheDocument();
+                // The list is gone, not layered under a second sheet.
+                expect(screen.queryByText(OTHER_FREE_AGENT.name)).toBeNull();
+
+                await user.click(screen.getByRole('button', { name: /Ranks/ }));
+                expect(screen.getByText(OTHER_FREE_AGENT.name)).toBeInTheDocument();
+            });
+
+            it('carries the sample size on every manager claim (§3 copy rules)', async () => {
+                const user = userEvent.setup();
+                renderWithIntel();
+
+                await user.click(screen.getByRole('button', { name: new RegExp(FREE_AGENT.name) }));
+
+                // 3 drafts seen, never taken him - a rate would overclaim.
+                expect(screen.getByText('never taken him · 3 drafts seen')).toBeInTheDocument();
+                // 1 draft seen, never taken him - same shape, smaller sample.
+                expect(screen.getByText('never taken him · 1 draft seen')).toBeInTheDocument();
+                // 30 drafts and 5 takes clears the threshold, so the ADP shows.
+                expect(screen.getByText('took him 5× of 30 drafts · their ADP 30.6')).toBeInTheDocument();
+            });
+
+            it('does not make a row tappable when there is nothing behind the tap', () => {
+                renderWithIntel();
+
+                const noReads = screen.getByText(OTHER_FREE_AGENT.name).closest('li');
+                expect(within(noReads).queryByRole('button')).toBeNull();
+            });
+        });
+
+        it('says so plainly when the corpus has no reads at all (§3e)', () => {
+            // A 200 with a resolved board and targets: [] is the deliberate
+            // "no reads yet" state, not a failure to render as one.
+            renderWithIntel({ availability: availability({ targets: [], corpusDrafts: 0 }) });
+
+            expect(screen.getByText(/No reads yet/)).toBeInTheDocument();
+            expect(screen.getByText(FREE_AGENT.name)).toBeInTheDocument();
+        });
+    });
 });

--- a/src/Components/BestAvailable.test.jsx
+++ b/src/Components/BestAvailable.test.jsx
@@ -257,23 +257,18 @@ describe('BestAvailable', () => {
             adpGap: -0.1,
             perManager: [{ manager: 'baconstains', times: 5, of: 30, adp: 30.6, picks: ['3.1@25'] }],
             notable: null,
+            // One hazard per pick. The manager, their drafts-seen and the take
+            // count are joined from `board`/`perManager` - see stationsFor.
+            hazards: [
+                { pick: 35, prob: 0.18 },
+                { pick: 36, prob: 0.22 },
+                { pick: 37, prob: 0.15 },
+            ],
             byPick: {
-                35: { adjSurvival: 1, baseSurvival: 1, threats: [] },
-                37: {
-                    adjSurvival: 0.77,
-                    baseSurvival: 0.75,
-                    threats: [{ manager: 'atekipp', pick: 35, prob: 0.18, drafts: 3, tookCount: 0 }],
-                },
-                39: {
-                    adjSurvival: 0.59,
-                    baseSurvival: 0.56,
-                    threats: [
-                        { manager: 'atekipp', pick: 35, prob: 0.18, drafts: 3, tookCount: 0 },
-                        { manager: 'cja9689', pick: 36, prob: 0.22, drafts: 1, tookCount: 0 },
-                        { manager: 'baconstains', pick: 37, prob: 0.15, drafts: 30, tookCount: 5 },
-                    ],
-                },
-                40: { adjSurvival: 0.5, baseSurvival: 0.48, threats: [] },
+                35: { adjSurvival: 1, baseSurvival: 1 },
+                37: { adjSurvival: 0.77, baseSurvival: 0.75 },
+                39: { adjSurvival: 0.59, baseSurvival: 0.56 },
+                40: { adjSurvival: 0.5, baseSurvival: 0.48 },
             },
         };
 

--- a/src/Components/IntelDetail.jsx
+++ b/src/Components/IntelDetail.jsx
@@ -1,0 +1,285 @@
+import PositionTag from './PositionTag';
+import { TermTip } from './IntelTermTip';
+import { gapPhrase, gapTone, survivalPhrase, survivalTone } from './intelGlossary.js';
+import { managerSample, survivalAt } from '../lib/availability.js';
+
+// The drill-down (docs/leaguemate-intel.md §3 Frontend).
+//
+// Pushed in place with a `← Ranks` back control rather than opened as a
+// second Sheet: on a phone the rank list is already inside a sheet, so a
+// sheet-on-a-sheet reads as a replacement with no way back. Not an accordion
+// either - there is no room for the gauntlet inside a row.
+//
+// Everything is scoped to `atPick`, which the selector owns. Nothing here
+// computes a survival number a second way: the station decay is read from the
+// same `byPick` matrix the row chip reads, so the two cannot disagree.
+
+// Threat severity for the station dot and its bar. `--raw-mark` is the
+// "nothing to see here" end of the scale, not a colour of its own.
+function threatFill(probability) {
+    if (probability >= 0.25) return 'var(--raw-danger)';
+    if (probability >= 0.1) return 'var(--raw-warn)';
+    return 'var(--raw-mark)';
+}
+
+const Stat = ({ label, value, sub, tone = 'text-ink' }) => (
+    <div className="min-w-0">
+        <p className="text-ink-dim m-0 flex items-center font-mono text-[9px] tracking-[.08em] uppercase">{label}</p>
+        <p className={`m-0 font-mono text-[15px] font-semibold tabular-nums ${tone}`}>{value}</p>
+        {sub && <p className="text-ink-dim m-0 font-mono text-[9px]">{sub}</p>}
+    </div>
+);
+
+/**
+ * One manager's history with this player, in words. This is the §3 copy-rules
+ * table reaching the screen: `managerSample` decides what may be said, and
+ * each branch here says only that. The recurring failure in this feature was
+ * never the maths - it was the sentence next to the number.
+ */
+function evidenceFor(sample) {
+    switch (sample.kind) {
+        case 'none':
+            return 'no drafts of theirs seen — league average';
+        case 'never':
+            return `never taken him · ${sample.of} draft${sample.of === 1 ? '' : 's'} seen`;
+        case 'singlePick':
+            return sample.pick
+                ? `took him once — at ${sample.pick}`
+                : `took him once of ${sample.of} draft${sample.of === 1 ? '' : 's'}`;
+        case 'thin':
+            return `took him ${sample.times}× · we've only seen ${sample.of} of their drafts`;
+        case 'countOnly':
+            return `took him ${sample.times}× of ${sample.of} drafts`;
+        default:
+            return `took him ${sample.times}× of ${sample.of} drafts · their ADP ${sample.adp}`;
+    }
+}
+
+/**
+ * The picks between now and `atPick`, with survival decaying across them.
+ *
+ * `byPick[atPick].threats` holds every pick *before* atPick - exactly the set
+ * of stations being rendered - so the threat list is read once from the
+ * target pick. Looking each one up under its own pick number silently found
+ * nothing and rendered "no read" on every station while the survival figure
+ * beside it visibly decayed.
+ */
+export function stationsFor(target, board, atPick) {
+    const between = (board || []).filter((slot) => slot.pick < atPick);
+    const byManager = new Map((target.perManager || []).map((entry) => [entry.manager, entry]));
+    const threatByPick = new Map((target.byPick?.[String(atPick)]?.threats || []).map((t) => [t.pick, t]));
+
+    return between.map((slot) => {
+        const threat = threatByPick.get(slot.pick) || { prob: 0, tookCount: 0, drafts: slot.drafts };
+        return {
+            pick: slot.pick,
+            manager: slot.manager,
+            isMine: slot.mine,
+            probability: threat.prob ?? 0,
+            tookCount: threat.tookCount ?? 0,
+            draftsSeen: threat.drafts ?? 0,
+            mate: byManager.get(slot.manager),
+            // Survival *after* this pick is the value stored at the next one,
+            // which is why byPick runs one past lastPick.
+            survivalAfter: survivalAt(target, slot.pick + 1),
+        };
+    });
+}
+
+const Station = ({ station, threshold, isLast }) => {
+    const { probability, isMine, mate, tookCount, draftsSeen } = station;
+    const live = probability > 0.08;
+    const sample = managerSample({ times: tookCount, of: draftsSeen, adp: mate?.adp, picks: mate?.picks }, threshold);
+
+    return (
+        <li className="relative flex items-start gap-2.5">
+            {!isLast && <span className="bg-line absolute top-6 left-[10px] h-[calc(100%-12px)] w-px" aria-hidden />}
+            <span
+                className={`relative z-10 mt-0.5 grid h-5 w-5 shrink-0 place-items-center rounded-full font-mono text-[9px] font-semibold ${
+                    isMine || live ? 'text-ground' : 'text-ink-dim'
+                }`}
+                style={{ background: isMine ? 'var(--raw-mine)' : live ? threatFill(probability) : 'var(--raw-mark)' }}
+            >
+                {station.pick}
+            </span>
+            <div className="min-w-0 flex-1 pb-2.5">
+                <div className="flex items-baseline justify-between gap-2">
+                    <span
+                        className={`truncate text-[13px] ${
+                            isMine ? 'text-mine font-semibold' : live ? 'text-ink font-semibold' : 'text-ink-quiet'
+                        }`}
+                    >
+                        {isMine ? 'You' : station.manager}
+                    </span>
+                    <span className="text-ink-dim shrink-0 font-mono text-[10px] tabular-nums">
+                        {station.survivalAfter == null ? 'no read' : `${Math.round(station.survivalAfter * 100)}% left`}
+                    </span>
+                </div>
+                <div className="mt-1 flex items-center gap-2">
+                    <div className="bg-line-mid h-1 w-full max-w-[110px] overflow-hidden rounded-full">
+                        <div
+                            className="h-full rounded-full"
+                            style={{
+                                width: `${Math.min(100, probability * 200)}%`,
+                                background: threatFill(probability),
+                            }}
+                        />
+                    </div>
+                    <span className="text-ink-dim shrink-0 font-mono text-[10px] tabular-nums">
+                        {probability >= 0.01 ? `${Math.round(probability * 100)}% to take him` : 'no read'}
+                    </span>
+                </div>
+                <p className="text-ink-dim mt-0.5 font-mono text-[10px]">{evidenceFor(sample)}</p>
+            </div>
+        </li>
+    );
+};
+
+const IntelDetail = ({ target, board, atPick, threshold, onBack }) => {
+    const survival = survivalAt(target, atPick);
+    const stations = stationsFor(target, board, atPick);
+    const gap = target.adpGap;
+    const perManager = target.perManager || [];
+
+    return (
+        <div className="px-2 py-2.5">
+            <button
+                type="button"
+                onClick={onBack}
+                className="text-ink-quiet hover:text-ink mb-2 -ml-1 flex min-h-11 items-center gap-1.5 px-1.5 py-1 font-mono text-[11px]"
+            >
+                <span className="text-[13px]">←</span> Ranks
+            </button>
+
+            <div className="px-1.5 pb-3">
+                <div className="flex min-w-0 items-center gap-2">
+                    <PositionTag position={target.position} />
+                    <span className="text-ink truncate text-[17px] font-semibold">{target.name}</span>
+                </div>
+                {/* A statement of fact, never a recommendation (§3g). */}
+                {survival == null ? (
+                    <p className="text-ink-muted mt-2 text-[15px] leading-snug">
+                        {atPick == null ? 'No further picks this draft.' : `No read for pick ${atPick}.`}
+                    </p>
+                ) : (
+                    <p className="mt-2 text-[15px] leading-snug">
+                        <span className={`font-semibold ${survivalTone(survival)}`}>{survivalPhrase(survival)}</span>
+                        <span className="text-ink-quiet"> at pick {atPick} — </span>
+                        <span className={`font-mono font-semibold ${survivalTone(survival)}`}>
+                            {Math.round(survival * 100)}%
+                        </span>
+                        <span className="text-ink-quiet"> of the time.</span>
+                    </p>
+                )}
+            </div>
+
+            <div className="px-1.5">
+                <div className="bg-raised-2 mb-3 grid grid-cols-3 gap-3 rounded-lg px-3 py-2.5">
+                    <Stat
+                        label={
+                            <>
+                                ADP
+                                <TermTip termKey="adp" />
+                            </>
+                        }
+                        // Null for real: a player FantasyCalc tracks but has no
+                        // draft-year info for. An em dash, not a zero.
+                        value={target.marketPick ? `#${target.marketPick}` : '—'}
+                        sub="dynasty-wide"
+                        tone="text-ink-muted"
+                    />
+                    <Stat
+                        label={
+                            <>
+                                League ADP
+                                <TermTip termKey="leagueAdp" />
+                            </>
+                        }
+                        value={target.leagueAdp}
+                        sub={`±${target.sd} · ${target.n} drafts`}
+                        tone="text-ink"
+                    />
+                    <Stat
+                        label={
+                            <>
+                                Gap
+                                <TermTip termKey="gap" />
+                            </>
+                        }
+                        value={gap == null ? '—' : `${gap > 0 ? '+' : ''}${gap}`}
+                        sub={gap == null ? 'no ADP data' : gap > 0 ? 'slides' : 'reached'}
+                        tone={gapTone(gap)}
+                    />
+                </div>
+
+                {gapPhrase(gap) && (
+                    <p className="text-ink-quiet -mt-1 mb-3 text-[12px] leading-snug">
+                        Dynasty ADP has him <span className="text-ink font-semibold">#{target.marketPick}</span> in this
+                        rookie class, but {gapPhrase(gap)} — they spend pick{' '}
+                        <span className="text-ink font-semibold">{target.leagueAdp}</span> on him on average.
+                    </p>
+                )}
+
+                {target.notable && (
+                    <div className="border-mine/30 bg-mine-row mb-3 rounded-lg border px-3 py-2.5">
+                        <p className="text-ink-dim m-0 flex items-center font-mono text-[9px] tracking-[.08em] uppercase">
+                            {target.notable.manager}’s own ADP
+                            <TermTip termKey="managerAdp" />
+                        </p>
+                        <p className="m-0 mt-0.5 text-[13px] leading-snug">
+                            <span className="text-ink font-mono text-[15px] font-semibold tabular-nums">
+                                {target.notable.adp}
+                            </span>
+                            <span className="text-ink-quiet">
+                                {' '}
+                                — took him {target.notable.times} of {target.notable.of} drafts.
+                            </span>
+                        </p>
+                    </div>
+                )}
+
+                <p className="text-ink-dim mb-2 font-mono text-[10px] tracking-[.08em] uppercase">
+                    {stations.length === 0
+                        ? `Nothing between now and ${atPick}`
+                        : `Who picks before ${atPick} (${stations.length} pick${stations.length === 1 ? '' : 's'})`}
+                </p>
+                {stations.length > 0 && (
+                    <ol className="m-0 list-none p-0">
+                        {stations.map((station, index) => (
+                            <Station
+                                key={station.pick}
+                                station={station}
+                                threshold={threshold}
+                                isLast={index === stations.length - 1}
+                            />
+                        ))}
+                    </ol>
+                )}
+
+                {perManager.length > 0 && (
+                    <div className="border-line-mid border-t pt-2">
+                        <p className="text-ink-dim mb-1 font-mono text-[10px] tracking-[.08em] uppercase">
+                            Everyone who has drafted him
+                        </p>
+                        {perManager.slice(0, 4).map((entry) => (
+                            <div key={entry.manager} className="flex items-baseline justify-between gap-2 py-0.5">
+                                <span className="text-ink-quiet truncate text-[12px]">
+                                    {entry.manager}{' '}
+                                    <span className="text-ink-dim">
+                                        {entry.times} of {entry.of}
+                                    </span>
+                                </span>
+                                <span className="text-ink-dim shrink-0 font-mono text-[10px] tabular-nums">
+                                    {entry.picks.slice(0, 3).join('  ')}
+                                </span>
+                            </div>
+                        ))}
+                        <p className="text-ink-dim mt-1 font-mono text-[9px]">round.slot @ overall pick</p>
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export default IntelDetail;

--- a/src/Components/IntelDetail.jsx
+++ b/src/Components/IntelDetail.jsx
@@ -1,7 +1,7 @@
 import PositionTag from './PositionTag';
 import { TermTip } from './IntelTermTip';
 import { gapPhrase, gapTone, survivalPhrase, survivalTone } from './intelGlossary.js';
-import { managerSample, survivalAt } from '../lib/availability.js';
+import { managerSample, stationsFor, survivalAt } from '../lib/availability.js';
 
 // The drill-down (docs/leaguemate-intel.md §3 Frontend).
 //
@@ -53,37 +53,6 @@ function evidenceFor(sample) {
         default:
             return `took him ${sample.times}× of ${sample.of} drafts · their ADP ${sample.adp}`;
     }
-}
-
-/**
- * The picks between now and `atPick`, with survival decaying across them.
- *
- * `byPick[atPick].threats` holds every pick *before* atPick - exactly the set
- * of stations being rendered - so the threat list is read once from the
- * target pick. Looking each one up under its own pick number silently found
- * nothing and rendered "no read" on every station while the survival figure
- * beside it visibly decayed.
- */
-export function stationsFor(target, board, atPick) {
-    const between = (board || []).filter((slot) => slot.pick < atPick);
-    const byManager = new Map((target.perManager || []).map((entry) => [entry.manager, entry]));
-    const threatByPick = new Map((target.byPick?.[String(atPick)]?.threats || []).map((t) => [t.pick, t]));
-
-    return between.map((slot) => {
-        const threat = threatByPick.get(slot.pick) || { prob: 0, tookCount: 0, drafts: slot.drafts };
-        return {
-            pick: slot.pick,
-            manager: slot.manager,
-            isMine: slot.mine,
-            probability: threat.prob ?? 0,
-            tookCount: threat.tookCount ?? 0,
-            draftsSeen: threat.drafts ?? 0,
-            mate: byManager.get(slot.manager),
-            // Survival *after* this pick is the value stored at the next one,
-            // which is why byPick runs one past lastPick.
-            survivalAfter: survivalAt(target, slot.pick + 1),
-        };
-    });
 }
 
 const Station = ({ station, threshold, isLast }) => {

--- a/src/Components/IntelPickSelector.jsx
+++ b/src/Components/IntelPickSelector.jsx
@@ -1,0 +1,85 @@
+import { pickOptions } from '../lib/availability.js';
+
+// Choosing which pick to analyze (docs/leaguemate-intel.md §3g gap 1).
+//
+// The header used to state the pick as fact ("% = lasts to your pick (39)").
+// It is a control instead: everything downstream - the chip, the row
+// ordering's meaning, the gauntlet - recomputes from whatever is selected.
+// That is also what answers "which of these two lasts longer?" without a
+// dedicated compare mode: scope the list to a pick and read two rows.
+//
+// A horizontal chip row rather than a dropdown or a stepper, validated at
+// 375px: on a phone this has to be one tap, and the picks worth choosing are
+// a short known list. Each chip shows the pick's CURRENT owner, trade-resolved
+// by the API (§3d) - deriving ownership from the draft order got two of three
+// picks wrong, and attributing danger to the wrong manager is the one thing
+// this feature must not do.
+
+const IntelPickSelector = ({ board, selected, onSelect, currentPick }) => {
+    const options = pickOptions(board);
+
+    // §3g gap 1b's honest ending. A finished draft (or a last-round pick with
+    // nothing after it) has no pick to analyze, and the fix for 1b is only
+    // half done if the UI answers that with a number anyway.
+    if (options.length === 0) {
+        return (
+            <p className="text-ink-muted m-0 flex min-h-11 items-center px-1.5 text-sm">No picks left in this draft.</p>
+        );
+    }
+
+    return (
+        <div className="-mx-2 px-2">
+            <div className="flex scrollbar-none gap-1.5 overflow-x-auto pb-1">
+                {options.map((slot) => {
+                    const isSelected = slot.pick === selected;
+
+                    return (
+                        <button
+                            key={slot.pick}
+                            type="button"
+                            onClick={() => onSelect(slot.pick)}
+                            aria-pressed={isSelected}
+                            aria-label={`Analyze pick ${slot.pick}${slot.mine ? ', yours' : `, ${slot.manager}`}`}
+                            className={`flex shrink-0 flex-col items-center rounded-lg border px-2.5 py-1 transition-colors ${
+                                isSelected
+                                    ? 'border-mine bg-mine-chip'
+                                    : slot.mine
+                                      ? 'border-mine/40 bg-mine-row'
+                                      : 'border-line'
+                            }`}
+                        >
+                            <span
+                                className={`font-mono text-[13px] font-semibold tabular-nums ${
+                                    isSelected ? 'text-ink' : slot.mine ? 'text-mine' : 'text-ink-quiet'
+                                }`}
+                            >
+                                {slot.pick}
+                            </span>
+                            <span
+                                className={`max-w-[52px] truncate font-mono text-[9px] ${
+                                    slot.mine ? 'text-mine' : 'text-ink-dim'
+                                }`}
+                            >
+                                {slot.mine ? 'YOU' : slot.manager}
+                            </span>
+                        </button>
+                    );
+                })}
+            </div>
+            <p className="text-ink-dim pt-1 font-mono text-[10px]">{caption({ selected, currentPick })}</p>
+        </div>
+    );
+};
+
+// The one line under the chips. Never phrased as advice - §3g: a high number
+// means "you can wait" or "don't spend this pick on him" depending on the
+// question, so this states what the number is and stops.
+function caption({ selected, currentPick }) {
+    if (selected == null) return 'Pick one to analyze against.';
+    if (selected === currentPick) return `On the clock at ${selected}`;
+
+    const away = selected - currentPick;
+    return `Chance he lasts to pick ${selected} · ${away} pick${away === 1 ? '' : 's'} from now`;
+}
+
+export default IntelPickSelector;

--- a/src/Components/IntelTermTip.jsx
+++ b/src/Components/IntelTermTip.jsx
@@ -1,0 +1,84 @@
+import { useRef, useState } from 'react';
+import Popover from './Popover';
+import { TERMS } from './intelGlossary.js';
+
+// Tap-for-meaning, built on the app's own Popover rather than a `title`
+// attribute or a hover tooltip. Three reasons, all load-bearing here:
+//
+//   1. Hover does not exist on the phone this is designed for. Tap does.
+//   2. Popover portals to document.body, and this lives inside the sheet's
+//      own scroller - an absolutely positioned tooltip is clipped at the
+//      sheet edge (the exact bug Popover's own comment records).
+//   3. Popover already stops Escape from bubbling to the Sheet, so one
+//      keystroke closes the tip and not the whole sheet underneath it.
+
+/** A `?` against one figure. */
+export function TermTip({ termKey, label }) {
+    const ref = useRef(null);
+    const [open, setOpen] = useState(false);
+    const term = TERMS[termKey];
+
+    return (
+        <>
+            <button
+                ref={ref}
+                type="button"
+                onClick={(event) => {
+                    // The row behind this is itself a button that pushes the
+                    // detail view - a tap on the tip must not also navigate.
+                    event.stopPropagation();
+                    setOpen((isOpen) => !isOpen);
+                }}
+                aria-label={`What is ${term.short}?`}
+                className="text-ink-dim hover:text-ink-quiet border-line ml-1 grid h-[13px] w-[13px] shrink-0 place-items-center rounded-full border align-middle text-[8px] leading-none"
+            >
+                ?
+            </button>
+            {open && (
+                <Popover triggerRef={ref} onClose={() => setOpen(false)} label={term.short} width={230}>
+                    <div className="px-2 py-1.5">
+                        <p className="text-ink m-0 font-mono text-[10px] font-semibold tracking-[.06em] uppercase">
+                            {label ?? term.short}
+                        </p>
+                        <p className="text-ink-muted m-0 mt-1 text-[11px] leading-snug">{term.long}</p>
+                    </div>
+                </Popover>
+            )}
+        </>
+    );
+}
+
+/** The whole key - the one "what am I looking at?" entry point. */
+export default function IntelKey({ children = 'What do these mean?' }) {
+    const ref = useRef(null);
+    const [open, setOpen] = useState(false);
+
+    return (
+        <>
+            <button
+                ref={ref}
+                type="button"
+                onClick={() => setOpen((isOpen) => !isOpen)}
+                aria-label="What do these numbers mean?"
+                className="text-ink-quiet hover:text-ink flex items-center gap-1.5 font-mono text-[10px]"
+            >
+                <span className="border-line grid h-[13px] w-[13px] place-items-center rounded-full border text-[8px]">
+                    ?
+                </span>
+                {children}
+            </button>
+            {open && (
+                <Popover triggerRef={ref} onClose={() => setOpen(false)} label="What these numbers mean" width={268}>
+                    <dl className="m-0 px-2 py-1.5">
+                        {Object.values(TERMS).map((term) => (
+                            <div key={term.short} className="py-1">
+                                <dt className="text-ink m-0 font-mono text-[10px] font-semibold">{term.short}</dt>
+                                <dd className="text-ink-muted m-0 text-[11px] leading-snug">{term.long}</dd>
+                            </div>
+                        ))}
+                    </dl>
+                </Popover>
+            )}
+        </>
+    );
+}

--- a/src/Components/intelGlossary.js
+++ b/src/Components/intelGlossary.js
@@ -1,0 +1,90 @@
+// What every leaguemate-intel number means, in one place
+// (docs/leaguemate-intel.md §3 Frontend).
+//
+// The naming here is the settled decision, not a preference: `ADP` is
+// dynasty-wide and `League ADP` is your leaguemates. One label doing both
+// jobs was the single biggest source of confusion in testing - and the gap
+// between the two is the only number here that says "your circle disagrees
+// with the market about this guy", which is the product.
+
+export const TERMS = {
+    still: {
+        short: 'Still there',
+        long: 'Chance he is still undrafted when your pick comes around.',
+    },
+    adp: {
+        short: 'ADP',
+        long: 'Average draft position across dynasty as a whole — where the wider market takes him. Nothing to do with your leagues.',
+    },
+    leagueAdp: {
+        short: 'League ADP',
+        long: 'Where your leaguemates actually take him, measured across the completed rookie drafts they ran in their other leagues this year.',
+    },
+    managerAdp: {
+        short: "A manager's ADP",
+        long: 'One specific leaguemate’s own average pick on him. Only shown when we have seen enough of their drafts to mean something.',
+    },
+    gap: {
+        short: 'Gap',
+        long: 'League ADP minus ADP. Negative means your leaguemates reach earlier than the market; positive means they let him slide.',
+    },
+    spread: {
+        short: 'Spread (±)',
+        long: 'How much his draft slot bounces around. A small spread is a lock; a big one means he could go anywhere.',
+    },
+    threat: {
+        short: 'Threat',
+        long: 'A manager picking before you, and how likely they are to take him if he is on the board.',
+    },
+    seen: {
+        short: 'Drafts seen',
+        long: 'How many drafts a number is measured from. Small numbers mean the estimate is soft — treat single digits as a hint, not a fact.',
+    },
+};
+
+// "Still there" in words. A bare percentage invites false precision; these
+// buckets are what the number is actually good for. Deliberately a statement
+// of fact rather than advice - §3g: the same number means "wait" or "don't
+// spend this pick on him" depending on which question is being asked, and the
+// app cannot know which.
+export function survivalPhrase(probability) {
+    if (probability < 0.15) return 'almost certainly gone';
+    if (probability < 0.35) return 'probably gone';
+    if (probability < 0.55) return 'coin flip';
+    if (probability < 0.8) return 'probably there';
+    return 'almost certainly there';
+}
+
+export function survivalTone(probability) {
+    if (probability >= 0.66) return 'text-live';
+    if (probability >= 0.33) return 'text-warn';
+    return 'text-danger';
+}
+
+// The chip's fill. `bg-danger/15` rather than a `--raw-danger-tint` token
+// because the design system defines tints for live and warn only, and an
+// opacity modifier on the token is the idiom already in use for danger
+// (LineupPanel's "Taken" pill) - no invented hex either way.
+export function survivalBand(probability) {
+    if (probability >= 0.66) return 'bg-live-tint';
+    if (probability >= 0.33) return 'bg-warn-tint';
+    return 'bg-danger/15';
+}
+
+// Plain-English rendering of the circle-vs-market gap. Hedged at small gaps
+// on purpose: below a few picks this is noise, not a read.
+export function gapPhrase(gap) {
+    if (gap == null) return null;
+    if (gap <= -8) return 'your leaguemates reach way earlier than that';
+    if (gap <= -3) return 'your leaguemates take him earlier than that';
+    if (gap < 3) return 'your leaguemates agree';
+    if (gap < 8) return 'your leaguemates let him slide';
+    return 'your leaguemates fade him hard';
+}
+
+export function gapTone(gap) {
+    if (gap == null) return 'text-ink-dim';
+    if (gap <= -3) return 'text-danger';
+    if (gap < 3) return 'text-ink-dim';
+    return 'text-live';
+}

--- a/src/Panels/DraftPanel.jsx
+++ b/src/Panels/DraftPanel.jsx
@@ -20,10 +20,12 @@ import { useSeenPicks } from '../useSeenPicks.js';
 import { usePublishSyncStatus } from '../SyncStatus.jsx';
 const { DRAFT, PICKS, TRADED_PICKS } = SLEEPER_API_URLS;
 
-// How many rank-list players the sheet asks for intel on. See the comment on
-// `intelPlayerIds` below: the response is quadratic in picks remaining and
-// uncompressed, so this is a payload bound, not a product limit.
-const INTEL_PLAYER_LIMIT = 30;
+// How many rank-list players the sheet asks for intel on. A safety bound on
+// an unbounded pasted list, not a product limit: at ~2KB per player at the
+// very start of a draft (and well under that once it is under way) this is
+// far more players than a rookie board ever has, so in practice it does not
+// bind. See the comment on `intelPlayerIds` below.
+const INTEL_PLAYER_LIMIT = 100;
 
 const VIEW_OPTIONS = [
     { value: 'feed', label: 'Feed' },
@@ -119,13 +121,13 @@ const DraftPanel = ({
     // `ownership` is: that component is mounted only while the sheet is open,
     // and it is also the Lineup sheet's list, which has no draft to ask about.
     //
-    // The ids are capped because the response is quadratic in picks remaining
-    // - `byPick[n].threats` lists every pick before n, so one target costs
-    // ~85KB at pick 1 and ~9KB at pick 35, and the API does not compress.
-    // Asking about a whole 200-player rank list at the start of a draft would
-    // be tens of megabytes on a phone. The cap is applied to the *available*
-    // rows in rank order, so it covers the top of the board, which is the only
-    // part of the list where "will he last?" is a live question.
+    // Capped only as a bound on a pasted list of unknown length. It used to
+    // be a much tighter payload limit: the response carried a full threat
+    // list under every pick, which made it quadratic in picks remaining and
+    // put a single target at ~85KB at the start of a draft. The API now sends
+    // one hazard per pick (~2KB), so the cap no longer trades coverage for
+    // bytes - which matters, because a capped-out row shows no chip and looks
+    // exactly like a player the corpus has genuinely never seen.
     const intelPlayerIds = useMemo(
         () =>
             filterBestAvailable({

--- a/src/Panels/DraftPanel.jsx
+++ b/src/Panels/DraftPanel.jsx
@@ -1,16 +1,17 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import SegmentedControl from '../Components/SegmentedControl';
 import PickFeed from './PickFeed';
 import DraftGrid from './DraftGrid';
 import Sheet from '../Components/Sheet';
-import BestAvailable, { countAvailable } from '../Components/BestAvailable';
+import BestAvailable, { countAvailable, filterBestAvailable, playerId } from '../Components/BestAvailable';
 import { draftDefaultOwnership } from '../Components/OwnershipFilters';
 import BestAvailableHandle from '../Components/BestAvailableHandle';
 import ClockCard from '../Components/ClockCard';
 import DraftSourceSheet, { readLastMock, writeLastMock } from './DraftSourceSheet';
 import RankListSwitcher from '../Components/RankListSwitcher';
 import { managerLabel, pickNumberLabel } from './pickLabels.js';
-import { SLEEPER_API_URLS } from '../urls';
+import { SLEEPER_API_URLS, SLEEPER_USER_ID } from '../urls';
+import { fetchAvailability } from '../lib/sleeperApi.js';
 import { syncLiveDraft } from '../lib/liveDraft.js';
 import { pollIntervalMs } from '../lib/draftClock.js';
 import { nextUnpickedPick, picksUntilMine } from '../lib/onTheClock.js';
@@ -18,6 +19,11 @@ import { agoLabel } from '../lib/relativeTime.js';
 import { useSeenPicks } from '../useSeenPicks.js';
 import { usePublishSyncStatus } from '../SyncStatus.jsx';
 const { DRAFT, PICKS, TRADED_PICKS } = SLEEPER_API_URLS;
+
+// How many rank-list players the sheet asks for intel on. See the comment on
+// `intelPlayerIds` below: the response is quadratic in picks remaining and
+// uncompressed, so this is a payload bound, not a product limit.
+const INTEL_PLAYER_LIMIT = 30;
 
 const VIEW_OPTIONS = [
     { value: 'feed', label: 'Feed' },
@@ -49,6 +55,7 @@ const DraftPanel = ({
     const [boardView, setBoardView] = useState('feed');
     const [isBestAvailableOpen, setIsBestAvailableOpen] = useState(false);
     const [isSourceOpen, setIsSourceOpen] = useState(false);
+    const [availability, setAvailability] = useState(undefined);
     // Read once at mount rather than on every render: this is a per-league
     // memory of the last mock, and only this component writes it.
     const [lastMockId, setLastMockId] = useState(() => readLastMock(currentDraft.draft_id));
@@ -106,6 +113,62 @@ const DraftPanel = ({
               0,
           )
         : null;
+
+    // Leaguemate intel for the rank-list sheet (docs/leaguemate-intel.md §6
+    // step 3). Held here rather than inside BestAvailable for the same reason
+    // `ownership` is: that component is mounted only while the sheet is open,
+    // and it is also the Lineup sheet's list, which has no draft to ask about.
+    //
+    // The ids are capped because the response is quadratic in picks remaining
+    // - `byPick[n].threats` lists every pick before n, so one target costs
+    // ~85KB at pick 1 and ~9KB at pick 35, and the API does not compress.
+    // Asking about a whole 200-player rank list at the start of a draft would
+    // be tens of megabytes on a phone. The cap is applied to the *available*
+    // rows in rank order, so it covers the top of the board, which is the only
+    // part of the list where "will he last?" is a live question.
+    const intelPlayerIds = useMemo(
+        () =>
+            filterBestAvailable({
+                entries,
+                playerInfo,
+                eligibleSlots: null,
+                ownership,
+                rosterInfo,
+                myDisplayName,
+            })
+                .slice(0, INTEL_PLAYER_LIMIT)
+                .map(({ entry }) => playerId(entry)),
+        [entries, playerInfo, ownership, rosterInfo, myDisplayName],
+    );
+
+    // Refetched when the board moves, not when a pick chip is tapped: the
+    // response carries the whole byPick matrix, so re-answering the list
+    // against another pick already on the board is client-side and instant.
+    // What does go stale is the board itself - who is still to pick, and who
+    // is already gone - and that is what `picksMade` changing means.
+    useEffect(() => {
+        if (!isBestAvailableOpen || intelPlayerIds.length === 0) {
+            return;
+        }
+        let cancelled = false;
+
+        fetchAvailability({
+            draftId: currentDraftId,
+            userId: SLEEPER_USER_ID,
+            playerIds: intelPlayerIds,
+        }).then((response) => {
+            // Resolves to undefined on any failure, and intel is additive, so
+            // a failed fetch leaves the sheet rendering the plain rank list
+            // rather than showing an error over a list that is still correct.
+            if (!cancelled && response) {
+                setAvailability(response);
+            }
+        });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [isBestAvailableOpen, currentDraftId, picksMade, intelPlayerIds]);
 
     const onTheClock = nextUnpickedPick(currentDraft.built_draft);
     // null, not a "nobody is up" sentence: ClockCard reads this as the signal
@@ -381,6 +444,7 @@ const DraftPanel = ({
                         ownership={ownership}
                         onOwnershipChange={setOwnership}
                         onSelect={null}
+                        availability={availability}
                     />
                 </Sheet>
             )}

--- a/src/lib/availability.js
+++ b/src/lib/availability.js
@@ -55,6 +55,50 @@ export function pickOptions(board) {
 }
 
 /**
+ * The picks between now and `atPick`, each with the odds its owner takes
+ * this player and the survival left after them.
+ *
+ * This is a three-way join, and the shape of the response is why. The API
+ * used to send a full threat list under every pick in `byPick` - a prefix
+ * accumulation that re-sent the same entries once per remaining pick, and
+ * repeated two fields that never varied by pick. It now sends one
+ * `{pick, prob}` per pick, and the rest is recovered from data already on
+ * screen:
+ *
+ *   - the manager and their drafts-seen come from the `board` entry
+ *   - the take count comes from `perManager`, which lists only managers who
+ *     have actually taken him - so absent means zero
+ *
+ * A pick missing from `hazards` is one whose owner is not a tracked
+ * leaguemate. It still affects survival (through the multiplier the server
+ * applied) but carries no itemized read, which is why it contributes no
+ * probability here rather than an invented one.
+ */
+export function stationsFor(target, board, atPick) {
+    const byManager = new Map((target?.perManager || []).map((entry) => [entry.manager, entry]));
+    const hazardByPick = new Map((target?.hazards || []).map((hazard) => [hazard.pick, hazard.prob]));
+
+    return (board || [])
+        .filter((slot) => slot.pick < atPick)
+        .map((slot) => {
+            const mate = byManager.get(slot.manager);
+
+            return {
+                pick: slot.pick,
+                manager: slot.manager,
+                isMine: slot.mine,
+                probability: hazardByPick.get(slot.pick) ?? 0,
+                tookCount: mate?.times ?? 0,
+                draftsSeen: slot.drafts ?? 0,
+                mate,
+                // Survival *after* this pick is the value stored at the next
+                // one, which is why byPick runs one past lastPick.
+                survivalAfter: survivalAt(target, slot.pick + 1),
+            };
+        });
+}
+
+/**
  * How much can honestly be said about one manager's history with one player.
  *
  * This is the copy-rules table in §3 Frontend, and it exists because the

--- a/src/lib/availability.js
+++ b/src/lib/availability.js
@@ -1,0 +1,98 @@
+// Reading the /availability response (docs/leaguemate-intel.md §3e).
+//
+// Everything here is pure and takes the response apart; nothing fetches and
+// nothing renders. That split is deliberate: every bug this feature has
+// produced, on both sides of the wire, has been a number-or-sentence bug
+// rather than a layout one, so the rules that decide which number and which
+// sentence live somewhere they can be tested directly.
+
+/**
+ * Which pick the list should answer against by default.
+ *
+ * §3g gap 1b: this used to be "the first pick at or after the current one
+ * that I own", which resolves to the pick you are *making* the moment you are
+ * on the clock - nothing between, every player 100%, the feature blank at the
+ * exact moment it is most wanted. My next pick means the next one I have not
+ * used yet, so it is strictly after the current pick.
+ *
+ * `null` means there is no following pick of mine. That is a real state (a
+ * last-round pick, or a draft I am done with) and callers must say so rather
+ * than substituting a pick I do not own - which is what the prototype's
+ * `?? currentPick + 1` silently did.
+ */
+export function defaultAnalyzedPick({ myPicks, currentPick }) {
+    const following = (myPicks || []).filter((pick) => pick > currentPick);
+    // Sorted here rather than trusted: the caller reads this straight off the
+    // API response, and "first element of the array" and "earliest pick"
+    // being the same thing is the API's promise, not this function's.
+    return following.length > 0 ? Math.min(...following) : null;
+}
+
+/**
+ * The odds `target` is still on the board at `pick`, or `null` where the
+ * response carries no read for it.
+ *
+ * Null rather than 1. The prototype defaulted a missing entry to certainty,
+ * which is the same class of mistake as gap 1b: a number the data does not
+ * support, rendered with full confidence. `byPick` runs one pick past
+ * `lastPick` (the gauntlet needs `pick + 1` for "survival after this pick"),
+ * so its range is enumerated from the response and never computed here.
+ */
+export function survivalAt(target, pick) {
+    if (pick == null) return null;
+    const entry = target?.byPick?.[String(pick)];
+    return entry ? entry.adjSurvival : null;
+}
+
+/**
+ * The picks the selector can offer: every pick left on the board, each with
+ * the manager who actually owns it. Ownership is trade-resolved by the API
+ * (§3d) - two of three picks were attributed to the wrong manager when this
+ * was derived from the draft order instead.
+ */
+export function pickOptions(board) {
+    return (board || []).map(({ pick, manager, mine }) => ({ pick, manager, mine }));
+}
+
+/**
+ * How much can honestly be said about one manager's history with one player.
+ *
+ * This is the copy-rules table in §3 Frontend, and it exists because the
+ * recurring failure in this feature was never the maths - it was the sentence
+ * next to the number. Three separate times the prototype quoted "took him 1x
+ * in 1 drafts" as evidence, showed a 0-draft manager's league baseline as if
+ * it were their own tendency, and labelled a single pick an "ADP".
+ *
+ * Returns a `kind` the UI switches on, carrying only the figures that kind is
+ * allowed to state. `adp` is absent unless it has earned its place, so a
+ * template cannot print one by reaching for a field that happens to be there.
+ */
+export function managerSample({ times, of, adp, picks } = {}, threshold) {
+    const { minDrafts, minTimes } = threshold || {};
+
+    // None of their drafts seen: whatever we would show is the league
+    // baseline, not this manager, and presenting it as theirs is the bug.
+    if (!of) return { kind: 'none', times: times || 0, of: of || 0 };
+
+    // Never taken him. Stated as the fact it is rather than as a 0% rate,
+    // with the sample size carrying how much the fact is worth.
+    if (!times) return { kind: 'never', times: 0, of };
+
+    // One pick is not an average. Name the pick that actually happened.
+    if (times === 1) return { kind: 'singlePick', times, of, pick: pickNumber(picks?.[0]) };
+
+    // Too little of their history to quote a rate at all.
+    if (of < 5) return { kind: 'thin', times, of };
+
+    // Past the signal threshold their own ADP means something. Below it the
+    // count still does - the threshold gates the average, not the sample.
+    if (of >= minDrafts && times >= minTimes) return { kind: 'full', times, of, adp };
+
+    return { kind: 'countOnly', times, of };
+}
+
+// "4.9@39" - round.slot @ overall (§4e). The overall pick is the only part
+// worth showing next to a name; the rest is receipts for the detail view.
+function pickNumber(pickString) {
+    return pickString?.split('@')[1];
+}

--- a/src/lib/availability.test.js
+++ b/src/lib/availability.test.js
@@ -1,0 +1,177 @@
+import { describe, expect, it } from 'vitest';
+import { defaultAnalyzedPick, managerSample, pickOptions, survivalAt } from './availability.js';
+
+describe('defaultAnalyzedPick', () => {
+    // docs/leaguemate-intel.md §3g gap 1b. "My next pick" was resolved as the
+    // first pick at *or after* the current one that I own, so the moment I was
+    // on the clock it resolved to the pick I was making right now: nothing
+    // between, every player 100%, the feature blank exactly when it is wanted.
+    it('is my next pick when someone else is on the clock', () => {
+        expect(defaultAnalyzedPick({ myPicks: [39], currentPick: 35 })).toBe(39);
+    });
+
+    it('is my FOLLOWING pick when I am the one on the clock, not the pick I am making', () => {
+        expect(defaultAnalyzedPick({ myPicks: [39, 51], currentPick: 39 })).toBe(51);
+    });
+
+    it('is null when I am on the clock with no pick after this one', () => {
+        // A last-round pick. "No further picks this draft" is the honest
+        // answer; rendering 100% for every player is not.
+        expect(defaultAnalyzedPick({ myPicks: [48], currentPick: 48 })).toBeNull();
+    });
+
+    it('is null when I have no remaining picks at all', () => {
+        expect(defaultAnalyzedPick({ myPicks: [], currentPick: 35 })).toBeNull();
+    });
+
+    it('takes the earliest following pick when I own several', () => {
+        expect(defaultAnalyzedPick({ myPicks: [39, 51, 63], currentPick: 35 })).toBe(39);
+    });
+
+    it('does not assume myPicks arrives sorted', () => {
+        expect(defaultAnalyzedPick({ myPicks: [63, 39, 51], currentPick: 35 })).toBe(39);
+    });
+
+    it('treats a missing myPicks as no picks rather than throwing', () => {
+        // The API returns `myPicks: []` for a completed draft; a caller
+        // rendering before the first response has nothing at all.
+        expect(defaultAnalyzedPick({ currentPick: 35 })).toBeNull();
+        expect(defaultAnalyzedPick({})).toBeNull();
+    });
+});
+
+describe('survivalAt', () => {
+    const target = {
+        byPick: {
+            35: { adjSurvival: 1, baseSurvival: 1, threats: [] },
+            39: { adjSurvival: 0.459, baseSurvival: 0.447, threats: [] },
+        },
+    };
+
+    it('reads the adjusted survival for a pick the response covers', () => {
+        expect(survivalAt(target, 39)).toBe(0.459);
+    });
+
+    it('accepts the pick as a number even though byPick is keyed by string', () => {
+        expect(survivalAt(target, 35)).toBe(1);
+    });
+
+    // The prototype ended this in `?? 1`, which renders a missing read as a
+    // confident 100% - the same failure gap 1b is about, reintroduced as a
+    // default. A number the data does not support must not reach the screen.
+    it('is null for a pick the response has no read for', () => {
+        expect(survivalAt(target, 42)).toBeNull();
+    });
+
+    it('is null rather than throwing for a target with no byPick at all', () => {
+        expect(survivalAt({}, 39)).toBeNull();
+        expect(survivalAt(undefined, 39)).toBeNull();
+    });
+
+    it('is null when no pick is being analyzed', () => {
+        // What §3g's "no further picks this draft" case passes in.
+        expect(survivalAt(target, null)).toBeNull();
+    });
+
+    it('keeps a real zero rather than treating it as missing', () => {
+        expect(survivalAt({ byPick: { 48: { adjSurvival: 0 } } }, 48)).toBe(0);
+    });
+});
+
+describe('pickOptions', () => {
+    const board = [
+        { pick: 35, manager: 'atekipp', mine: false, drafts: 3 },
+        { pick: 39, manager: 'ryangh', mine: true, drafts: 4 },
+    ];
+
+    it('offers every pick left on the board, with its trade-resolved owner', () => {
+        expect(pickOptions(board)).toEqual([
+            { pick: 35, manager: 'atekipp', mine: false },
+            { pick: 39, manager: 'ryangh', mine: true },
+        ]);
+    });
+
+    it('is empty for a finished draft rather than throwing', () => {
+        expect(pickOptions([])).toEqual([]);
+        expect(pickOptions(undefined)).toEqual([]);
+    });
+});
+
+describe('managerSample', () => {
+    // The copy-rules table in docs/leaguemate-intel.md §3 Frontend. The
+    // standing lesson of this feature is that the numbers were fine and the
+    // sentence next to them overclaimed, so each row is its own test.
+    const threshold = { minDrafts: 8, minTimes: 3 };
+
+    it('says none of their drafts were seen when there are none', () => {
+        expect(managerSample({ times: 0, of: 0 }, threshold)).toEqual({
+            kind: 'none',
+            of: 0,
+            times: 0,
+        });
+    });
+
+    // "took him 0× of 3 drafts" is a rate nobody asked for; the fact is that
+    // they have never taken him, and the sample size qualifies how much that
+    // is worth. Distinct from 'none', where we have seen nothing at all and
+    // cannot say even that.
+    it('says they have never taken him rather than quoting a zero rate', () => {
+        const sample = managerSample({ times: 0, of: 3, picks: [] }, threshold);
+
+        expect(sample.kind).toBe('never');
+        expect(sample.of).toBe(3);
+    });
+
+    it('still says never at a large sample, where it means considerably more', () => {
+        expect(managerSample({ times: 0, of: 30, picks: [] }, threshold).kind).toBe('never');
+    });
+
+    it('names the literal pick when there is only one, and never calls it an ADP', () => {
+        const sample = managerSample({ times: 1, of: 4, adp: 46.6, picks: ['4.9@39'] }, threshold);
+
+        expect(sample.kind).toBe('singlePick');
+        expect(sample.pick).toBe('39');
+        // A single pick is not an average of anything.
+        expect(sample.adp).toBeUndefined();
+    });
+
+    it('quotes no rate when fewer than five of their drafts were seen', () => {
+        const sample = managerSample({ times: 2, of: 3, adp: 30.6, picks: ['3.1@25', '3.5@29'] }, threshold);
+
+        expect(sample.kind).toBe('thin');
+        expect(sample.of).toBe(3);
+        expect(sample.adp).toBeUndefined();
+    });
+
+    it('gives the count and their own ADP once past the signal threshold', () => {
+        const sample = managerSample({ times: 11, of: 24, adp: 20.9, picks: [] }, threshold);
+
+        expect(sample).toEqual({ kind: 'full', times: 11, of: 24, adp: 20.9 });
+    });
+
+    // Not in the table: enough drafts to quote a rate, too few picks on this
+    // player to call the average an ADP. The threshold gates the ADP
+    // specifically (§3), so the count survives and the ADP does not.
+    it('gives the count without an ADP when the drafts clear but the picks do not', () => {
+        const sample = managerSample({ times: 2, of: 12, adp: 31.4, picks: [] }, threshold);
+
+        expect(sample.kind).toBe('countOnly');
+        expect(sample.times).toBe(2);
+        expect(sample.of).toBe(12);
+        expect(sample.adp).toBeUndefined();
+    });
+
+    it('withholds the ADP when they have the picks but too few drafts seen', () => {
+        const sample = managerSample({ times: 3, of: 6, adp: 28.1, picks: [] }, threshold);
+
+        expect(sample.kind).toBe('countOnly');
+        expect(sample.adp).toBeUndefined();
+    });
+
+    it('reads the threshold from the response rather than hardcoding it', () => {
+        const entry = { times: 3, of: 8, adp: 20.9, picks: [] };
+
+        expect(managerSample(entry, { minDrafts: 8, minTimes: 3 }).kind).toBe('full');
+        expect(managerSample(entry, { minDrafts: 20, minTimes: 3 }).kind).toBe('countOnly');
+    });
+});

--- a/src/lib/availability.test.js
+++ b/src/lib/availability.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { defaultAnalyzedPick, managerSample, pickOptions, survivalAt } from './availability.js';
+import { defaultAnalyzedPick, managerSample, pickOptions, stationsFor, survivalAt } from './availability.js';
 
 describe('defaultAnalyzedPick', () => {
     // docs/leaguemate-intel.md §3g gap 1b. "My next pick" was resolved as the
@@ -94,6 +94,73 @@ describe('pickOptions', () => {
     it('is empty for a finished draft rather than throwing', () => {
         expect(pickOptions([])).toEqual([]);
         expect(pickOptions(undefined)).toEqual([]);
+    });
+});
+
+describe('stationsFor', () => {
+    // The API sends one hazard per pick; the manager, their drafts-seen and
+    // the take count are recovered by joining `board` and `perManager`. These
+    // tests are the frontend half of that contract - the backend's golden
+    // test asserts the same reconstruction against the frozen fixture.
+    const board = [
+        { pick: 35, manager: 'atekipp', mine: false, drafts: 3 },
+        { pick: 36, manager: 'cja9689', mine: false, drafts: 1 },
+        { pick: 37, manager: 'baconstains', mine: false, drafts: 30 },
+        { pick: 39, manager: 'ryangh', mine: true, drafts: 4 },
+    ];
+
+    const target = {
+        hazards: [
+            { pick: 35, prob: 0.18 },
+            { pick: 36, prob: 0.22 },
+            { pick: 37, prob: 0.15 },
+        ],
+        perManager: [{ manager: 'baconstains', times: 5, of: 30, adp: 30.6, picks: ['3.1@25'] }],
+        byPick: {
+            36: { adjSurvival: 0.82 },
+            37: { adjSurvival: 0.64 },
+            38: { adjSurvival: 0.54 },
+        },
+    };
+
+    it('walks only the picks before the one being analyzed', () => {
+        expect(stationsFor(target, board, 39).map((s) => s.pick)).toEqual([35, 36, 37]);
+    });
+
+    it('takes the manager and their drafts-seen from the board entry', () => {
+        const [first] = stationsFor(target, board, 39);
+
+        expect(first.manager).toBe('atekipp');
+        expect(first.draftsSeen).toBe(3);
+    });
+
+    it('takes the take count from perManager, and treats absence as zero rather than unknown', () => {
+        const stations = stationsFor(target, board, 39);
+
+        // perManager lists only managers who have actually taken him.
+        expect(stations.find((s) => s.manager === 'baconstains').tookCount).toBe(5);
+        expect(stations.find((s) => s.manager === 'atekipp').tookCount).toBe(0);
+    });
+
+    it('reads survival AFTER each pick, which is the entry at pick + 1', () => {
+        expect(stationsFor(target, board, 39).map((s) => s.survivalAfter)).toEqual([0.82, 0.64, 0.54]);
+    });
+
+    it('contributes no probability for a pick with no hazard entry', () => {
+        // Its owner is not a tracked leaguemate: no itemized read. The pick
+        // still affected survival server-side; it just has no receipt.
+        const stations = stationsFor({ ...target, hazards: [{ pick: 35, prob: 0.18 }] }, board, 39);
+
+        expect(stations.map((s) => s.probability)).toEqual([0.18, 0, 0]);
+    });
+
+    it('marks my own pick as mine', () => {
+        expect(stationsFor(target, board, 48).find((s) => s.pick === 39).isMine).toBe(true);
+    });
+
+    it('is empty rather than throwing when there is nothing to walk', () => {
+        expect(stationsFor(target, board, 35)).toEqual([]);
+        expect(stationsFor({}, undefined, 39)).toEqual([]);
     });
 });
 

--- a/src/lib/sleeperApi.js
+++ b/src/lib/sleeperApi.js
@@ -2,7 +2,7 @@ import { checkErrors } from './http.js';
 import { decorateRosters } from './rosterInfo.js';
 import { resolveLeagueSeason } from './sleeper.js';
 import APP_DB_URLS, { SLEEPER_API_URLS } from '../urls.js';
-const { ACTIVE_PLAYERS } = APP_DB_URLS;
+const { ACTIVE_PLAYERS, AVAILABILITY } = APP_DB_URLS;
 const { LEAGUE, USER_LEAGUES, NFL_STATE, DRAFT, ROSTERS, SLEEPER_USERS, TRADED_PICKS, DRAFTS } = SLEEPER_API_URLS;
 
 // Every function here returns its data instead of writing it to state. That is
@@ -100,5 +100,41 @@ export async function fetchDraft(draftId) {
         .then((response) => response.json())
         .catch((error) => {
             console.error('Error:', error);
+        });
+}
+
+/**
+ * Leaguemate intel for a draft: who owns every remaining pick, and for each
+ * player asked about, the odds they last to each of those picks
+ * (docs/leaguemate-intel.md §3e).
+ *
+ * `playerIds` is the caller's own rank list. Sending it is what makes the
+ * answer line up with the rows already on screen - without it the API picks
+ * its own 20 targets by league ADP, which need not overlap the list at all.
+ * A player the corpus has never seen is simply absent from `targets`; that is
+ * the honest "no read", not an error, and the caller renders it as one.
+ *
+ * `atPick` is only for hypotheticals ("if I trade up to 30"). The response
+ * carries the whole `byPick` matrix for every remaining pick, so moving the
+ * pick selector between picks that are already on the board needs no refetch.
+ *
+ * Resolves to `undefined` on failure, per this module's contract. Intel is
+ * additive - a rank list with no intel is exactly the list this app rendered
+ * before the feature existed, so callers drop the extra column rather than
+ * failing the whole sheet.
+ */
+export async function fetchAvailability({ draftId, userId, playerIds, atPick }) {
+    const params = new URLSearchParams({ user_id: userId });
+    // Left off entirely when empty rather than sent blank: an empty rank list
+    // and "no opinion about which players" are different questions, and only
+    // the second one wants the API to choose targets for itself.
+    if (playerIds?.length) params.set('player_ids', playerIds.join(','));
+    if (atPick != null) params.set('at_pick', String(atPick));
+
+    return await fetch(`${AVAILABILITY(draftId)}?${params}`)
+        .then(checkErrors)
+        .then((response) => response.json())
+        .catch((error) => {
+            console.error('Error fetching leaguemate intel:', error);
         });
 }

--- a/src/lib/sleeperApi.test.js
+++ b/src/lib/sleeperApi.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import {
+    fetchAvailability,
     fetchDraft,
     fetchLeagueBundle,
     fetchLeagueSeason,
@@ -120,5 +121,67 @@ describe('sleeperApi', () => {
     it('fetchTradedDraftPicks returns the picks on success', async () => {
         global.fetch = vi.fn(() => jsonResponse([{ round: 1, roster_id: 2, owner_id: 3 }]));
         expect(await fetchTradedDraftPicks('draft123')).toHaveLength(1);
+    });
+
+    describe('fetchAvailability', () => {
+        const requestedUrl = () => new URL(global.fetch.mock.calls[0][0], 'http://localhost');
+
+        it('asks about the caller-supplied player ids, so the answer matches the rows on screen', async () => {
+            global.fetch = vi.fn(() => jsonResponse({ targets: [] }));
+
+            await fetchAvailability({ draftId: 'draft123', userId: '99', playerIds: ['1', '2', '3'] });
+
+            const url = requestedUrl();
+            expect(url.pathname).toBe('/api/v1/drafts/draft123/availability');
+            expect(url.searchParams.get('user_id')).toBe('99');
+            expect(url.searchParams.get('player_ids')).toBe('1,2,3');
+        });
+
+        it('omits player_ids entirely when the list is empty rather than sending it blank', async () => {
+            global.fetch = vi.fn(() => jsonResponse({ targets: [] }));
+
+            await fetchAvailability({ draftId: 'draft123', userId: '99', playerIds: [] });
+
+            expect(requestedUrl().searchParams.has('player_ids')).toBe(false);
+        });
+
+        it('sends at_pick only for hypotheticals, since the response already covers every pick on the board', async () => {
+            global.fetch = vi.fn(() => jsonResponse({ targets: [] }));
+
+            await fetchAvailability({ draftId: 'draft123', userId: '99' });
+            expect(requestedUrl().searchParams.has('at_pick')).toBe(false);
+
+            global.fetch = vi.fn(() => jsonResponse({ targets: [] }));
+            await fetchAvailability({ draftId: 'draft123', userId: '99', atPick: 30 });
+            expect(requestedUrl().searchParams.get('at_pick')).toBe('30');
+        });
+
+        it('resolves to undefined on a network failure', async () => {
+            global.fetch = vi.fn(() => Promise.reject(new Error('offline')));
+            await expect(fetchAvailability({ draftId: 'draft123', userId: '99' })).resolves.toBeUndefined();
+        });
+
+        it('resolves to undefined on a non-ok response rather than returning an error body', async () => {
+            // The API answers a missing user_id with a 422 whose body is JSON.
+            // Without checkErrors that body would flow on as if it were an
+            // availability response and be read for `.targets`.
+            global.fetch = vi.fn(() =>
+                Promise.resolve({
+                    ok: false,
+                    status: 422,
+                    statusText: 'Unprocessable Entity',
+                    json: () => Promise.resolve({ errors: { detail: 'missing required param: user_id' } }),
+                }),
+            );
+
+            await expect(fetchAvailability({ draftId: 'draft123', userId: '99' })).resolves.toBeUndefined();
+        });
+
+        it('returns the parsed body on success', async () => {
+            const body = { currentPick: 35, myPicks: [39], board: [], targets: [{ id: '1' }] };
+            global.fetch = vi.fn(() => jsonResponse(body));
+
+            expect(await fetchAvailability({ draftId: 'draft123', userId: '99' })).toEqual(body);
+        });
     });
 });

--- a/src/urls.js
+++ b/src/urls.js
@@ -4,6 +4,7 @@ const appDB = 'https://sleeper-player-db-default-rtdb.firebaseio.com/';
 // so a direct cross-origin request from localhost is blocked by the browser.
 const fta = import.meta.env.DEV ? '/' : 'https://fantasyteamassistant.com/';
 const ftaLegacy = 'api/legacy/players';
+const ftaAvailability = (draftId) => `api/v1/drafts/${draftId}/availability`;
 const latestUpdateAttempt = 'latest_update_attempt/';
 const dlfADP = 'dlf_adp/';
 const users = 'users/';
@@ -27,6 +28,10 @@ const APP_DB_URLS = {
     APP_DB: appDB,
     LATEST_UPDATE_ATTEMPT: appDB + latestUpdateAttempt + typeParams,
     ACTIVE_PLAYERS: fta + ftaLegacy,
+    // Leaguemate intel (docs/leaguemate-intel.md §3e). Same origin and the
+    // same dev-relative treatment as ACTIVE_PLAYERS above - see the comment
+    // on `fta` about why localhost must go through the Vite proxy.
+    AVAILABILITY: (draftId) => fta + ftaAvailability(draftId),
     DLF_ADP: appDB + dlfADP + typeParams,
     APP_USERS: appDB + users,
     TYPE_PARAMS: typeParams,

--- a/src/urls.test.js
+++ b/src/urls.test.js
@@ -31,4 +31,11 @@ describe('other endpoints', () => {
         // import.meta.env.DEV is true under Vitest, matching the dev-server case.
         expect(APP_DB_URLS.ACTIVE_PLAYERS).toBe('/api/legacy/players');
     });
+
+    it('keeps the availability path relative in dev too, and under a proxied prefix', () => {
+        // Same CORS reasoning as ACTIVE_PLAYERS. The `/api/v1` prefix has to
+        // match a `server.proxy` key in vite.config.mjs or dev requests go
+        // to the Vite server itself and 404.
+        expect(APP_DB_URLS.AVAILABILITY('123')).toBe('/api/v1/drafts/123/availability');
+    });
 });

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -23,6 +23,13 @@ export default defineConfig({
                 target: 'https://fantasyteamassistant.com',
                 changeOrigin: true,
             },
+            // Leaguemate intel. Same reason as /api/legacy above: the API
+            // only sends CORS headers for the deployed origin, so a direct
+            // request from localhost is blocked by the browser.
+            '/api/v1': {
+                target: 'https://fantasyteamassistant.com',
+                changeOrigin: true,
+            },
         },
     },
     test: {


### PR DESCRIPTION
The last step of the leaguemate-intel plan (§6 step 3). The rank-list sheet now
answers "will he still be there at my pick?" from the deployed `/availability`
endpoint, in both places `BestAvailable` renders — the phone bottom sheet and
the desktop aside rail.

Rebuilt with tests rather than promoting the prototype, which was written under
prototype rules: no tests, no error handling, raw `rgba()` literals, and `?? 1`
defaults that render a missing read as a confident 100%.

## Decisions worth reviewing

**Intel decorates the rank list; it doesn't replace it.** "Best Available" means
the user's own list everywhere else in the app, so the list keeps its order and
the percent chip carries the comparison across rows. The request sends those
player ids (the `player_ids` param added in sleeper-player-be#34) and joins the
answer back by id. A player the corpus has never seen has no chip — the honest
"no read".

**The pick selector does not refetch.** The response carries the whole `byPick`
matrix, so chip taps are instant and client-side. The fetch re-runs when the
*board* moves, which is what actually goes stale.

**The ids are capped at 30.** Measured against production: the response is
quadratic in picks remaining and uncompressed — ~85KB per target at pick 1,
~9KB at pick 35. A whole rank list at the start of a draft would be tens of
megabytes. See the follow-up note below.

## §3g gap 1b — a correctness bug, not an enhancement

"My next pick" resolved to the first pick *at or after* the current one that I
own. On the clock, that is the pick you are making right now: `between` empty,
every player 100%, the feature blank at exactly the moment it is most wanted.

It now means the *following* pick you own, and where none follows it says "No
picks left in this draft" rather than rendering a number. `survivalAt` returns
`null` instead of `1` for the same reason — a number the data does not support
must not reach the screen.

## Verification

498 tests (was 456). Every correctness fix was sabotaged and confirmed to fail
before being restored — gap 1b (`>` → `>=`), the `?? 1` default, and the
rank-order decision each caught by their tests.

Checked against the deployed endpoint rather than only the suite:

- every field the UI reads is present in the live response; `byPick` spans one
  pick past `lastPick` as documented
- the gauntlet's decay telescopes 83 → 69 → 61 → **53%**, landing exactly on the
  row chip
- the copy rules render correctly on live thin samples — "no drafts of theirs
  seen", "never taken him · 1 draft seen" (singular), "· 3 drafts seen"
- a chip tap re-scoped the whole list with **zero** further network requests

All six gates pass, and the build carries no prototype data
(`babaghanoush123`, `District 13`, `Prototypes` all 0).

## Follow-ups, not in this PR

- **The API does not gzip.** This JSON is highly repetitive; compression would
  likely cut it by an order of magnitude and would let the 30-id cap rise.
- `at_pick` rewinds the board but not the drafted-player set, so a completed
  draft can't be replayed mid-draft for testing.

The prototype is parked on `prototype/rank-list-intel` and deleted here.