### PR TITLE
Add the Leaguemates section

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import AppShell from './Components/AppShell';
 import ErrorBanner from './Components/ErrorBanner';
 import LeaguePanel from './Panels/LeaguePanel';
 import RanksPanel from './Panels/RanksPanel';
+import LeaguemateIntelPanel from './Panels/LeaguemateIntelPanel';
 import Spinner from './Components/Spinner';
 import { SyncStatusProvider } from './SyncStatus.jsx';
 import { RankListProvider, useRankList } from './RankList.jsx';
@@ -475,6 +476,7 @@ class App extends React.Component {
             myDisplayName,
             savedRankLists,
             savedRankListsLoading,
+            season,
         } = this.state;
         if (loading === LOADING.INITIAL) {
             return <Spinner size="page" />;
@@ -557,6 +559,9 @@ class App extends React.Component {
                                     renderSection={(activeId) => {
                                         if (activeId === 'ranks') {
                                             return ranksPanel;
+                                        }
+                                        if (activeId === 'leaguemates') {
+                                            return <LeaguemateIntelPanel leagueID={leagueID} season={season} />;
                                         }
                                         return (
                                             <LeaguePanel

--- a/src/Panels/LeaguemateIntelPanel.jsx
+++ b/src/Panels/LeaguemateIntelPanel.jsx
@@ -1,0 +1,262 @@
+import { useEffect, useState } from 'react';
+import ListRow from '../Components/ListRow';
+import PositionTag from '../Components/PositionTag';
+import Spinner from '../Components/Spinner';
+import { agoLabel } from '../lib/relativeTime.js';
+import { fetchLeagueIntel } from '../lib/sleeperApi.js';
+import {
+    countLabel,
+    crushesShowPattern,
+    managerSignal,
+    reachPhrase,
+    reachPhraseShort,
+    sortManagers,
+} from '../lib/leagueIntel.js';
+
+// Who your leaguemates are and what they do in their other leagues
+// (docs/leaguemate-intel.md §6 step 4).
+//
+// League-scoped, not `global`, even though §3 Frontend reserved 'global' for
+// it. The endpoint is keyed by league — it answers "the managers in *this*
+// league", and the cross-league part is what they do elsewhere, not what the
+// view spans. A global section would hide the league switcher (AppShell drops
+// the pill for that scope) while still showing per-league content, so the
+// screen could not tell you why it was showing what it was showing.
+//
+// Same drill-down idiom as the rank list's intel: push a profile in place with
+// a back control rather than opening a sheet.
+
+// The two samples these figures rest on, and they are not interchangeable:
+// `reachVsAdp` is an average per draft, the positional shares are proportions
+// of picks. See `managerSignal`.
+const THRESHOLDS = { minDrafts: 5, minPicks: 20 };
+
+const Header = ({ corpus }) => {
+    const crawled = agoLabel(corpus?.lastCrawledAt ? Date.parse(corpus.lastCrawledAt) : null);
+
+    return (
+        <div className="flex flex-col gap-0.5 px-4 pt-4 pb-2">
+            <h2 className="text-ink m-0 text-[20px] font-bold tracking-[-.02em]">Leaguemates</h2>
+            {/* The sample the whole screen rests on, stated once at the top
+                rather than implied. A stale crawl is the difference between
+                "they have never taken him" and "we have not looked lately". */}
+            <p className="text-ink-dim m-0 font-mono text-[11px]">
+                {corpus?.drafts ? `${corpus.drafts} drafts · ${corpus.picks} picks` : 'No drafts observed yet'}
+                {crawled && <span className="text-ink-quiet"> · crawled {crawled}</span>}
+            </p>
+        </div>
+    );
+};
+
+const Crush = ({ crush }) => (
+    <div className="flex items-baseline justify-between gap-2 py-0.5">
+        <span className="flex min-w-0 items-center gap-2">
+            <PositionTag position={crush.position} />
+            <span className="text-ink-quiet truncate text-[13px]">{crush.name}</span>
+        </span>
+        {/* Always a count over its own denominator, never a rate: "3 of 6"
+            carries its sample where "50%" hides it. */}
+        <span className="text-ink-dim shrink-0 font-mono text-[11px] tabular-nums">
+            {crush.times} of {crush.of}
+        </span>
+    </div>
+);
+
+const Profile = ({ manager, onBack }) => {
+    const signal = managerSignal(manager, THRESHOLDS);
+    const { crushes = [], positionLean = [], reachVsAdp } = manager.tendencies || {};
+
+    return (
+        <div className="px-2 py-2.5">
+            <button
+                type="button"
+                onClick={onBack}
+                className="text-ink-quiet hover:text-ink mb-2 -ml-1 flex min-h-11 items-center gap-1.5 px-1.5 py-1 font-mono text-[11px]"
+            >
+                <span className="text-[13px]">←</span> Leaguemates
+            </button>
+
+            <div className="px-1.5">
+                <h3 className="text-ink m-0 text-[17px] font-semibold">{manager.displayName}</h3>
+                <p className="text-ink-dim m-0 mt-0.5 font-mono text-[11px]">
+                    {countLabel(manager.leaguesCount, 'league')} · {countLabel(manager.draftsCount, 'draft')} ·{' '}
+                    {manager.draftsComplete} complete
+                </p>
+
+                {signal.kind === 'none' ? (
+                    <p className="text-ink-muted mt-3 text-[13px] leading-snug">
+                        None of their drafts have been seen yet, so there is nothing to read here.
+                    </p>
+                ) : (
+                    <>
+                        <div className="bg-raised-2 mt-3 rounded-lg px-3 py-2.5">
+                            <p className="text-ink-dim m-0 font-mono text-[9px] tracking-[.08em] uppercase">
+                                Vs league ADP
+                            </p>
+                            {signal.quotesReach ? (
+                                <p className="text-ink m-0 mt-0.5 text-[15px] font-semibold">
+                                    {reachPhrase(reachVsAdp)}
+                                </p>
+                            ) : (
+                                // Below the threshold the copy changes shape
+                                // rather than shrinking: no average, just the
+                                // sample that is too small to average over.
+                                <p className="text-ink-muted m-0 mt-0.5 text-[13px] leading-snug">
+                                    We&rsquo;ve only seen {signal.draftsComplete} of their drafts — not enough to call a
+                                    tendency.
+                                </p>
+                            )}
+                        </div>
+
+                        {positionLean.length > 0 && (
+                            <div className="mt-3">
+                                <p className="text-ink-dim mb-1 font-mono text-[10px] tracking-[.08em] uppercase">
+                                    What they spend picks on
+                                    <span className="text-ink-quiet"> · {signal.picks} picks</span>
+                                </p>
+                                {positionLean.map((entry) => (
+                                    <div
+                                        key={entry.position}
+                                        className="flex items-baseline justify-between gap-2 py-0.5"
+                                    >
+                                        <span className="flex min-w-0 items-center gap-2">
+                                            <PositionTag position={entry.position} />
+                                        </span>
+                                        <span className="text-ink-dim shrink-0 font-mono text-[11px] tabular-nums">
+                                            {/* A share is a proportion; below
+                                                the pick threshold only the raw
+                                                count is defensible. */}
+                                            {signal.quotesShares
+                                                ? `${Math.round(entry.share * 100)}% · ${entry.picks}`
+                                                : `${entry.picks} pick${entry.picks === 1 ? '' : 's'}`}
+                                        </span>
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+
+                        {crushes.length > 0 && (
+                            <div className="border-line-mid mt-3 border-t pt-2">
+                                {/* The counts carry their own denominator,
+                                    but this heading is its own claim - and
+                                    "keep taking" over a list of "1 of 1" is a
+                                    pattern asserted from one observation. */}
+                                <p className="text-ink-dim mb-1 font-mono text-[10px] tracking-[.08em] uppercase">
+                                    {crushesShowPattern(crushes)
+                                        ? 'Players they keep taking'
+                                        : 'Players they have taken'}
+                                </p>
+                                {crushes.map((crush) => (
+                                    <Crush key={crush.playerId} crush={crush} />
+                                ))}
+                            </div>
+                        )}
+                    </>
+                )}
+            </div>
+        </div>
+    );
+};
+
+const LeaguemateIntelPanel = ({ leagueID, season }) => {
+    const [intel, setIntel] = useState(undefined);
+    const [loading, setLoading] = useState(true);
+    const [selectedUserId, setSelectedUserId] = useState(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        setLoading(true);
+
+        fetchLeagueIntel({ leagueId: leagueID, season }).then((response) => {
+            if (cancelled) return;
+            setIntel(response);
+            setLoading(false);
+        });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [leagueID, season]);
+
+    if (loading) {
+        return (
+            <div className="flex min-h-40 items-center justify-center">
+                <Spinner />
+            </div>
+        );
+    }
+
+    // Unlike the rank list, intel is not additive here - it is the whole
+    // screen, so a failed fetch has to say so rather than render an empty one.
+    if (!intel) {
+        return (
+            <p className="text-ink-muted m-0 flex min-h-11 items-center px-4 text-sm">
+                Couldn&rsquo;t load leaguemate intel. It may not have been crawled for this league yet.
+            </p>
+        );
+    }
+
+    const managers = sortManagers(intel.managers);
+    const selected = managers.find((manager) => manager.userId === selectedUserId);
+
+    if (selected) {
+        return <Profile manager={selected} onBack={() => setSelectedUserId(null)} />;
+    }
+
+    return (
+        <div>
+            <Header corpus={intel.corpus} />
+            {managers.length === 0 ? (
+                <p className="text-ink-muted m-0 flex min-h-11 items-center px-4 text-sm">
+                    No leaguemates found for this league yet.
+                </p>
+            ) : (
+                <ul className="flex list-none flex-col gap-0.5 px-2 py-2.5">
+                    {managers.map((manager) => {
+                        const signal = managerSignal(manager, THRESHOLDS);
+                        // Short form on the row: the long one truncates the
+                        // meta line beside it at 375px. The profile uses the
+                        // full sentence, where there is room for it.
+                        const phrase = signal.quotesReach ? reachPhraseShort(manager.tendencies?.reachVsAdp) : null;
+
+                        return (
+                            <li key={manager.userId}>
+                                <ListRow
+                                    // The accessible name keeps the long
+                                    // form - it is read, not laid out.
+                                    label={`${manager.displayName}, ${countLabel(manager.draftsComplete, 'draft')} seen${
+                                        signal.quotesReach ? `, ${reachPhrase(manager.tendencies?.reachVsAdp)}` : ''
+                                    }`}
+                                    onClick={() => setSelectedUserId(manager.userId)}
+                                    name={manager.displayName}
+                                    meta={
+                                        <>
+                                            <span>{countLabel(manager.leaguesCount, 'league')}</span>
+                                            <span> · </span>
+                                            <span>{countLabel(manager.draftsComplete, 'draft')} seen</span>
+                                        </>
+                                    }
+                                    trailing={
+                                        <span
+                                            className={`shrink-0 font-mono text-[11px] ${
+                                                phrase ? 'text-ink-quiet' : 'text-ink-dim'
+                                            }`}
+                                        >
+                                            {/* The one comparable line across
+                                                rows, and absent rather than
+                                                guessed when the sample cannot
+                                                support it. */}
+                                            {phrase ?? 'no read'}
+                                        </span>
+                                    }
+                                />
+                            </li>
+                        );
+                    })}
+                </ul>
+            )}
+        </div>
+    );
+};
+
+export default LeaguemateIntelPanel;

--- a/src/Panels/LeaguemateIntelPanel.test.jsx
+++ b/src/Panels/LeaguemateIntelPanel.test.jsx
@@ -1,0 +1,209 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import LeaguemateIntelPanel from './LeaguemateIntelPanel';
+
+// The panel owns its own fetch, so these tests drive the real effect rather
+// than a passed-in prop - that wiring is exactly what went untested when the
+// rank-list intel shipped, and had to be added afterwards (#150).
+
+const jsonResponse = (data) => Promise.resolve({ ok: true, statusText: 'OK', json: () => Promise.resolve(data) });
+
+const manager = ({ tendencies, ...overrides } = {}) => ({
+    userId: 1,
+    displayName: 'atekipp',
+    leaguesCount: 3,
+    draftsCount: 3,
+    draftsComplete: 3,
+    ...overrides,
+    tendencies: { crushes: [], positionLean: [], reachVsAdp: -2.03, ...tendencies },
+});
+
+// baconstains is the well-observed case; cja9689 the thin one. Having both in
+// every render is what makes "withheld" distinguishable from "not rendered".
+const HEAVY = manager({
+    userId: 2,
+    displayName: 'baconstains',
+    leaguesCount: 30,
+    draftsCount: 30,
+    draftsComplete: 30,
+    tendencies: {
+        reachVsAdp: -2.03,
+        positionLean: [
+            { position: 'WR', picks: 40, share: 0.4 },
+            { position: 'RB', picks: 30, share: 0.3 },
+        ],
+        crushes: [{ playerId: '13278', name: 'Max Klare', position: 'TE', times: 9, of: 30 }],
+    },
+});
+
+const THIN = manager({
+    userId: 3,
+    displayName: 'cja9689',
+    leaguesCount: 1,
+    draftsCount: 1,
+    draftsComplete: 1,
+    tendencies: {
+        reachVsAdp: -6.1,
+        positionLean: [{ position: 'QB', picks: 2, share: 0.5 }],
+        crushes: [],
+    },
+});
+
+const intelBody = (overrides = {}) => ({
+    corpus: { drafts: 72, picks: 3382, lastCrawledAt: '2026-08-06T20:58:28Z' },
+    managers: [THIN, HEAVY],
+    ...overrides,
+});
+
+const renderPanel = (body = intelBody(), props = {}) => {
+    global.fetch = vi.fn(() => (body instanceof Promise ? body : jsonResponse(body)));
+    return render(<LeaguemateIntelPanel leagueID="lg1" season="2026" {...props} />);
+};
+
+describe('LeaguemateIntelPanel', () => {
+    beforeEach(() => {
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('asks for the league it was given, for the right season', async () => {
+        renderPanel();
+        await screen.findByText('baconstains');
+
+        const url = new URL(global.fetch.mock.calls[0][0], 'http://localhost');
+        expect(url.pathname).toBe('/api/v1/leagues/lg1/intel');
+        expect(url.searchParams.get('season')).toBe('2026');
+    });
+
+    it('states the corpus the whole screen rests on', async () => {
+        renderPanel();
+        // A stale crawl is the difference between "they have never taken him"
+        // and "we have not looked lately", so it is header text, not a detail.
+        expect(await screen.findByText(/72 drafts · 3382 picks/)).toBeInTheDocument();
+        expect(screen.getByText(/crawled/)).toBeInTheDocument();
+    });
+
+    it('lists the most-observed managers first', async () => {
+        renderPanel();
+        await screen.findByText('baconstains');
+
+        const names = screen.getAllByRole('listitem').map((item) => item.textContent);
+        expect(names[0]).toContain('baconstains');
+        expect(names[1]).toContain('cja9689');
+    });
+
+    it('quotes a reach tendency only where the sample supports it', async () => {
+        renderPanel();
+        await screen.findByText('baconstains');
+
+        const heavy = screen.getByText('baconstains').closest('li');
+        // Short form on the row so the meta line beside it is not truncated
+        // at 375px; the long sentence survives in the accessible name, which
+        // is read rather than laid out.
+        expect(within(heavy).getByText('2.0 early')).toBeInTheDocument();
+        expect(
+            screen.getByRole('button', { name: /baconstains, 30 drafts seen, reaches 2\.0 picks early/ }),
+        ).toBeInTheDocument();
+
+        // cja9689 has a reachVsAdp too - a bigger one - but off one draft.
+        // Rendering it would be the "0-draft manager shown with a league
+        // baseline as if it were their own tendency" trap all over again.
+        const thin = screen.getByText('cja9689').closest('li');
+        expect(within(thin).getByText('no read')).toBeInTheDocument();
+        expect(within(thin).queryByText(/picks early/)).toBeNull();
+    });
+
+    it('pushes a profile in place and comes back', async () => {
+        const user = userEvent.setup();
+        renderPanel();
+        await screen.findByText('baconstains');
+
+        await user.click(screen.getByRole('button', { name: /baconstains/ }));
+
+        expect(screen.getByText('Players they keep taking')).toBeInTheDocument();
+        expect(screen.getByText('9 of 30')).toBeInTheDocument();
+        // The list is gone, not layered underneath.
+        expect(screen.queryByText('cja9689')).toBeNull();
+
+        await user.click(screen.getByRole('button', { name: /Leaguemates/ }));
+        expect(screen.getByText('cja9689')).toBeInTheDocument();
+    });
+
+    it('shows positional shares as percentages only above the pick threshold', async () => {
+        const user = userEvent.setup();
+        renderPanel();
+        await screen.findByText('baconstains');
+
+        await user.click(screen.getByRole('button', { name: /baconstains/ }));
+        expect(screen.getByText('40% · 40')).toBeInTheDocument();
+    });
+
+    it('replaces the share with a raw count when there are too few picks behind it', async () => {
+        const user = userEvent.setup();
+        renderPanel();
+        await screen.findByText('cja9689');
+
+        await user.click(screen.getByRole('button', { name: /cja9689/ }));
+
+        // 2 picks is not a 50% lean, it is two picks.
+        expect(screen.getByText('2 picks')).toBeInTheDocument();
+        expect(screen.queryByText(/50%/)).toBeNull();
+        expect(screen.getByText(/only seen 1 of their drafts/)).toBeInTheDocument();
+    });
+
+    it('does not call it a pattern when every player was taken exactly once', async () => {
+        const user = userEvent.setup();
+        const once = manager({
+            userId: 5,
+            displayName: 'skeefe',
+            draftsComplete: 1,
+            tendencies: {
+                positionLean: [{ position: 'RB', picks: 2, share: 0.5 }],
+                crushes: [{ playerId: '1', name: 'Ted Hurst', position: 'WR', times: 1, of: 1 }],
+            },
+        });
+        renderPanel(intelBody({ managers: [once] }));
+        await screen.findByText('skeefe');
+
+        await user.click(screen.getByRole('button', { name: /skeefe/ }));
+
+        // "1 of 1" is honest; "players they keep taking" over it is not.
+        expect(screen.getByText('Players they have taken')).toBeInTheDocument();
+        expect(screen.queryByText('Players they keep taking')).toBeNull();
+    });
+
+    it('says nothing can be read for a manager with no observed drafts', async () => {
+        const user = userEvent.setup();
+        const unseen = manager({ userId: 4, displayName: 'pavelito0010', draftsComplete: 0 });
+        renderPanel(intelBody({ managers: [unseen] }));
+        await screen.findByText('pavelito0010');
+
+        await user.click(screen.getByRole('button', { name: /pavelito0010/ }));
+        expect(screen.getByText(/None of their drafts have been seen/)).toBeInTheDocument();
+    });
+
+    it('says so when the fetch fails, rather than rendering an empty screen', async () => {
+        // Unlike the rank list, intel is not additive here - it is the whole
+        // section, so a failure has to be visible.
+        global.fetch = vi.fn(() => Promise.reject(new Error('offline')));
+        render(<LeaguemateIntelPanel leagueID="lg1" season="2026" />);
+
+        expect(await screen.findByText(/Couldn’t load leaguemate intel/)).toBeInTheDocument();
+    });
+
+    it('re-asks when the league changes', async () => {
+        const { rerender } = renderPanel();
+        await screen.findByText('baconstains');
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+
+        rerender(<LeaguemateIntelPanel leagueID="lg2" season="2026" />);
+        await screen.findByText('baconstains');
+
+        expect(global.fetch).toHaveBeenCalledTimes(2);
+        expect(global.fetch.mock.calls[1][0]).toContain('/leagues/lg2/intel');
+    });
+});

--- a/src/lib/leagueIntel.js
+++ b/src/lib/leagueIntel.js
@@ -1,0 +1,113 @@
+// Reading the /intel response (docs/leaguemate-intel.md §3e).
+//
+// Pure, like `availability.js` next door, and for the same reason: every
+// figure here is an aggregate over a sample that ranges from 1 observed draft
+// to 30, and the recurring failure in this feature has never been the maths -
+// it is the sentence next to the number. What may be said about a manager is
+// decided here, where it can be tested, rather than inside a template.
+
+/**
+ * How many corpus picks a manager's tendencies actually rest on.
+ *
+ * `positionLean` is a breakdown of every pick of theirs the crawl has seen, so
+ * its total is the sample behind the shares. `draftsComplete` is the sample
+ * behind anything measured per draft - the two are not interchangeable, and
+ * conflating them is how "38% WR" off four picks gets presented as a lean.
+ */
+export function observedPicks(manager) {
+    return (manager?.tendencies?.positionLean || []).reduce((total, entry) => total + (entry.picks || 0), 0);
+}
+
+/**
+ * What may honestly be said about one manager, given how much of their
+ * drafting has been seen.
+ *
+ * Two independent gates, because the two figures rest on different samples:
+ * `reachVsAdp` is an average per draft and is gated on `draftsComplete`;
+ * the positional shares are proportions of picks and are gated on the pick
+ * count. A manager can clear one and not the other - 12 drafts with four
+ * picks in them is a real shape in this data, not a contrived one.
+ */
+export function managerSignal(manager, { minDrafts, minPicks }) {
+    const draftsComplete = manager?.draftsComplete || 0;
+    const picks = observedPicks(manager);
+    const reach = manager?.tendencies?.reachVsAdp;
+
+    const quotesReach = draftsComplete >= minDrafts && reach != null;
+    const quotesShares = picks >= minPicks;
+
+    // `none` is its own state rather than the bottom of a scale: with nothing
+    // observed there is no number to hedge, only an absence to state plainly.
+    const kind = draftsComplete === 0 ? 'none' : quotesReach && quotesShares ? 'measured' : 'thin';
+
+    return { kind, draftsComplete, picks, quotesReach, quotesShares };
+}
+
+// Below half a pick the sign is noise, so it gets a name of its own instead of
+// a direction the data does not support. Stated as fact, never as advice -
+// "reaches early" is neither good nor bad without knowing who you are asking
+// for, same rule the survival number follows in §3g.
+const CHALKY = 0.5;
+
+/**
+ * `reachVsAdp` in words. Negative means they take players before the league's
+ * own ADP; positive means they let them slide.
+ */
+export function reachPhrase(reach) {
+    if (reach == null) return null;
+    if (Math.abs(reach) < CHALKY) return 'drafts to ADP';
+
+    const picks = Math.abs(reach).toFixed(1);
+    return reach < 0 ? `reaches ${picks} picks early` : `waits ${picks} picks`;
+}
+
+/**
+ * Row-width version of `reachPhrase`. The long form truncates the meta line
+ * next to it at 375px - measured against the real league, where the widest
+ * ("reaches 0.9 picks early") pushed "31 drafts seen" to "31 drafts se…" on
+ * the very first row. Same lesson the prototype learned about the ADP gap:
+ * the one novel signal on the row is the thing that must always fit.
+ */
+export function reachPhraseShort(reach) {
+    if (reach == null) return null;
+    if (Math.abs(reach) < CHALKY) return 'on ADP';
+
+    const picks = Math.abs(reach).toFixed(1);
+    return reach < 0 ? `${picks} early` : `${picks} late`;
+}
+
+/**
+ * Whether a manager's "crushes" actually show repetition.
+ *
+ * The figures are self-carrying - "9 of 31" states its own denominator - but
+ * the heading over them is a claim in its own right, and "players they keep
+ * taking" is false over a list where every entry is "1 of 1". Caught against
+ * real data on a one-draft manager: the counts were honest and the sentence
+ * above them was not, which is this feature's oldest failure mode.
+ */
+export function crushesShowPattern(crushes) {
+    return (crushes || []).some((crush) => (crush.times || 0) >= 2);
+}
+
+/**
+ * `n thing` / `n things`, so a one-league manager does not read "1 leagues".
+ * Trivial, and it was wrong on four of thirteen rows against real data.
+ */
+export function countLabel(count, noun) {
+    return `${count} ${noun}${count === 1 ? '' : 's'}`;
+}
+
+/**
+ * Managers most-observed first — the ones the corpus can actually say
+ * something about, rather than alphabetical order that buries them.
+ *
+ * Copies before sorting: the argument is the fetch response, and sorting it in
+ * place would reorder the caller's own state behind its back.
+ */
+export function sortManagers(managers) {
+    return [...(managers || [])].sort(
+        (a, b) =>
+            (b.draftsComplete || 0) - (a.draftsComplete || 0) ||
+            (a.displayName || '').localeCompare(b.displayName || ''),
+    );
+}

--- a/src/lib/leagueIntel.test.js
+++ b/src/lib/leagueIntel.test.js
@@ -1,0 +1,213 @@
+import { describe, expect, it } from 'vitest';
+import {
+    countLabel,
+    crushesShowPattern,
+    managerSignal,
+    observedPicks,
+    reachPhrase,
+    reachPhraseShort,
+    sortManagers,
+} from './leagueIntel.js';
+
+// `tendencies` is merged rather than replaced: overriding just `positionLean`
+// used to drop `reachVsAdp` with it, which made two cases here look like
+// implementation failures when the fixture was the thing at fault.
+const manager = ({ tendencies, ...overrides } = {}) => ({
+    userId: 1,
+    displayName: 'atekipp',
+    leaguesCount: 3,
+    draftsCount: 3,
+    draftsComplete: 3,
+    ...overrides,
+    tendencies: { crushes: [], positionLean: [], reachVsAdp: -2.03, ...tendencies },
+});
+
+const lean = (...counts) => counts.map((picks, i) => ({ position: ['WR', 'RB', 'TE'][i], picks, share: 0 }));
+
+describe('observedPicks', () => {
+    it('totals the picks behind a manager’s positional lean', () => {
+        expect(observedPicks(manager({ tendencies: { positionLean: lean(15, 7, 6) } }))).toBe(28);
+    });
+
+    it('is zero for a manager with nothing observed, rather than undefined', () => {
+        expect(observedPicks(manager({ tendencies: { positionLean: [] } }))).toBe(0);
+        expect(observedPicks({})).toBe(0);
+    });
+});
+
+describe('managerSignal', () => {
+    // Same discipline as the rank list's copy rules: an average measured over
+    // 3 drafts is not the same claim as one measured over 30, and the UI must
+    // change shape rather than just shrink the number.
+    const thresholds = { minDrafts: 5, minPicks: 20 };
+
+    it('says nothing can be said when none of their drafts were seen', () => {
+        const signal = managerSignal(manager({ draftsComplete: 0, tendencies: { positionLean: [] } }), thresholds);
+
+        expect(signal.kind).toBe('none');
+        expect(signal.quotesReach).toBe(false);
+        expect(signal.quotesShares).toBe(false);
+    });
+
+    it('withholds the reach average below the draft threshold', () => {
+        const signal = managerSignal(
+            manager({ draftsComplete: 3, tendencies: { positionLean: lean(15, 7, 6) } }),
+            thresholds,
+        );
+
+        expect(signal.kind).toBe('thin');
+        expect(signal.draftsComplete).toBe(3);
+        // 28 picks clears minPicks, but 3 drafts does not clear minDrafts -
+        // reach is an average *per draft*, so it is the drafts that gate it.
+        expect(signal.quotesReach).toBe(false);
+    });
+
+    it('withholds positional shares when they rest on too few picks', () => {
+        // Plenty of drafts, but almost no picks in them - percentages off a
+        // handful of picks are noise dressed as a tendency.
+        const signal = managerSignal(
+            manager({ draftsComplete: 12, tendencies: { positionLean: lean(2, 1, 1) } }),
+            thresholds,
+        );
+
+        expect(signal.quotesShares).toBe(false);
+        expect(signal.quotesReach).toBe(true);
+    });
+
+    it('quotes both once the sample supports them', () => {
+        const signal = managerSignal(
+            manager({ draftsComplete: 30, tendencies: { positionLean: lean(40, 20, 15) } }),
+            thresholds,
+        );
+
+        expect(signal.kind).toBe('measured');
+        expect(signal.quotesReach).toBe(true);
+        expect(signal.quotesShares).toBe(true);
+    });
+
+    it('treats a missing reach figure as nothing to quote, however big the sample', () => {
+        const signal = managerSignal(
+            manager({ draftsComplete: 30, tendencies: { positionLean: lean(40), reachVsAdp: null } }),
+            thresholds,
+        );
+
+        expect(signal.quotesReach).toBe(false);
+    });
+});
+
+describe('reachPhrase', () => {
+    // Negative means they take players before the league's own ADP.
+    it('reads a negative gap as reaching early', () => {
+        expect(reachPhrase(-2.03)).toBe('reaches 2.0 picks early');
+    });
+
+    it('reads a positive gap as waiting', () => {
+        expect(reachPhrase(3.4)).toBe('waits 3.4 picks');
+    });
+
+    it('calls a gap under half a pick chalky rather than inventing a direction', () => {
+        expect(reachPhrase(0.2)).toBe('drafts to ADP');
+        expect(reachPhrase(-0.4)).toBe('drafts to ADP');
+        expect(reachPhrase(0)).toBe('drafts to ADP');
+    });
+
+    it('is null when there is no figure at all', () => {
+        expect(reachPhrase(null)).toBeNull();
+        expect(reachPhrase(undefined)).toBeNull();
+    });
+});
+
+describe('reachPhraseShort', () => {
+    // The long form truncated the meta line beside it at 375px against real
+    // data, on the very first row.
+    it('keeps the direction but drops the words that do not fit', () => {
+        expect(reachPhraseShort(-2.03)).toBe('2.0 early');
+        expect(reachPhraseShort(3.4)).toBe('3.4 late');
+        expect(reachPhraseShort(0.2)).toBe('on ADP');
+    });
+
+    it('is null when there is no figure', () => {
+        expect(reachPhraseShort(null)).toBeNull();
+    });
+
+    it('is always shorter than the long form it replaces', () => {
+        for (const reach of [-9.9, -2.03, -0.4, 0, 0.2, 3.4, 12.5]) {
+            expect(reachPhraseShort(reach).length).toBeLessThan(reachPhrase(reach).length);
+        }
+    });
+});
+
+describe('crushesShowPattern', () => {
+    // The counts state their own denominator, so they cannot lie. The heading
+    // over them can: "players they keep taking" over a list of "1 of 1" is a
+    // pattern claimed from a single observation.
+    it('is false when nothing has been taken more than once', () => {
+        expect(
+            crushesShowPattern([
+                { times: 1, of: 1 },
+                { times: 1, of: 1 },
+            ]),
+        ).toBe(false);
+    });
+
+    it('is true as soon as one player was taken repeatedly', () => {
+        expect(
+            crushesShowPattern([
+                { times: 1, of: 6 },
+                { times: 3, of: 6 },
+            ]),
+        ).toBe(true);
+    });
+
+    it('is false for no crushes at all', () => {
+        expect(crushesShowPattern([])).toBe(false);
+        expect(crushesShowPattern(undefined)).toBe(false);
+    });
+});
+
+describe('countLabel', () => {
+    it('does not say "1 leagues"', () => {
+        expect(countLabel(1, 'league')).toBe('1 league');
+        expect(countLabel(1, 'draft')).toBe('1 draft');
+    });
+
+    it('pluralises everything else, including zero', () => {
+        expect(countLabel(0, 'league')).toBe('0 leagues');
+        expect(countLabel(31, 'draft')).toBe('31 drafts');
+    });
+});
+
+describe('sortManagers', () => {
+    it('puts the most-observed managers first, since they are the ones worth reading', () => {
+        const managers = [
+            manager({ displayName: 'cja9689', draftsComplete: 1 }),
+            manager({ displayName: 'baconstains', draftsComplete: 30 }),
+            manager({ displayName: 'atekipp', draftsComplete: 3 }),
+        ];
+
+        expect(sortManagers(managers).map((m) => m.displayName)).toEqual(['baconstains', 'atekipp', 'cja9689']);
+    });
+
+    it('breaks ties by name so the order is stable between loads', () => {
+        const managers = [
+            manager({ displayName: 'zeta', draftsComplete: 4 }),
+            manager({ displayName: 'alpha', draftsComplete: 4 }),
+        ];
+
+        expect(sortManagers(managers).map((m) => m.displayName)).toEqual(['alpha', 'zeta']);
+    });
+
+    it('does not mutate the response it was handed', () => {
+        const managers = [
+            manager({ displayName: 'b', draftsComplete: 1 }),
+            manager({ displayName: 'a', draftsComplete: 9 }),
+        ];
+        sortManagers(managers);
+
+        expect(managers.map((m) => m.displayName)).toEqual(['b', 'a']);
+    });
+
+    it('is empty rather than throwing when there is no manager list', () => {
+        expect(sortManagers(undefined)).toEqual([]);
+    });
+});

--- a/src/lib/sleeperApi.js
+++ b/src/lib/sleeperApi.js
@@ -2,7 +2,7 @@ import { checkErrors } from './http.js';
 import { decorateRosters } from './rosterInfo.js';
 import { resolveLeagueSeason } from './sleeper.js';
 import APP_DB_URLS, { SLEEPER_API_URLS } from '../urls.js';
-const { ACTIVE_PLAYERS, AVAILABILITY } = APP_DB_URLS;
+const { ACTIVE_PLAYERS, AVAILABILITY, LEAGUE_INTEL } = APP_DB_URLS;
 const { LEAGUE, USER_LEAGUES, NFL_STATE, DRAFT, ROSTERS, SLEEPER_USERS, TRADED_PICKS, DRAFTS } = SLEEPER_API_URLS;
 
 // Every function here returns its data instead of writing it to state. That is
@@ -123,6 +123,29 @@ export async function fetchDraft(draftId) {
  * before the feature existed, so callers drop the extra column rather than
  * failing the whole sheet.
  */
+/**
+ * Who your leaguemates are and what they do in their other leagues
+ * (docs/leaguemate-intel.md §3e) - how many leagues and drafts each is in,
+ * their repeated targets, positional lean and reach-vs-ADP, plus a `corpus`
+ * block saying how much was actually observed and when it was last crawled.
+ *
+ * `corpus` is not decoration: every tendency here is measured over a sample
+ * that varies from 1 draft to 30, and a figure without its sample size is the
+ * failure this feature keeps re-learning.
+ *
+ * Resolves to `undefined` on failure, per this module's contract.
+ */
+export async function fetchLeagueIntel({ leagueId, season }) {
+    const params = new URLSearchParams(season ? { season } : {});
+
+    return await fetch(`${LEAGUE_INTEL(leagueId)}?${params}`)
+        .then(checkErrors)
+        .then((response) => response.json())
+        .catch((error) => {
+            console.error('Error fetching league intel:', error);
+        });
+}
+
 export async function fetchAvailability({ draftId, userId, playerIds, atPick }) {
     const params = new URLSearchParams({ user_id: userId });
     // Left off entirely when empty rather than sent blank: an empty rank list

--- a/src/lib/sleeperApi.test.js
+++ b/src/lib/sleeperApi.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import {
     fetchAvailability,
+    fetchLeagueIntel,
     fetchDraft,
     fetchLeagueBundle,
     fetchLeagueSeason,
@@ -121,6 +122,47 @@ describe('sleeperApi', () => {
     it('fetchTradedDraftPicks returns the picks on success', async () => {
         global.fetch = vi.fn(() => jsonResponse([{ round: 1, roster_id: 2, owner_id: 3 }]));
         expect(await fetchTradedDraftPicks('draft123')).toHaveLength(1);
+    });
+
+    describe('fetchLeagueIntel', () => {
+        const requestedUrl = () => new URL(global.fetch.mock.calls[0][0], 'http://localhost');
+
+        it('asks for one league season and returns the parsed body', async () => {
+            const body = { corpus: { drafts: 72, picks: 3382 }, managers: [{ displayName: 'atekipp' }] };
+            global.fetch = vi.fn(() => jsonResponse(body));
+
+            expect(await fetchLeagueIntel({ leagueId: 'lg1', season: '2026' })).toEqual(body);
+
+            const url = requestedUrl();
+            expect(url.pathname).toBe('/api/v1/leagues/lg1/intel');
+            expect(url.searchParams.get('season')).toBe('2026');
+        });
+
+        it('omits season when there is none rather than sending an empty one', async () => {
+            global.fetch = vi.fn(() => jsonResponse({ managers: [] }));
+
+            await fetchLeagueIntel({ leagueId: 'lg1' });
+
+            expect(requestedUrl().searchParams.has('season')).toBe(false);
+        });
+
+        it('resolves to undefined on failure rather than rejecting', async () => {
+            global.fetch = vi.fn(() => Promise.reject(new Error('offline')));
+            await expect(fetchLeagueIntel({ leagueId: 'lg1', season: '2026' })).resolves.toBeUndefined();
+        });
+
+        it('resolves to undefined on a non-ok response rather than returning an error body', async () => {
+            global.fetch = vi.fn(() =>
+                Promise.resolve({
+                    ok: false,
+                    status: 404,
+                    statusText: 'Not Found',
+                    json: () => Promise.resolve({ errors: { detail: 'not found' } }),
+                }),
+            );
+
+            await expect(fetchLeagueIntel({ leagueId: 'nope', season: '2026' })).resolves.toBeUndefined();
+        });
     });
 
     describe('fetchAvailability', () => {

--- a/src/sections.js
+++ b/src/sections.js
@@ -9,6 +9,13 @@ export const SECTIONS = [
     { id: 'draft', label: 'Draft', scope: 'league' },
     { id: 'lineup', label: 'Lineup', scope: 'league' },
     { id: 'ranks', label: 'Ranks', scope: 'league' },
+    // Leaguemate intel is 'league' scope despite being the "cross-league"
+    // view the docstring above imagines: /intel is keyed by league, so it
+    // answers "the managers in *this* league", and the cross-league part is
+    // what those managers do elsewhere. Hiding the league switcher for it
+    // would leave per-league content depending on a league you can neither
+    // see nor change. 'global' is still unused.
+    { id: 'leaguemates', label: 'Leaguemates', scope: 'league' },
 ];
 
 export const DEFAULT_SECTION_ID = 'draft';

--- a/src/urls.js
+++ b/src/urls.js
@@ -5,6 +5,7 @@ const appDB = 'https://sleeper-player-db-default-rtdb.firebaseio.com/';
 const fta = import.meta.env.DEV ? '/' : 'https://fantasyteamassistant.com/';
 const ftaLegacy = 'api/legacy/players';
 const ftaAvailability = (draftId) => `api/v1/drafts/${draftId}/availability`;
+const ftaLeagueIntel = (leagueId) => `api/v1/leagues/${leagueId}/intel`;
 const latestUpdateAttempt = 'latest_update_attempt/';
 const dlfADP = 'dlf_adp/';
 const users = 'users/';
@@ -32,6 +33,11 @@ const APP_DB_URLS = {
     // same dev-relative treatment as ACTIVE_PLAYERS above - see the comment
     // on `fta` about why localhost must go through the Vite proxy.
     AVAILABILITY: (draftId) => fta + ftaAvailability(draftId),
+    // The leaguemates of one league, and what they do in their other ones
+    // (docs/leaguemate-intel.md §3e). Keyed by league despite being the
+    // "cross-league" view - the cross-league part is what the managers do
+    // elsewhere, not what the request spans.
+    LEAGUE_INTEL: (leagueId) => fta + ftaLeagueIntel(leagueId),
     DLF_ADP: appDB + dlfADP + typeParams,
     APP_USERS: appDB + users,
     TYPE_PARAMS: typeParams,

--- a/src/urls.test.js
+++ b/src/urls.test.js
@@ -38,4 +38,8 @@ describe('other endpoints', () => {
         // to the Vite server itself and 404.
         expect(APP_DB_URLS.AVAILABILITY('123')).toBe('/api/v1/drafts/123/availability');
     });
+
+    it('builds the league-intel path under the same proxied prefix', () => {
+        expect(APP_DB_URLS.LEAGUE_INTEL('abc')).toBe('/api/v1/leagues/abc/intel');
+    });
 });


### PR DESCRIPTION
Plan §6 step 4. The `/intel` endpoint has been deployed since
sleeper-player-be#33 — this is the view for it: who your leaguemates are, how
much of their drafting has actually been seen, and what it shows.

A list ordered by drafts observed (the managers the corpus can say something
about), each row carrying its sample plus one comparable figure. Tap for a
profile pushed in place — same idiom as the rank list's drill-down.

## League scope, not the `global` the plan reserved

§3 Frontend called for `{ scope: 'global' }`. I don't think it survives contact
with the endpoint: `/intel` is keyed by league, so it answers "the managers in
*this* league" — the cross-league part is what those managers do elsewhere, not
what the view spans. A global section drops the league switcher (`AppShell`
hides the pill for that scope), which would leave per-league content depending
on a league you can neither see nor change. `'global'` stays unused.

## Sample-size discipline, with two gates

`reachVsAdp` is an average per draft and is gated on drafts seen. Positional
shares are proportions of picks and are gated on the pick count. A manager can
clear one and not the other — 12 drafts with four picks in them is a real shape
in this data. Below threshold the copy changes shape rather than shrinking: no
average, just the sample too small to average over.

## Three defects only the live endpoint showed

The tests all passed before each of these:

- **"1 leagues · 1 drafts seen"** — wrong on four of thirteen rows.
- **Truncation at 375px.** The long reach phrase pushed the meta line to
  "31 drafts se…" on the very first row. Rows now use a short form; the full
  sentence survives in the accessible name, which is read rather than laid out.
  Same fix the prototype needed for the ADP gap.
- **"Players they keep taking" over a list of "1 of 1".** The counts carry
  their own denominators and cannot lie; the heading over them can. Claiming a
  pattern from one observation is this feature's oldest failure mode. The
  heading now depends on whether anything was actually repeated.

## Scope

Deliberately excludes roster % and trades. §6 step 4's prose mentions them, but
`/intel` returns neither — roster % is a §5 item, trades are step 6.

549 tests. Both sample gates sabotage-verified at unit and panel level (removing
the reach gate fails 4, removing the share gate fails 3). Verified against the
deployed endpoint: baconstains' crushes reproduce §4c's measured figures (Joly
9, Bell 9, Allen 8).