### PR TITLE
Show a leaguemate's recent moves

### DIFF
--- a/src/Panels/LeaguemateIntelPanel.jsx
+++ b/src/Panels/LeaguemateIntelPanel.jsx
@@ -3,10 +3,14 @@ import ListRow from '../Components/ListRow';
 import PositionTag from '../Components/PositionTag';
 import Spinner from '../Components/Spinner';
 import { agoLabel } from '../lib/relativeTime.js';
-import { fetchLeagueIntel } from '../lib/sleeperApi.js';
+import { fetchLeagueIntel, fetchManagerActivity } from '../lib/sleeperApi.js';
 import {
     countLabel,
+    coverageLabel,
     crushesShowPattern,
+    didHappen,
+    movedPlayers,
+    transactionLabel,
     managerSignal,
     reachPhrase,
     reachPhraseShort,
@@ -62,9 +66,120 @@ const Crush = ({ crush }) => (
     </div>
 );
 
-const Profile = ({ manager, onBack }) => {
+const MOVE_LIMIT = 3;
+
+const Moved = ({ label, players }) =>
+    players.length > 0 && (
+        <span className="min-w-0 truncate">
+            <span className="text-ink-dim">{label} </span>
+            <span className="text-ink-quiet">
+                {players
+                    .slice(0, MOVE_LIMIT)
+                    .map((p) => p.name)
+                    .join(', ')}
+                {players.length > MOVE_LIMIT && ` +${players.length - MOVE_LIMIT}`}
+            </span>
+        </span>
+    );
+
+const Transaction = ({ transaction, players }) => {
+    const happened = didHappen(transaction);
+    const { adds, drops } = movedPlayers(transaction, players);
+
+    return (
+        <div className="flex flex-col gap-0.5 py-1.5">
+            <span className="flex items-center gap-2">
+                <span className="text-ink-quiet font-mono text-[10px] tracking-[.08em] uppercase">
+                    {transactionLabel(transaction.type)}
+                </span>
+                {/* 11% of real transactions failed. Mixing them in unlabelled
+                    would claim things happened that did not. */}
+                {!happened && (
+                    <span className="text-warn font-mono text-[9px] font-semibold tracking-[.08em] uppercase">
+                        Failed
+                    </span>
+                )}
+                {transaction.waiverBid != null && (
+                    <span className="text-ink-dim font-mono text-[10px] tabular-nums">${transaction.waiverBid}</span>
+                )}
+                {transaction.draftPicks?.length > 0 && (
+                    <span className="text-ink-dim font-mono text-[10px]">
+                        {countLabel(transaction.draftPicks.length, 'pick')}
+                    </span>
+                )}
+                <span className="text-ink-dim ml-auto shrink-0 font-mono text-[10px]">
+                    {agoLabel(Date.parse(transaction.created))}
+                </span>
+            </span>
+            <span className={`flex min-w-0 gap-2 text-[12px] ${happened ? '' : 'opacity-60'}`}>
+                <Moved label="+" players={adds} />
+                <Moved label="−" players={drops} />
+            </span>
+        </div>
+    );
+};
+
+const Activity = ({ activity, loading }) => {
+    if (loading) {
+        return (
+            <div className="border-line-mid mt-3 flex min-h-20 items-center justify-center border-t pt-2">
+                <Spinner />
+            </div>
+        );
+    }
+
+    // Additive, like the rank list's intel: a failed fetch leaves the profile
+    // rendering everything else rather than failing the screen. `transactions`
+    // is checked rather than assumed - this reads somebody else's response,
+    // and a body without it should render nothing, not throw and take the
+    // whole profile down.
+    if (!activity?.transactions) return null;
+
+    const coverage = coverageLabel(activity.coverage);
+
+    return (
+        <div className="border-line-mid mt-3 border-t pt-2">
+            <p className="text-ink-dim mb-1 font-mono text-[10px] tracking-[.08em] uppercase">
+                Recent moves
+                {/* Never the count alone: "5 trades" across 42 leagues and
+                    across 4 are different claims, and a live run once
+                    reported a denominator describing nobody. */}
+                {coverage && <span className="text-ink-quiet"> · {coverage}</span>}
+            </p>
+            {activity.transactions.length === 0 ? (
+                <p className="text-ink-muted m-0 text-[13px] leading-snug">Nothing seen yet in any of their leagues.</p>
+            ) : (
+                activity.transactions.map((transaction) => (
+                    <Transaction key={transaction.id} transaction={transaction} players={activity.players || {}} />
+                ))
+            )}
+        </div>
+    );
+};
+
+const Profile = ({ manager, onBack, season }) => {
     const signal = managerSignal(manager, THRESHOLDS);
     const { crushes = [], positionLean = [], reachVsAdp } = manager.tendencies || {};
+    const [activity, setActivity] = useState(undefined);
+    const [activityLoading, setActivityLoading] = useState(true);
+
+    // Fetched when the profile opens rather than with the list: thirteen
+    // managers render from one cheap /intel call, and activity is only wanted
+    // for the one actually looked at.
+    useEffect(() => {
+        let cancelled = false;
+        setActivityLoading(true);
+
+        fetchManagerActivity({ userId: manager.userId, season, limit: 10 }).then((response) => {
+            if (cancelled) return;
+            setActivity(response);
+            setActivityLoading(false);
+        });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [manager.userId, season]);
 
     return (
         <div className="px-2 py-2.5">
@@ -153,6 +268,8 @@ const Profile = ({ manager, onBack }) => {
                         )}
                     </>
                 )}
+
+                <Activity activity={activity} loading={activityLoading} />
             </div>
         </div>
     );
@@ -200,7 +317,7 @@ const LeaguemateIntelPanel = ({ leagueID, season }) => {
     const selected = managers.find((manager) => manager.userId === selectedUserId);
 
     if (selected) {
-        return <Profile manager={selected} onBack={() => setSelectedUserId(null)} />;
+        return <Profile manager={selected} season={season} onBack={() => setSelectedUserId(null)} />;
     }
 
     return (

--- a/src/Panels/LeaguemateIntelPanel.test.jsx
+++ b/src/Panels/LeaguemateIntelPanel.test.jsx
@@ -56,10 +56,20 @@ const intelBody = (overrides = {}) => ({
     ...overrides,
 });
 
-const renderPanel = (body = intelBody(), props = {}) => {
-    global.fetch = vi.fn(() => (body instanceof Promise ? body : jsonResponse(body)));
+// Routed by URL: opening a profile fires a second request to /activity, and
+// answering it with the intel body would be testing a shape the API never
+// sends.
+const renderPanel = (body = intelBody(), props = {}, activity = activityBody()) => {
+    global.fetch = vi.fn((url) => (String(url).includes('/activity') ? jsonResponse(activity) : jsonResponse(body)));
     return render(<LeaguemateIntelPanel leagueID="lg1" season="2026" {...props} />);
 };
+
+const activityBody = (overrides = {}) => ({
+    transactions: [],
+    players: {},
+    coverage: { leaguesSeen: 0, leaguesKnown: 0, lastCrawledAt: null },
+    ...overrides,
+});
 
 describe('LeaguemateIntelPanel', () => {
     beforeEach(() => {
@@ -184,6 +194,110 @@ describe('LeaguemateIntelPanel', () => {
 
         await user.click(screen.getByRole('button', { name: /pavelito0010/ }));
         expect(screen.getByText(/None of their drafts have been seen/)).toBeInTheDocument();
+    });
+
+    // The activity block (§6 step 6 phase 4). Two of these exist because a
+    // live crawl found what no fixture had: `commissioner` transactions, and
+    // that 11% of real transactions are `failed`.
+    describe('the activity block', () => {
+        const tx = (overrides = {}) => ({
+            id: 1,
+            type: 'trade',
+            status: 'complete',
+            created: '2026-08-05T12:00:00Z',
+            creator: 2,
+            participantIds: [2, 3],
+            adds: { 4001: 1 },
+            drops: {},
+            draftPicks: [],
+            waiverBid: null,
+            ...overrides,
+        });
+
+        const withActivity = (overrides) =>
+            renderPanel(
+                intelBody(),
+                {},
+                activityBody({ players: { 4001: { name: 'Some Player', position: 'WR' } }, ...overrides }),
+            );
+
+        const openProfile = async (user) => {
+            await screen.findByText('baconstains');
+            await user.click(screen.getByRole('button', { name: /baconstains/ }));
+        };
+
+        it('asks for that manager only, when the profile is opened', async () => {
+            const user = userEvent.setup();
+            withActivity({ transactions: [] });
+            await openProfile(user);
+
+            const call = global.fetch.mock.calls.map((c) => String(c[0])).find((u) => u.includes('/activity'));
+            const url = new URL(call, 'http://localhost');
+            expect(url.pathname).toBe('/api/v1/users/2/activity');
+            expect(url.searchParams.get('season')).toBe('2026');
+        });
+
+        it('renders a move with the players named', async () => {
+            const user = userEvent.setup();
+            withActivity({ transactions: [tx()], coverage: { leaguesSeen: 33, leaguesKnown: 42 } });
+            await openProfile(user);
+
+            expect(await screen.findByText('Trade')).toBeInTheDocument();
+            expect(screen.getByText(/Some Player/)).toBeInTheDocument();
+        });
+
+        it('always states coverage beside the count', async () => {
+            // "5 trades" across 42 leagues and across 4 are different claims,
+            // and a live run once reported a denominator describing nobody.
+            const user = userEvent.setup();
+            withActivity({ transactions: [tx()], coverage: { leaguesSeen: 33, leaguesKnown: 42 } });
+            await openProfile(user);
+
+            expect(await screen.findByText(/33 of 42 leagues/)).toBeInTheDocument();
+        });
+
+        it('labels a failed transaction rather than mixing it in', async () => {
+            // 11% of real transactions are failed. Unlabelled, the list claims
+            // things happened that did not.
+            const user = userEvent.setup();
+            withActivity({ transactions: [tx({ type: 'waiver', status: 'failed', waiverBid: 37 })] });
+            await openProfile(user);
+
+            expect(await screen.findByText('Failed')).toBeInTheDocument();
+            expect(screen.getByText('$37')).toBeInTheDocument();
+        });
+
+        it('names a commissioner move instead of showing the raw API string', async () => {
+            // 143 of 13,610 in the real corpus, and absent from the scope.
+            const user = userEvent.setup();
+            withActivity({ transactions: [tx({ type: 'commissioner' })] });
+            await openProfile(user);
+
+            expect(await screen.findByText('Commissioner')).toBeInTheDocument();
+            expect(screen.queryByText('commissioner')).toBeNull();
+        });
+
+        it('says nothing is seen yet rather than rendering an empty block', async () => {
+            const user = userEvent.setup();
+            withActivity({ transactions: [], coverage: { leaguesSeen: 0, leaguesKnown: 42 } });
+            await openProfile(user);
+
+            expect(await screen.findByText(/Nothing seen yet/)).toBeInTheDocument();
+        });
+
+        it('leaves the rest of the profile intact when activity fails', async () => {
+            // Additive, like the rank list's intel: a failed fetch must not
+            // take the profile down with it.
+            const user = userEvent.setup();
+            global.fetch = vi.fn((url) =>
+                String(url).includes('/activity') ? Promise.reject(new Error('offline')) : jsonResponse(intelBody()),
+            );
+            render(<LeaguemateIntelPanel leagueID="lg1" season="2026" />);
+            await openProfile(user);
+
+            expect(screen.getByText('Players they keep taking')).toBeInTheDocument();
+            expect(screen.queryByText('Recent moves')).toBeNull();
+        });
     });
 
     it('says so when the fetch fails, rather than rendering an empty screen', async () => {

--- a/src/lib/leagueIntel.js
+++ b/src/lib/leagueIntel.js
@@ -111,3 +111,70 @@ export function sortManagers(managers) {
             (a.displayName || '').localeCompare(b.displayName || ''),
     );
 }
+
+// ---------------------------------------------------------------------
+// Manager activity (docs/leaguemate-intel.md §6 step 6)
+// ---------------------------------------------------------------------
+
+// What each transaction type is called on screen. `commissioner` is here
+// because a live crawl found 143 of them in 13,610 - it is not in the plan's
+// scope and would otherwise have rendered as a raw API string.
+const TYPE_LABELS = {
+    trade: 'Trade',
+    waiver: 'Waiver',
+    free_agent: 'Free agent',
+    commissioner: 'Commissioner',
+};
+
+/**
+ * The human label for a transaction type, falling back to the raw value
+ * rather than hiding a type nobody anticipated. The API is somebody else's
+ * and its vocabulary can grow; an unknown type should look odd on screen,
+ * not vanish from a list that claims to be complete.
+ */
+export function transactionLabel(type) {
+    return TYPE_LABELS[type] || type || 'Unknown';
+}
+
+/**
+ * Whether a transaction actually happened.
+ *
+ * 11% of real transactions come back `failed` (1,497 of 13,610), so this is
+ * not a rare edge. They are kept deliberately - a failed waiver claim is a
+ * revealed preference nobody else in that league can see - but a list that
+ * mixes them in unlabelled is claiming things happened that did not.
+ */
+export function didHappen(transaction) {
+    return transaction?.status !== 'failed';
+}
+
+/**
+ * The players added and dropped, resolved to names through the `players` map
+ * the endpoint sends alongside.
+ *
+ * Falls back to the raw id rather than dropping a player the lookup misses -
+ * a transaction that silently lists two of its three players is worse than
+ * one showing an id.
+ */
+export function movedPlayers(transaction, players = {}) {
+    const named = (ids) => ids.map((id) => ({ id, name: players[id]?.name || id, position: players[id]?.position }));
+
+    return {
+        adds: named(Object.keys(transaction?.adds || {})),
+        drops: named(Object.keys(transaction?.drops || {})),
+    };
+}
+
+/**
+ * How much of a manager's activity is actually visible, as a sentence.
+ *
+ * `null` when there is nothing to qualify. Otherwise it always states both
+ * numbers: "5 trades" across 42 leagues and across 4 are different claims,
+ * and a live run once reported "33 of 175" for a manager who is in 42 -
+ * a denominator describing nobody.
+ */
+export function coverageLabel(coverage) {
+    if (!coverage || !coverage.leaguesKnown) return null;
+
+    return `${coverage.leaguesSeen} of ${countLabel(coverage.leaguesKnown, 'league')}`;
+}

--- a/src/lib/leagueIntel.js
+++ b/src/lib/leagueIntel.js
@@ -149,19 +149,34 @@ export function didHappen(transaction) {
 }
 
 /**
- * The players added and dropped, resolved to names through the `players` map
- * the endpoint sends alongside.
+ * The players this manager added and dropped, resolved to names through the
+ * `players` map the endpoint sends alongside.
+ *
+ * **Filtered to their own roster.** `adds`/`drops` are league-wide: a trade
+ * adds a player to one roster and drops him from another, so rendering both
+ * sides showed the same player as added *and* dropped. Caught against live
+ * data, where a real trade read "+Marvin Harrison −Marvin Harrison".
+ * `rosterId` is which roster is theirs; when it is null (a league whose
+ * roster map could not be fetched) the move is shown unsided rather than
+ * hidden, because a partial answer beats a blank one.
  *
  * Falls back to the raw id rather than dropping a player the lookup misses -
  * a transaction that silently lists two of its three players is worse than
  * one showing an id.
  */
 export function movedPlayers(transaction, players = {}) {
+    const rosterId = transaction?.rosterId;
+
+    const mine = (moves) =>
+        Object.entries(moves || {})
+            .filter(([, roster]) => rosterId == null || roster === rosterId)
+            .map(([id]) => id);
+
     const named = (ids) => ids.map((id) => ({ id, name: players[id]?.name || id, position: players[id]?.position }));
 
     return {
-        adds: named(Object.keys(transaction?.adds || {})),
-        drops: named(Object.keys(transaction?.drops || {})),
+        adds: named(mine(transaction?.adds)),
+        drops: named(mine(transaction?.drops)),
     };
 }
 

--- a/src/lib/leagueIntel.test.js
+++ b/src/lib/leagueIntel.test.js
@@ -1,8 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
     countLabel,
+    coverageLabel,
     crushesShowPattern,
+    didHappen,
     managerSignal,
+    movedPlayers,
+    transactionLabel,
     observedPicks,
     reachPhrase,
     reachPhraseShort,
@@ -209,5 +213,78 @@ describe('sortManagers', () => {
 
     it('is empty rather than throwing when there is no manager list', () => {
         expect(sortManagers(undefined)).toEqual([]);
+    });
+});
+
+describe('transactionLabel', () => {
+    it('names the types the plan anticipated', () => {
+        expect(transactionLabel('trade')).toBe('Trade');
+        expect(transactionLabel('waiver')).toBe('Waiver');
+        expect(transactionLabel('free_agent')).toBe('Free agent');
+    });
+
+    it('names commissioner moves, which the scope missed and a live crawl found', () => {
+        // 143 of 13,610 real transactions. Without this it renders as the raw
+        // API string.
+        expect(transactionLabel('commissioner')).toBe('Commissioner');
+    });
+
+    it('shows an unrecognised type rather than hiding it', () => {
+        // Somebody else's API, and its vocabulary can grow. A type nobody
+        // anticipated should look odd on screen, not vanish from a list that
+        // claims to be complete.
+        expect(transactionLabel('some_new_type')).toBe('some_new_type');
+        expect(transactionLabel(undefined)).toBe('Unknown');
+    });
+});
+
+describe('didHappen', () => {
+    it('separates completed from failed', () => {
+        // 11% of real transactions are failed, so this is not a rare edge.
+        expect(didHappen({ status: 'complete' })).toBe(true);
+        expect(didHappen({ status: 'failed' })).toBe(false);
+    });
+
+    it('treats an unknown status as having happened rather than hiding it', () => {
+        expect(didHappen({ status: 'pending' })).toBe(true);
+        expect(didHappen({})).toBe(true);
+    });
+});
+
+describe('movedPlayers', () => {
+    const players = { 4001: { name: 'Some Player', position: 'WR' } };
+
+    it('resolves ids to names through the map the endpoint sends', () => {
+        const moved = movedPlayers({ adds: { 4001: 1 }, drops: {} }, players);
+
+        expect(moved.adds).toEqual([{ id: '4001', name: 'Some Player', position: 'WR' }]);
+        expect(moved.drops).toEqual([]);
+    });
+
+    it('falls back to the id rather than dropping a player the lookup misses', () => {
+        // A transaction that silently lists two of its three players is worse
+        // than one showing an id.
+        const moved = movedPlayers({ adds: { 9999: 1 } }, players);
+
+        expect(moved.adds).toEqual([{ id: '9999', name: '9999', position: undefined }]);
+    });
+
+    it('is empty rather than throwing for a transaction with neither', () => {
+        expect(movedPlayers(undefined)).toEqual({ adds: [], drops: [] });
+    });
+});
+
+describe('coverageLabel', () => {
+    it('always states both numbers', () => {
+        expect(coverageLabel({ leaguesSeen: 33, leaguesKnown: 42 })).toBe('33 of 42 leagues');
+    });
+
+    it('does not say "1 leagues"', () => {
+        expect(coverageLabel({ leaguesSeen: 1, leaguesKnown: 1 })).toBe('1 of 1 league');
+    });
+
+    it('is null when there is nothing to qualify', () => {
+        expect(coverageLabel({ leaguesSeen: 0, leaguesKnown: 0 })).toBeNull();
+        expect(coverageLabel(undefined)).toBeNull();
     });
 });

--- a/src/lib/leagueIntel.test.js
+++ b/src/lib/leagueIntel.test.js
@@ -252,13 +252,32 @@ describe('didHappen', () => {
 });
 
 describe('movedPlayers', () => {
-    const players = { 4001: { name: 'Some Player', position: 'WR' } };
+    const players = { 4001: { name: 'Some Player', position: 'WR' }, 4002: { name: 'Other Guy', position: 'RB' } };
 
     it('resolves ids to names through the map the endpoint sends', () => {
-        const moved = movedPlayers({ adds: { 4001: 1 }, drops: {} }, players);
+        const moved = movedPlayers({ adds: { 4001: 1 }, drops: {}, rosterId: 1 }, players);
 
         expect(moved.adds).toEqual([{ id: '4001', name: 'Some Player', position: 'WR' }]);
         expect(moved.drops).toEqual([]);
+    });
+
+    it("shows a trade from this manager's side only", () => {
+        // adds/drops are league-wide, so both sides of a trade appear in each.
+        // Unfiltered this rendered "+Some Player −Some Player" against live
+        // data, which reads as nonsense.
+        const trade = { adds: { 4001: 1, 4002: 2 }, drops: { 4001: 2, 4002: 1 }, rosterId: 1 };
+        const moved = movedPlayers(trade, players);
+
+        expect(moved.adds.map((p) => p.name)).toEqual(['Some Player']);
+        expect(moved.drops.map((p) => p.name)).toEqual(['Other Guy']);
+    });
+
+    it('shows the move unsided when the roster is unknown, rather than hiding it', () => {
+        // A league whose roster map could not be fetched. A partial answer
+        // beats a blank one.
+        const trade = { adds: { 4001: 1, 4002: 2 }, drops: {}, rosterId: null };
+
+        expect(movedPlayers(trade, players).adds).toHaveLength(2);
     });
 
     it('falls back to the id rather than dropping a player the lookup misses', () => {

--- a/src/lib/sleeperApi.js
+++ b/src/lib/sleeperApi.js
@@ -2,7 +2,7 @@ import { checkErrors } from './http.js';
 import { decorateRosters } from './rosterInfo.js';
 import { resolveLeagueSeason } from './sleeper.js';
 import APP_DB_URLS, { SLEEPER_API_URLS } from '../urls.js';
-const { ACTIVE_PLAYERS, AVAILABILITY, LEAGUE_INTEL } = APP_DB_URLS;
+const { ACTIVE_PLAYERS, AVAILABILITY, LEAGUE_INTEL, MANAGER_ACTIVITY } = APP_DB_URLS;
 const { LEAGUE, USER_LEAGUES, NFL_STATE, DRAFT, ROSTERS, SLEEPER_USERS, TRADED_PICKS, DRAFTS } = SLEEPER_API_URLS;
 
 // Every function here returns its data instead of writing it to state. That is
@@ -104,26 +104,6 @@ export async function fetchDraft(draftId) {
 }
 
 /**
- * Leaguemate intel for a draft: who owns every remaining pick, and for each
- * player asked about, the odds they last to each of those picks
- * (docs/leaguemate-intel.md §3e).
- *
- * `playerIds` is the caller's own rank list. Sending it is what makes the
- * answer line up with the rows already on screen - without it the API picks
- * its own 20 targets by league ADP, which need not overlap the list at all.
- * A player the corpus has never seen is simply absent from `targets`; that is
- * the honest "no read", not an error, and the caller renders it as one.
- *
- * `atPick` is only for hypotheticals ("if I trade up to 30"). The response
- * carries the whole `byPick` matrix for every remaining pick, so moving the
- * pick selector between picks that are already on the board needs no refetch.
- *
- * Resolves to `undefined` on failure, per this module's contract. Intel is
- * additive - a rank list with no intel is exactly the list this app rendered
- * before the feature existed, so callers drop the extra column rather than
- * failing the whole sheet.
- */
-/**
  * Who your leaguemates are and what they do in their other leagues
  * (docs/leaguemate-intel.md §3e) - how many leagues and drafts each is in,
  * their repeated targets, positional lean and reach-vs-ADP, plus a `corpus`
@@ -146,6 +126,50 @@ export async function fetchLeagueIntel({ leagueId, season }) {
         });
 }
 
+/**
+ * One leaguemate's recent activity - trades, waiver claims and free-agent
+ * adds across every league they are in, newest first.
+ *
+ * The response carries `coverage` alongside the transactions, and it is not
+ * optional decoration: "5 trades" across 42 leagues and across 4 are
+ * different claims. Render one only with the other to hand.
+ *
+ * Resolves to `undefined` on failure, per this module's contract.
+ */
+export async function fetchManagerActivity({ userId, season, limit, types }) {
+    const params = new URLSearchParams();
+    if (season) params.set('season', season);
+    if (limit != null) params.set('limit', String(limit));
+    if (types?.length) params.set('types', types.join(','));
+
+    return await fetch(`${MANAGER_ACTIVITY(userId)}?${params}`)
+        .then(checkErrors)
+        .then((response) => response.json())
+        .catch((error) => {
+            console.error('Error fetching manager activity:', error);
+        });
+}
+
+/**
+ * Leaguemate intel for a draft: who owns every remaining pick, and for each
+ * player asked about, the odds they last to each of those picks
+ * (docs/leaguemate-intel.md §3e).
+ *
+ * `playerIds` is the caller's own rank list. Sending it is what makes the
+ * answer line up with the rows already on screen - without it the API picks
+ * its own 20 targets by league ADP, which need not overlap the list at all.
+ * A player the corpus has never seen is simply absent from `targets`; that is
+ * the honest "no read", not an error, and the caller renders it as one.
+ *
+ * `atPick` is only for hypotheticals ("if I trade up to 30"). The response
+ * carries the whole `byPick` matrix for every remaining pick, so moving the
+ * pick selector between picks that are already on the board needs no refetch.
+ *
+ * Resolves to `undefined` on failure, per this module's contract. Intel is
+ * additive - a rank list with no intel is exactly the list this app rendered
+ * before the feature existed, so callers drop the extra column rather than
+ * failing the whole sheet.
+ */
 export async function fetchAvailability({ draftId, userId, playerIds, atPick }) {
     const params = new URLSearchParams({ user_id: userId });
     // Left off entirely when empty rather than sent blank: an empty rank list

--- a/src/lib/sleeperApi.test.js
+++ b/src/lib/sleeperApi.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
 import {
     fetchAvailability,
     fetchLeagueIntel,
+    fetchManagerActivity,
     fetchDraft,
     fetchLeagueBundle,
     fetchLeagueSeason,
@@ -162,6 +163,36 @@ describe('sleeperApi', () => {
             );
 
             await expect(fetchLeagueIntel({ leagueId: 'nope', season: '2026' })).resolves.toBeUndefined();
+        });
+    });
+
+    describe('fetchManagerActivity', () => {
+        const requestedUrl = () => new URL(global.fetch.mock.calls[0][0], 'http://localhost');
+
+        it('asks for one user across every league, and returns the parsed body', async () => {
+            const body = { transactions: [{ id: 1 }], players: {}, coverage: { leaguesSeen: 33, leaguesKnown: 42 } };
+            global.fetch = vi.fn(() => jsonResponse(body));
+
+            expect(await fetchManagerActivity({ userId: '111', season: '2026' })).toEqual(body);
+            expect(requestedUrl().pathname).toBe('/api/v1/users/111/activity');
+            expect(requestedUrl().searchParams.get('season')).toBe('2026');
+        });
+
+        it('sends limit and types only when given', async () => {
+            global.fetch = vi.fn(() => jsonResponse({ transactions: [] }));
+            await fetchManagerActivity({ userId: '111' });
+            expect(requestedUrl().searchParams.has('limit')).toBe(false);
+            expect(requestedUrl().searchParams.has('types')).toBe(false);
+
+            global.fetch = vi.fn(() => jsonResponse({ transactions: [] }));
+            await fetchManagerActivity({ userId: '111', limit: 20, types: ['trade', 'waiver'] });
+            expect(requestedUrl().searchParams.get('limit')).toBe('20');
+            expect(requestedUrl().searchParams.get('types')).toBe('trade,waiver');
+        });
+
+        it('resolves to undefined on failure', async () => {
+            global.fetch = vi.fn(() => Promise.reject(new Error('offline')));
+            await expect(fetchManagerActivity({ userId: '111' })).resolves.toBeUndefined();
         });
     });
 

--- a/src/urls.js
+++ b/src/urls.js
@@ -6,6 +6,7 @@ const fta = import.meta.env.DEV ? '/' : 'https://fantasyteamassistant.com/';
 const ftaLegacy = 'api/legacy/players';
 const ftaAvailability = (draftId) => `api/v1/drafts/${draftId}/availability`;
 const ftaLeagueIntel = (leagueId) => `api/v1/leagues/${leagueId}/intel`;
+const ftaManagerActivity = (userId) => `api/v1/users/${userId}/activity`;
 const latestUpdateAttempt = 'latest_update_attempt/';
 const dlfADP = 'dlf_adp/';
 const users = 'users/';
@@ -38,6 +39,11 @@ const APP_DB_URLS = {
     // "cross-league" view - the cross-league part is what the managers do
     // elsewhere, not what the request spans.
     LEAGUE_INTEL: (leagueId) => fta + ftaLeagueIntel(leagueId),
+    // One leaguemate's recent trades, waivers and free-agent adds, across
+    // every league they are in. Not nested under a league on purpose - the
+    // data spans all of theirs, so a league in the path would imply a filter
+    // that does not happen.
+    MANAGER_ACTIVITY: (userId) => fta + ftaManagerActivity(userId),
     DLF_ADP: appDB + dlfADP + typeParams,
     APP_USERS: appDB + users,
     TYPE_PARAMS: typeParams,

--- a/src/urls.test.js
+++ b/src/urls.test.js
@@ -42,4 +42,9 @@ describe('other endpoints', () => {
     it('builds the league-intel path under the same proxied prefix', () => {
         expect(APP_DB_URLS.LEAGUE_INTEL('abc')).toBe('/api/v1/leagues/abc/intel');
     });
+
+    it('builds the manager-activity path as a flat user route', () => {
+        // Not nested under a league: the data spans every league they are in.
+        expect(APP_DB_URLS.MANAGER_ACTIVITY('111')).toBe('/api/v1/users/111/activity');
+    });
 });


### PR DESCRIPTION
Phase 4 of §6 step 6, and the last piece. The Leaguemate profile fetches that
manager's recent trades, waivers and free-agent adds when it opens — not with
the list, which renders thirteen managers from one cheap `/intel` call.

Backend is sleeper-player-be#39, #40 and #41, all merged and deployed.

## Verified against the deployed endpoint, at 375px

Not just unit tests — and it earned it, because the live pass found three
things nothing else could:

**Sleeper ids exceed JavaScript's safe integer range** (#41). The profile
requested `/users/859581197427257300/activity` for a manager whose id ends
`...344`, so the block said "Nothing seen yet" for someone with four
transactions. `JSON.parse` rounds 19-digit ids silently. It was invisible
until now because an id was only ever compared to itself — the list keyed rows
by a mangled `userId` and looked them up with the same mangled value.

**A trade rendered both sides** (#40). `adds`/`drops` are league-wide, so a
real trade read `+Marvin Harrison −Marvin Harrison`. The API now says which
roster is theirs.

**`type: "commissioner"` exists** — 143 of 13,610 real transactions, in no
fixture and no plan. Named rather than shown as a raw API string, and an
unrecognised type falls through to its raw value rather than vanishing from a
list claiming to be complete.

## Sample-size discipline, again

**11% of real transactions are `failed`** (1,497 of 13,610) — large enough that
mixing them in unlabelled would claim things happened that didn't. They carry a
badge and dim.

Coverage rides beside the heading, never the count alone: `Recent moves · 33 of
42 leagues`. That field reported "33 of 175" before `league_members` gave it an
honest denominator.

## Also

The block is additive — a failed activity fetch leaves the rest of the profile
rendering. It checks `transactions` rather than assuming it, since it reads a
response shape it doesn't own.

Re-attached a docstring I'd orphaned earlier: `fetchAvailability`'s doc had been
stranded above `fetchLeagueIntel`, leaving one function documented twice and the
other not at all.

573 tests. Dropping the failed label, the commissioner label, or the roster
filter each fail their own cases.