### PR TITLE
Let anyone connect their own Sleeper account

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -17,14 +17,27 @@ import {
     fetchLeagueBundle,
     fetchLeagueSeason,
     fetchPlayerData,
+    fetchSleeperUser,
     fetchTradedDraftPicks,
+    fetchUserLeagues,
 } from './lib/sleeperApi.js';
+import {
+    pickStartingLeague,
+    readLastLeagueId,
+    readLocalAccount,
+    readRemoteAccount,
+    reconcileAccounts,
+    writeLastLeagueId,
+    writeLocalAccount,
+    writeRemoteAccount,
+} from './lib/sleeperIdentity.js';
 import { addPlayerToRoster, removePlayerFromLineup, toRosterSlots } from './lib/roster.js';
 import { buildLineupSet, memoizeRosterInfo } from './lib/rosterInfo.js';
 import { resolveMyDisplayName } from './lib/sleeper.js';
 import { checkErrors } from './lib/http.js';
 import { auth } from './firebase.js';
-import APP_DB_URLS, { SLEEPER_USER_ID } from './urls.js';
+import APP_DB_URLS from './urls.js';
+import ConnectSleeper from './Components/ConnectSleeper';
 import BestAvailable, { countAvailable } from './Components/BestAvailable';
 import { draftDefaultOwnership } from './Components/OwnershipFilters';
 
@@ -51,6 +64,16 @@ const DEFAULT_SAVED_RANK_LISTS = {
 // vocabulary with App at all, so these names stay private to this file.
 const LEAGUE_LOAD_FAILED = "Couldn't load your league data. The Sleeper API may be unavailable.";
 const TRADED_PICKS_FAILED = "Couldn't load traded draft picks. The board shows every pick under its original owner.";
+const NO_LEAGUES = "This Sleeper account isn't in any leagues for the current season.";
+
+// The `users/{uid}` record is not only rank lists any more - the connected
+// Sleeper account is saved in the same subtree, so a signed-in user's record
+// now has a key that is not a list. Filtering on shape rather than on the one
+// known key name keeps the rank-list switcher from sprouting a phantom entry
+// for it (labelled "dunno", since it has no pretty_name), and keeps doing so
+// for whatever gets stored there next.
+const onlyRankLists = (record) =>
+    Object.fromEntries(Object.entries(record).filter(([, value]) => value && value.route_name));
 
 const LOADING = {
     NONE: 'none',
@@ -86,11 +109,20 @@ class App extends React.Component {
         draftWarning: null,
         loading: LOADING.INITIAL,
         rankingPlayersIdsList: [],
-        leagueID: '1312088290526003200',
+        // No hardcoded league any more - it is chosen from whatever leagues
+        // the connected account is actually in (see startLoadingLeagues).
+        leagueID: null,
         rosterSlots: [],
         notFoundPlayers: [],
         signedIn: false,
         signedInEmail: null,
+        // The Sleeper account the app is pointed at, `{ userId, username }`,
+        // and whether we have finished looking for one yet. The second flag is
+        // what keeps the connect screen from flashing on every load before
+        // storage has been read - "not connected" and "don't know yet" are
+        // different screens.
+        sleeperAccount: null,
+        accountResolved: false,
         season: null,
         myDisplayName: null,
         savedRankLists: DEFAULT_SAVED_RANK_LISTS,
@@ -100,20 +132,82 @@ class App extends React.Component {
     selectRosterInfo = memoizeRosterInfo();
 
     componentDidMount() {
-        this.unsubscribeAuth = observeAuthState((user) => {
-            if (user) {
-                const { playerInfo } = this.state;
-                this.setState(currentUserIdentity());
-                if (playerInfo && Object.keys(playerInfo).length === 0) {
-                    this.loadEverything();
-                } else {
-                    this.loadLeague(playerInfo);
-                }
-            } else {
+        this.unsubscribeAuth = observeAuthState(async (user) => {
+            if (!user) {
                 signInAnonymous();
+                return;
+            }
+            const { playerInfo } = this.state;
+            this.setState(currentUserIdentity());
+
+            // Resolved before anything loads, because it decides *what* loads:
+            // every league request below is built from this account's id.
+            const sleeperAccount = await this.resolveSleeperAccount(user);
+            this.setState({ sleeperAccount, accountResolved: true });
+
+            if (playerInfo && Object.keys(playerInfo).length === 0) {
+                this.loadEverything(sleeperAccount);
+            } else {
+                this.loadLeague(playerInfo, sleeperAccount);
             }
         });
     }
+
+    // Where the connected account comes from, and the one place the two
+    // storage sides are reconciled. Signed-out visitors have only the local
+    // one; signing in with Google brings a saved account down (or pushes the
+    // local one up, if the account is new). See reconcileAccounts for why the
+    // remote copy wins.
+    resolveSleeperAccount = async (user) => {
+        const local = readLocalAccount();
+        if (user.isAnonymous) {
+            return local;
+        }
+        const { account, promote } = reconcileAccounts({ local, remote: await readRemoteAccount(user) });
+        if (promote) {
+            await writeRemoteAccount(user, account);
+        }
+        // Mirrored back down so the next signed-out visit to this device opens
+        // on the same account rather than back on whatever it had before.
+        if (account) {
+            writeLocalAccount(account);
+        }
+        return account;
+    };
+
+    // Connecting from the ConnectSleeper screen. The account is stored before
+    // anything is fetched: a load failure should still leave you connected,
+    // otherwise a flaky network bounces you back to the form and loses the
+    // username you just typed.
+    connectSleeperAccount = async (account) => {
+        writeLocalAccount(account);
+        if (this.state.signedIn) {
+            await writeRemoteAccount(auth.currentUser, account);
+        }
+        this.setState({ sleeperAccount: account, leagueID: null, loadError: null, loading: LOADING.INITIAL }, () =>
+            this.loadLeague(this.state.playerInfo, account),
+        );
+    };
+
+    // Deliberately clears both copies, not just this device's: "disconnect"
+    // read as a per-device action would silently reconnect the account on the
+    // next sign-in, from the copy still in the database.
+    disconnectSleeperAccount = async () => {
+        writeLocalAccount(null);
+        if (this.state.signedIn) {
+            await writeRemoteAccount(auth.currentUser, null);
+        }
+        this.setState({
+            sleeperAccount: null,
+            leagueID: null,
+            leagueData: {},
+            myDisplayName: null,
+            rosterSlots: [],
+            loadError: null,
+            draftWarning: null,
+            loading: LOADING.NONE,
+        });
+    };
 
     componentDidUpdate(prevProps, prevState) {
         // Mirrors the effect RanksPanel used to run on `[signedIn]`: a fresh
@@ -152,7 +246,7 @@ class App extends React.Component {
             });
         if (result) {
             this.setState({
-                savedRankLists: { ...DEFAULT_SAVED_RANK_LISTS, ...result },
+                savedRankLists: { ...DEFAULT_SAVED_RANK_LISTS, ...onlyRankLists(result) },
                 savedRankListsLoading: false,
             });
         } else {
@@ -175,42 +269,81 @@ class App extends React.Component {
     // board. Each step passes its result to the next as an argument instead of
     // writing it to state and reading it back: #96 and #98 were both a read of
     // a value that had not settled, and neither is expressible in this shape.
-    loadEverything = async () => {
+    loadEverything = async (sleeperAccount) => {
         const playerInfo = await fetchPlayerData();
         if (playerInfo) {
             this.setState({ playerInfo });
         }
-        await this.loadLeague(playerInfo || this.state.playerInfo);
+        await this.loadLeague(playerInfo || this.state.playerInfo, sleeperAccount);
     };
 
     // `playerInfo` is a parameter rather than a state read for the same
     // reason: on the very first load the setState above has not necessarily
     // flushed, and warnAboutMissingRosterPlayers would compare rosters against
     // an empty database and warn about every player in the league.
-    loadLeague = async (playerInfo) => {
+    loadLeague = async (playerInfo, sleeperAccount = this.state.sleeperAccount) => {
+        // Nothing to load without an account, and this is not a failure: it is
+        // the connect screen's state, which render() picks up from
+        // `sleeperAccount` being null.
+        if (!sleeperAccount) {
+            this.setState({ loading: LOADING.NONE });
+            return;
+        }
+
         const season = this.state.season || (await fetchLeagueSeason());
-        const leagueData = await fetchLeagueBundle({ leagueID: this.state.leagueID, season });
+        const leagueID = this.state.leagueID || (await this.chooseLeague(sleeperAccount, season));
+        // Three outcomes, and they must not be collapsed: a league to open, a
+        // Sleeper account genuinely in no leagues, and a failed request.
+        // Telling someone whose league list failed to load that they are in no
+        // leagues is both wrong and unactionable.
+        if (leagueID === undefined) {
+            this.setState({ season, loading: LOADING.NONE, loadError: LEAGUE_LOAD_FAILED });
+            return;
+        }
+        if (leagueID === null) {
+            this.setState({ season, loading: LOADING.NONE, loadError: NO_LEAGUES });
+            return;
+        }
+
+        const leagueData = await fetchLeagueBundle({ leagueID, season, userId: sleeperAccount.userId });
         if (!leagueData) {
             // Both panels read league data unconditionally - LeaguePanel goes
             // straight for currentLeague.name - so there is nothing to render
             // them from and no partial view worth showing. Before this the app
             // fell through to a render with leagueData still empty and threw,
             // leaving a blank page.
-            this.setState({ season, loading: LOADING.NONE, loadError: LEAGUE_LOAD_FAILED });
+            this.setState({ season, leagueID, loading: LOADING.NONE, loadError: LEAGUE_LOAD_FAILED });
             return;
         }
 
         this.warnAboutMissingRosterPlayers(leagueData.rosterData, playerInfo);
         this.setState({
             season,
+            leagueID,
             leagueData,
             loadError: null,
             loading: LOADING.LEAGUE_PANEL,
-            myDisplayName: resolveMyDisplayName(leagueData.managerData, SLEEPER_USER_ID),
+            myDisplayName: resolveMyDisplayName(leagueData.managerData, sleeperAccount.userId),
             rosterSlots: toRosterSlots(leagueData.currentLeague.roster_positions),
         });
 
         await this.loadDraft(leagueData);
+    };
+
+    // Which league to open on for an account that has not picked one this
+    // session. Costs one extra request that the league bundle also makes -
+    // unavoidable, because the bundle is built *from* a league id, so
+    // something has to know the list before it can run at all.
+    //
+    // Returns `undefined` when the list could not be fetched and `null` when
+    // it came back empty, keeping apart the two states the caller renders
+    // different messages for.
+    chooseLeague = async (sleeperAccount, season) => {
+        const leagues = await fetchUserLeagues({ userId: sleeperAccount.userId, season });
+        if (!leagues) {
+            return undefined;
+        }
+        return pickStartingLeague({ leagues, lastLeagueId: readLastLeagueId(sleeperAccount.userId) });
     };
 
     loadDraft = async (leagueData) => {
@@ -304,6 +437,11 @@ class App extends React.Component {
     };
 
     updateLeagueID = (leagueID) => {
+        // Remembered per account so the next visit opens here, which is what
+        // the hardcoded league id used to give for free.
+        if (this.state.sleeperAccount) {
+            writeLastLeagueId(this.state.sleeperAccount.userId, leagueID);
+        }
         this.setState(
             {
                 leagueID,
@@ -477,146 +615,170 @@ class App extends React.Component {
             savedRankLists,
             savedRankListsLoading,
             season,
+            sleeperAccount,
+            accountResolved,
         } = this.state;
         if (loading === LOADING.INITIAL) {
             return <Spinner size="page" />;
-        } else {
-            const rosterInfo = this.selectRosterInfo({
-                rosterData: leagueData.rosterData,
-                builtDraft: leagueData.currentDraft?.built_draft,
-            });
-            const lineupSet = buildLineupSet(rosterSlots);
-            // One element, two possible slots: beside the league section on a
-            // wide screen, or as the main column when Ranks is the active
-            // section. Built once so the two call sites cannot drift apart.
-            const ranksPanel = (
-                <RanksPanel
-                    isLoading={loading === LOADING.RANKS_PANEL}
-                    signedIn={signedIn}
-                    playerInfo={playerInfo}
-                    rosterInfo={rosterInfo}
-                    updateRankingPlayersIdsList={this.updateRankingPlayersIdsList}
-                    startLoad={this.startLoad}
-                    addToRoster={this.addToRoster}
-                    updatePlayerId={this.updatePlayerId}
-                    notFoundPlayers={notFoundPlayers}
-                    rankingPlayersIdsList={rankingPlayersIdsList}
-                    myDisplayName={myDisplayName}
-                    lineupSet={lineupSet}
-                    savedRankLists={savedRankLists}
-                    savedRankListsLoading={savedRankListsLoading}
-                    updateSavedRankLists={this.updateSavedRankLists}
-                />
-            );
+        }
+
+        // No Sleeper account connected - the state that could not exist while
+        // the account was a constant. Checked before everything below because
+        // none of it has anything to render: no league, no roster, no draft.
+        // `accountResolved` gates it so this does not flash on top of a load
+        // that is about to find a stored account.
+        if (accountResolved && !sleeperAccount) {
             return (
-                <RankListProvider>
-                    <SyncStatusProvider>
-                        <div>
-                            {/*
-                            The shell renders its own top bar, because the bar's
-                            section pills and the tab bar have to share one
-                            active id. So this is an either/or, not a stack: the
-                            bare bar below covers the states where there is no
-                            shell yet - still loading a league, or a load error
-                            that replaced everything under it - and the shell
-                            takes over the moment there is a league to navigate.
-                            Rendering both is what it looked like first, and it
-                            put two top bars on the screen.
-                        */}
-                            {!loadError && leagueData.currentLeague ? (
-                                <AppShell
-                                    sections={SECTIONS}
-                                    // The league bundle already carries the draft's status, so this is
-                                    // known the moment the shell can mount. Reading it off
-                                    // currentDraft instead would be a render too late: that is
-                                    // filled by loadDraft, which resolves after the shell is
-                                    // already on screen.
-                                    defaultSectionId={defaultSectionFor(leagueData.currentLeagueDrafts?.[0]?.status)}
-                                    identity={{
-                                        signedIn,
-                                        signedInEmail,
-                                        myDisplayName,
-                                        onSignIn: this.googleSignIn,
-                                        onSignOut: this.signOut,
-                                    }}
-                                    leagueID={leagueID}
-                                    leagueIds={leagueData.leagueIds}
-                                    updateLeagueID={this.updateLeagueID}
-                                    // Inside the shell rather than above it: the
-                                    // shell owns the top bar now, so a banner
-                                    // rendered as a sibling would sit above the bar
-                                    // instead of under it.
-                                    banner={
-                                        draftWarning ? (
-                                            <ErrorBanner
-                                                message={draftWarning}
-                                                variant="warning"
-                                                onRetry={this.retryDraftLoad}
-                                            />
-                                        ) : null
-                                    }
-                                    renderAside={this.renderBestAvailableRail}
-                                    renderSection={(activeId) => {
-                                        if (activeId === 'ranks') {
-                                            return ranksPanel;
-                                        }
-                                        if (activeId === 'leaguemates') {
-                                            return <LeaguemateIntelPanel leagueID={leagueID} season={season} />;
-                                        }
-                                        return (
-                                            <LeaguePanel
-                                                view={activeId === 'lineup' ? 'weekly' : 'draft'}
-                                                leagueData={leagueData}
-                                                rankingPlayersIdsList={rankingPlayersIdsList}
-                                                rosterSlots={rosterSlots}
-                                                playerInfo={playerInfo}
-                                                rosterInfo={rosterInfo}
-                                                isLoading={loading === LOADING.LEAGUE_PANEL}
-                                                removeFromLineup={this.removeFromLineup}
-                                                updateDraftBoard={this.updateDraftBoard}
-                                                myDisplayName={myDisplayName}
-                                                addToRoster={this.addToRoster}
-                                                fillSlot={this.fillSlot}
-                                                savedRankLists={savedRankLists}
-                                                savedRankListsLoading={savedRankListsLoading}
-                                                signedIn={signedIn}
-                                                lineupSet={lineupSet}
-                                            />
-                                        );
-                                    }}
-                                />
-                            ) : (
-                                <>
-                                    <AppBar
-                                        signedIn={signedIn}
-                                        signedInEmail={signedInEmail}
-                                        myDisplayName={myDisplayName}
-                                        onSignIn={this.googleSignIn}
-                                        onSignOut={this.signOut}
-                                    />
-                                    {/* The banner is a card, so it needs the
-                                        screen's own gutter around it rather
-                                        than sitting flush to the viewport
-                                        edges with its corners rounded. */}
-                                    <div className="p-3.5 md:p-4">
-                                        {loadError ? (
-                                            <ErrorBanner message={loadError} onRetry={this.retryLeagueLoad} />
-                                        ) : null}
-                                        {!loadError && draftWarning ? (
-                                            <ErrorBanner
-                                                message={draftWarning}
-                                                variant="warning"
-                                                onRetry={this.retryDraftLoad}
-                                            />
-                                        ) : null}
-                                    </div>
-                                </>
-                            )}
-                        </div>
-                    </SyncStatusProvider>
-                </RankListProvider>
+                <div>
+                    <AppBar signedIn={signedIn} signedInEmail={signedInEmail} onSignIn={this.googleSignIn} />
+                    <ConnectSleeper
+                        onConnect={this.connectSleeperAccount}
+                        resolveUsername={fetchSleeperUser}
+                        signedIn={signedIn}
+                        onSignIn={this.googleSignIn}
+                    />
+                </div>
             );
         }
+
+        const rosterInfo = this.selectRosterInfo({
+            rosterData: leagueData.rosterData,
+            builtDraft: leagueData.currentDraft?.built_draft,
+        });
+        const lineupSet = buildLineupSet(rosterSlots);
+        // One element, two possible slots: beside the league section on a
+        // wide screen, or as the main column when Ranks is the active
+        // section. Built once so the two call sites cannot drift apart.
+        const ranksPanel = (
+            <RanksPanel
+                isLoading={loading === LOADING.RANKS_PANEL}
+                signedIn={signedIn}
+                playerInfo={playerInfo}
+                rosterInfo={rosterInfo}
+                updateRankingPlayersIdsList={this.updateRankingPlayersIdsList}
+                startLoad={this.startLoad}
+                addToRoster={this.addToRoster}
+                updatePlayerId={this.updatePlayerId}
+                notFoundPlayers={notFoundPlayers}
+                rankingPlayersIdsList={rankingPlayersIdsList}
+                myDisplayName={myDisplayName}
+                lineupSet={lineupSet}
+                savedRankLists={savedRankLists}
+                savedRankListsLoading={savedRankListsLoading}
+                updateSavedRankLists={this.updateSavedRankLists}
+            />
+        );
+        return (
+            <RankListProvider>
+                <SyncStatusProvider>
+                    <div>
+                        {/*
+                        The shell renders its own top bar, because the bar's
+                        section pills and the tab bar have to share one
+                        active id. So this is an either/or, not a stack: the
+                        bare bar below covers the states where there is no
+                        shell yet - still loading a league, or a load error
+                        that replaced everything under it - and the shell
+                        takes over the moment there is a league to navigate.
+                        Rendering both is what it looked like first, and it
+                        put two top bars on the screen.
+                    */}
+                        {!loadError && leagueData.currentLeague ? (
+                            <AppShell
+                                sections={SECTIONS}
+                                // The league bundle already carries the draft's status, so this is
+                                // known the moment the shell can mount. Reading it off
+                                // currentDraft instead would be a render too late: that is
+                                // filled by loadDraft, which resolves after the shell is
+                                // already on screen.
+                                defaultSectionId={defaultSectionFor(leagueData.currentLeagueDrafts?.[0]?.status)}
+                                identity={{
+                                    signedIn,
+                                    signedInEmail,
+                                    myDisplayName,
+                                    sleeperUsername: sleeperAccount?.username,
+                                    onSignIn: this.googleSignIn,
+                                    onSignOut: this.signOut,
+                                    onDisconnectSleeper: this.disconnectSleeperAccount,
+                                }}
+                                leagueID={leagueID}
+                                leagueIds={leagueData.leagueIds}
+                                updateLeagueID={this.updateLeagueID}
+                                // Inside the shell rather than above it: the
+                                // shell owns the top bar now, so a banner
+                                // rendered as a sibling would sit above the bar
+                                // instead of under it.
+                                banner={
+                                    draftWarning ? (
+                                        <ErrorBanner
+                                            message={draftWarning}
+                                            variant="warning"
+                                            onRetry={this.retryDraftLoad}
+                                        />
+                                    ) : null
+                                }
+                                renderAside={this.renderBestAvailableRail}
+                                renderSection={(activeId) => {
+                                    if (activeId === 'ranks') {
+                                        return ranksPanel;
+                                    }
+                                    if (activeId === 'leaguemates') {
+                                        return <LeaguemateIntelPanel leagueID={leagueID} season={season} />;
+                                    }
+                                    return (
+                                        <LeaguePanel
+                                            view={activeId === 'lineup' ? 'weekly' : 'draft'}
+                                            leagueData={leagueData}
+                                            rankingPlayersIdsList={rankingPlayersIdsList}
+                                            rosterSlots={rosterSlots}
+                                            playerInfo={playerInfo}
+                                            rosterInfo={rosterInfo}
+                                            isLoading={loading === LOADING.LEAGUE_PANEL}
+                                            removeFromLineup={this.removeFromLineup}
+                                            updateDraftBoard={this.updateDraftBoard}
+                                            myDisplayName={myDisplayName}
+                                            sleeperUserId={sleeperAccount?.userId}
+                                            addToRoster={this.addToRoster}
+                                            fillSlot={this.fillSlot}
+                                            savedRankLists={savedRankLists}
+                                            savedRankListsLoading={savedRankListsLoading}
+                                            signedIn={signedIn}
+                                            lineupSet={lineupSet}
+                                        />
+                                    );
+                                }}
+                            />
+                        ) : (
+                            <>
+                                <AppBar
+                                    signedIn={signedIn}
+                                    signedInEmail={signedInEmail}
+                                    myDisplayName={myDisplayName}
+                                    onSignIn={this.googleSignIn}
+                                    onSignOut={this.signOut}
+                                />
+                                {/* The banner is a card, so it needs the
+                                    screen's own gutter around it rather
+                                    than sitting flush to the viewport
+                                    edges with its corners rounded. */}
+                                <div className="p-3.5 md:p-4">
+                                    {loadError ? (
+                                        <ErrorBanner message={loadError} onRetry={this.retryLeagueLoad} />
+                                    ) : null}
+                                    {!loadError && draftWarning ? (
+                                        <ErrorBanner
+                                            message={draftWarning}
+                                            variant="warning"
+                                            onRetry={this.retryDraftLoad}
+                                        />
+                                    ) : null}
+                                </div>
+                            </>
+                        )}
+                    </div>
+                </SyncStatusProvider>
+            </RankListProvider>
+        );
     }
 }
 

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -947,9 +947,27 @@ describe('App, connecting a Sleeper account', () => {
         expect(await screen.findByText(/isn't in any leagues/i, {}, { timeout: 5000 })).toBeInTheDocument();
         empty.unmount();
 
-        global.fetch = vi.fn((url) =>
-            url.includes('leagues/nfl/') ? Promise.reject(new Error('Sleeper down')) : mockFetch(url),
-        );
+        // Only the *first* league-list request fails, and every other request
+        // succeeds - including ones for a league id of `undefined`.
+        //
+        // Both of those are load-bearing. The league list is fetched twice on
+        // this path (once to choose a league, once inside the league bundle),
+        // so failing it outright fails the bundle too, and code that ignored
+        // the first failure still reached this same message by falling through
+        // into a bundle that then failed for its own reasons. Failing only the
+        // first, and serving the fallthrough's `league/undefined/` requests,
+        // means the message can only appear if the failed list was caught
+        // where it happened.
+        let leagueListCalls = 0;
+        global.fetch = vi.fn((url) => {
+            if (url.includes('leagues/nfl/')) {
+                leagueListCalls += 1;
+                if (leagueListCalls === 1) {
+                    return Promise.reject(new Error('Sleeper down'));
+                }
+            }
+            return mockFetch(url.replace('league/undefined/', `league/${LEAGUE_ID}/`));
+        });
 
         render(<App />);
         expect(await screen.findByText(/Couldn't load your league data/i, {}, { timeout: 5000 })).toBeInTheDocument();
@@ -1001,6 +1019,15 @@ describe('App, connecting a Sleeper account', () => {
         render(<App />);
         await screen.findAllByText(/ryangh/, {}, { timeout: 5000 });
 
-        await waitFor(() => expect(screen.queryByText('dunno')).not.toBeInTheDocument());
+        // The switcher only exists on the Ranks section - RanksPanel is what
+        // publishes the list it renders from - so asserting anywhere else
+        // passes no matter what the map contains.
+        await userEvent.setup().click(screen.getAllByRole('button', { name: 'Ranks' })[0]);
+        const switcher = await screen.findByRole('combobox', { name: 'Rank list' });
+
+        // Every option is a real saved list: the placeholder and the one list
+        // this user has. An unfiltered read adds a third for the account,
+        // labelled "dunno" because it has no pretty_name.
+        expect([...switcher.options].map((option) => option.text)).toEqual(['-- Select saved ranks list', 'My Ranks']);
     });
 });

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1,7 +1,8 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import App from './App';
+import { auth } from './firebase.js';
 import rosterFlagsFixture from './lib/__fixtures__/roster-flags-2026.json';
 import realDraftFixture from './lib/__fixtures__/real-draft-2026.json';
 
@@ -24,14 +25,21 @@ vi.mock('./firebase.js', () => ({
     googleProvider: {},
 }));
 
-const authMockState = vi.hoisted(() => ({ unsubscribe: null, callback: null }));
+const authMockState = vi.hoisted(() => ({ unsubscribe: null, callback: null, user: null }));
+
+// The user the observer reports. Overridable per test because the app now
+// branches on `isAnonymous`: an anonymous visitor's Sleeper account is
+// local-only, while a real sign-in also reads the saved copy. Mutating
+// `auth.currentUser` alone does not cover it - that object feeds the
+// displayed identity, but this one is what the resolution logic receives.
+const observedUser = () => authMockState.user || { uid: 'test-uid', isAnonymous: true };
 
 vi.mock('firebase/auth', () => ({
     onAuthStateChanged: vi.fn((auth, callback) => {
         // Simplest path: report an already-signed-in (anonymous) user
         // immediately, so App skips the signInAnonymously branch entirely.
         authMockState.callback = callback;
-        callback({ uid: 'test-uid', isAnonymous: true });
+        callback({ ...observedUser(), getIdToken: vi.fn().mockResolvedValue('test-id-token') });
         authMockState.unsubscribe = vi.fn();
         return authMockState.unsubscribe;
     }),
@@ -43,6 +51,10 @@ vi.mock('firebase/auth', () => ({
 const { rosterDataRaw, managerData, playerInfo, livePicksPartial } = rosterFlagsFixture;
 const { currentDraft: draftSettings, tradedDraftPicks } = realDraftFixture;
 
+// The Sleeper account these tests connect as. This was a hardcoded constant in
+// the app itself until the app became multi-user; it lives here now because the
+// fixture's rosters and managerData are built around this manager.
+const SLEEPER_USER_ID = '521035584588267520';
 const LEAGUE_ID = '1312088290526003200';
 const OTHER_LEAGUE_ID = '9999999999999999999';
 const DRAFT_ID = 'draft123';
@@ -125,6 +137,21 @@ function mockFetch(url) {
 }
 
 describe('App', () => {
+    // Every test below renders the app expecting a league on screen, which now
+    // requires a connected Sleeper account - the id used to be a constant, so
+    // there was nothing to set up. `ryangh` is roster 1's owner in the fixture,
+    // which is what makes that roster "mine" in the assertions.
+    beforeEach(() => {
+        window.localStorage.setItem('sleeper.account', JSON.stringify({ userId: SLEEPER_USER_ID, username: 'ryangh' }));
+    });
+
+    // Cleared between tests because the app remembers the last league per
+    // account: without this, a test that switches leagues would leave the next
+    // one opening on the other league.
+    afterEach(() => {
+        window.localStorage.clear();
+    });
+
     it('renders a manager display name resolved from managerData on the draft board', async () => {
         global.fetch = vi.fn(mockFetch);
 
@@ -839,5 +866,141 @@ describe('App', () => {
         unmount();
 
         expect(authMockState.unsubscribe).toHaveBeenCalledTimes(1);
+    });
+});
+
+// The app was single-tenant until this feature: the Sleeper account was a
+// constant, so "nobody has connected one" was not a state that could exist.
+// These cover the states that constant used to make unreachable.
+describe('App, connecting a Sleeper account', () => {
+    afterEach(() => {
+        window.localStorage.clear();
+        auth.currentUser.isAnonymous = true;
+        auth.currentUser.email = null;
+        authMockState.user = null;
+    });
+
+    // Signs in for real, on both the object the app displays identity from and
+    // the one the observer hands to the account-resolution logic.
+    const signIn = () => {
+        auth.currentUser.isAnonymous = false;
+        auth.currentUser.email = 'ryan@example.com';
+        authMockState.user = { uid: 'test-uid', isAnonymous: false };
+    };
+
+    const connectFetch = (url) => {
+        if (/v1\/user\/[^/]+$/.test(url)) {
+            return jsonResponse({ user_id: SLEEPER_USER_ID, display_name: 'ryangh' });
+        }
+        return mockFetch(url);
+    };
+
+    it('asks for a Sleeper username when no account is connected', async () => {
+        global.fetch = vi.fn(connectFetch);
+
+        render(<App />);
+
+        expect(await screen.findByLabelText(/sleeper username/i)).toBeInTheDocument();
+        // The whole point of the screen: there is no league to show behind it.
+        expect(screen.queryByText(/ryangh/)).not.toBeInTheDocument();
+    });
+
+    it('loads the account’s leagues once a username is connected', async () => {
+        global.fetch = vi.fn(connectFetch);
+
+        render(<App />);
+        const user = userEvent.setup();
+        await user.type(await screen.findByLabelText(/sleeper username/i), 'ryangh');
+        await user.click(screen.getByRole('button', { name: /^connect$/i }));
+
+        expect(await screen.findAllByText(/ryangh/, {}, { timeout: 5000 })).not.toHaveLength(0);
+        // Every league request must be built from the resolved id, not from
+        // any surviving constant.
+        expect(global.fetch.mock.calls.some(([url]) => url.includes(`/user/${SLEEPER_USER_ID}/leagues/`))).toBe(true);
+    });
+
+    it('keeps the account across a reload, so it is only typed once', async () => {
+        global.fetch = vi.fn(connectFetch);
+
+        const first = render(<App />);
+        const user = userEvent.setup();
+        await user.type(await screen.findByLabelText(/sleeper username/i), 'ryangh');
+        await user.click(screen.getByRole('button', { name: /^connect$/i }));
+        await screen.findAllByText(/ryangh/, {}, { timeout: 5000 });
+        first.unmount();
+
+        render(<App />);
+
+        await screen.findAllByText(/ryangh/, {}, { timeout: 5000 });
+        expect(screen.queryByLabelText(/sleeper username/i)).not.toBeInTheDocument();
+    });
+
+    // A failed league-list request and an account genuinely in no leagues both
+    // end with no league to open, and it is tempting to render one message for
+    // both. Telling someone mid-outage that they are in no leagues is wrong
+    // and leaves them nothing to do about it.
+    it('separates an account in no leagues from a Sleeper that would not answer', async () => {
+        window.localStorage.setItem('sleeper.account', JSON.stringify({ userId: SLEEPER_USER_ID, username: 'ryangh' }));
+        global.fetch = vi.fn((url) => (url.includes('leagues/nfl/') ? jsonResponse([]) : mockFetch(url)));
+
+        const empty = render(<App />);
+        expect(await screen.findByText(/isn't in any leagues/i, {}, { timeout: 5000 })).toBeInTheDocument();
+        empty.unmount();
+
+        global.fetch = vi.fn((url) =>
+            url.includes('leagues/nfl/') ? Promise.reject(new Error('Sleeper down')) : mockFetch(url),
+        );
+
+        render(<App />);
+        expect(await screen.findByText(/Couldn't load your league data/i, {}, { timeout: 5000 })).toBeInTheDocument();
+    });
+
+    // Roaming is the only reason the account is saved server-side, so the
+    // saved copy has to beat whatever this particular device had stored.
+    it('follows the signed-in account rather than the one left on this device', async () => {
+        window.localStorage.setItem('sleeper.account', JSON.stringify({ userId: '999', username: 'someone-else' }));
+        signIn();
+
+        global.fetch = vi.fn((url) => {
+            if (url.includes('/users/test-uid/sleeper_account')) {
+                return jsonResponse({ userId: SLEEPER_USER_ID, username: 'ryangh' });
+            }
+            if (url.includes('/users/test-uid')) {
+                return jsonResponse({});
+            }
+            return connectFetch(url);
+        });
+
+        render(<App />);
+
+        await screen.findAllByText(/ryangh/, {}, { timeout: 5000 });
+        expect(global.fetch.mock.calls.some(([url]) => url.includes(`/user/${SLEEPER_USER_ID}/leagues/`))).toBe(true);
+        expect(global.fetch.mock.calls.some(([url]) => url.includes('/user/999/leagues/'))).toBe(false);
+    });
+
+    // The saved account lives in the same `users/{uid}` record as every saved
+    // rank list, so an unfiltered read turns it into a phantom list in the
+    // switcher - one with no pretty_name, which renders as "dunno".
+    it('does not mistake the saved account for a saved rank list', async () => {
+        window.localStorage.setItem('sleeper.account', JSON.stringify({ userId: SLEEPER_USER_ID, username: 'ryangh' }));
+        signIn();
+
+        global.fetch = vi.fn((url) => {
+            if (url.includes('/users/test-uid/sleeper_account')) {
+                return jsonResponse({ userId: SLEEPER_USER_ID, username: 'ryangh' });
+            }
+            if (url.includes('/users/test-uid')) {
+                return jsonResponse({
+                    sleeper_account: { userId: SLEEPER_USER_ID, username: 'ryangh' },
+                    my_ranks: { pretty_name: 'My Ranks', route_name: 'my_ranks' },
+                });
+            }
+            return connectFetch(url);
+        });
+
+        render(<App />);
+        await screen.findAllByText(/ryangh/, {}, { timeout: 5000 });
+
+        await waitFor(() => expect(screen.queryByText('dunno')).not.toBeInTheDocument());
     });
 });

--- a/src/Components/AppBar.jsx
+++ b/src/Components/AppBar.jsx
@@ -17,8 +17,10 @@ const AppBar = ({
     signedIn,
     signedInEmail,
     myDisplayName,
+    sleeperUsername,
     onSignIn,
     onSignOut,
+    onDisconnectSleeper,
     sections,
     activeId,
     onNavigate,
@@ -125,8 +127,10 @@ const AppBar = ({
                     leagueCount={leagueIds ? leagueIds.length : 0}
                     signedIn={signedIn}
                     signedInEmail={signedInEmail}
+                    sleeperUsername={sleeperUsername}
                     onSignIn={onSignIn}
                     onSignOut={onSignOut}
+                    onDisconnectSleeper={onDisconnectSleeper}
                 />
             ) : null}
         </>

--- a/src/Components/AppBar.test.jsx
+++ b/src/Components/AppBar.test.jsx
@@ -17,6 +17,8 @@ function renderAppBar(overrides = {}) {
         myDisplayName: null,
         onSignIn: vi.fn(),
         onSignOut: vi.fn(),
+        sleeperUsername: null,
+        onDisconnectSleeper: vi.fn(),
         ...overrides,
     };
     const result = render(<AppBar {...props} />);
@@ -194,6 +196,63 @@ describe('AppBar', () => {
 
             expect(screen.getByText('SYNC')).toBeTruthy();
             expect(screen.getByText('SYNCING')).toBeTruthy();
+        });
+    });
+    // The connected Sleeper account is a second identity from the Google one:
+    // it decides whose leagues you see, not where your rank lists are saved.
+    // The drawer shows both, and they have to stay tellable apart.
+    describe('the connected Sleeper account', () => {
+        it('shows the connected username', async () => {
+            const user = userEvent.setup();
+            renderAppBar({ sleeperUsername: 'ryangh' });
+            await openDrawer(user);
+
+            expect(screen.getByText('ryangh')).toBeInTheDocument();
+            expect(screen.getByRole('button', { name: /disconnect/i })).toBeInTheDocument();
+        });
+
+        it('offers nothing to disconnect when no account is connected', async () => {
+            const user = userEvent.setup();
+            renderAppBar();
+            await openDrawer(user);
+
+            expect(screen.queryByRole('button', { name: /disconnect/i })).not.toBeInTheDocument();
+        });
+
+        // Disconnecting clears the account for the signed-in user everywhere,
+        // not just on this device, so a stray tap must not do it.
+        it('asks before disconnecting rather than acting on the first tap', async () => {
+            const user = userEvent.setup();
+            const { onDisconnectSleeper } = renderAppBar({ sleeperUsername: 'ryangh' });
+            await openDrawer(user);
+
+            await user.click(screen.getByRole('button', { name: /disconnect/i }));
+
+            expect(onDisconnectSleeper).not.toHaveBeenCalled();
+            expect(screen.getByText(/disconnect .ryangh./i)).toBeInTheDocument();
+        });
+
+        it('reports the disconnect to its caller once confirmed', async () => {
+            const user = userEvent.setup();
+            const { onDisconnectSleeper } = renderAppBar({ sleeperUsername: 'ryangh' });
+            await openDrawer(user);
+
+            await user.click(screen.getByRole('button', { name: /disconnect/i }));
+            await user.click(screen.getByRole('button', { name: 'Disconnect' }));
+
+            expect(onDisconnectSleeper).toHaveBeenCalledTimes(1);
+        });
+
+        it('backs out of the confirmation without disconnecting', async () => {
+            const user = userEvent.setup();
+            const { onDisconnectSleeper } = renderAppBar({ sleeperUsername: 'ryangh' });
+            await openDrawer(user);
+
+            await user.click(screen.getByRole('button', { name: /disconnect/i }));
+            await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+            expect(onDisconnectSleeper).not.toHaveBeenCalled();
+            expect(screen.getByText('ryangh')).toBeInTheDocument();
         });
     });
 });

--- a/src/Components/ConnectSleeper.jsx
+++ b/src/Components/ConnectSleeper.jsx
@@ -1,0 +1,114 @@
+import { useState } from 'react';
+
+const fieldClass = 'border-line bg-raised-2 text-ink caret-ink-muted rounded-row w-full border p-3 text-[14px]';
+const primaryPill = 'bg-mine text-ground min-h-11 rounded-full px-3.5 text-[13px] font-semibold disabled:opacity-50';
+
+// What the app shows before it is pointed at a Sleeper account - the state it
+// could never be in while the account was a hardcoded constant.
+//
+// It asks for a username rather than an id because that is the only thing
+// anyone knows about their own Sleeper account; the id it resolves to is an
+// implementation detail the user never sees. No password and no OAuth is not
+// an omission: Sleeper has no auth API at all, so this is a public lookup of
+// public league data, and the copy says so rather than implying a login.
+//
+// The three outcomes of that lookup are deliberately distinct. A name nobody
+// owns is the expected result of a typo and gets a "check the spelling"
+// message with no retry button, because retrying fails identically. A failed
+// request is the one worth retrying. A hit connects immediately.
+const ConnectSleeper = ({ onConnect, resolveUsername, signedIn, onSignIn }) => {
+    const [username, setUsername] = useState('');
+    const [status, setStatus] = useState(null);
+    const [busy, setBusy] = useState(false);
+
+    const trimmed = username.trim();
+
+    const submit = async (event) => {
+        event.preventDefault();
+        if (!trimmed || busy) {
+            return;
+        }
+        setBusy(true);
+        setStatus(null);
+        const account = await resolveUsername(trimmed);
+        setBusy(false);
+
+        if (account === undefined) {
+            setStatus({ kind: 'error', message: "Couldn't reach Sleeper. Check your connection and try again." });
+            return;
+        }
+        if (account === null) {
+            setStatus({ kind: 'notFound', message: `No Sleeper account named “${trimmed}”. Check the spelling.` });
+            return;
+        }
+        onConnect(account);
+    };
+
+    return (
+        <div className="mx-auto flex w-full max-w-[420px] flex-col gap-5 p-3.5 md:p-4">
+            <div className="bg-raised border-line rounded-card flex flex-col gap-4 border p-[18px]">
+                <div className="flex flex-col gap-1.5">
+                    <h1 className="text-ink m-0 text-[19px] font-bold tracking-[-0.02em]">Connect your Sleeper</h1>
+                    <p className="text-ink-muted m-0 text-[13px]">
+                        Enter your Sleeper username to load your leagues, rosters and drafts.
+                    </p>
+                </div>
+
+                <form onSubmit={submit} className="flex flex-col gap-2">
+                    <label
+                        htmlFor="sleeper-username"
+                        className="text-ink-dim m-0 font-mono text-[11px] tracking-[.08em]"
+                    >
+                        SLEEPER USERNAME
+                    </label>
+                    <input
+                        id="sleeper-username"
+                        type="text"
+                        autoComplete="username"
+                        autoCapitalize="none"
+                        autoCorrect="off"
+                        spellCheck="false"
+                        placeholder="yourname"
+                        className={fieldClass}
+                        value={username}
+                        onChange={(event) => setUsername(event.target.value)}
+                        aria-describedby={status ? 'sleeper-username-status' : undefined}
+                        aria-invalid={status ? true : undefined}
+                    />
+                    <button type="submit" disabled={!trimmed || busy} className={primaryPill}>
+                        {busy ? 'Looking up…' : 'Connect'}
+                    </button>
+                </form>
+
+                {status ? (
+                    <p
+                        id="sleeper-username-status"
+                        role="alert"
+                        className={`m-0 text-[12px] ${status.kind === 'error' ? 'text-danger' : 'text-ink-muted'}`}
+                    >
+                        {status.message}
+                    </p>
+                ) : null}
+
+                <p className="text-ink-quiet m-0 font-mono text-[10px]">
+                    This is a public lookup of your Sleeper leagues. No password, and nothing is posted to Sleeper.
+                </p>
+            </div>
+
+            {/* Sign-in is genuinely optional, so it is offered here rather than
+                gating the form above. The only thing it buys is named on the
+                line: saved rank lists, and the account following you between
+                devices. */}
+            {!signedIn ? (
+                <p className="text-ink-quiet m-0 px-1 text-[12px]">
+                    <button type="button" onClick={onSignIn} className="text-ink font-medium underline">
+                        Sign in with Google
+                    </button>{' '}
+                    to save rank lists and keep this account across devices.
+                </p>
+            ) : null}
+        </div>
+    );
+};
+
+export default ConnectSleeper;

--- a/src/Components/ConnectSleeper.test.jsx
+++ b/src/Components/ConnectSleeper.test.jsx
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ConnectSleeper from './ConnectSleeper';
+
+const ACCOUNT = { userId: '521035584588267520', username: 'ryangh' };
+
+const renderConnect = (overrides = {}) => {
+    const props = {
+        onConnect: vi.fn(),
+        resolveUsername: vi.fn().mockResolvedValue(ACCOUNT),
+        signedIn: false,
+        onSignIn: vi.fn(),
+        ...overrides,
+    };
+    render(<ConnectSleeper {...props} />);
+    return props;
+};
+
+const typeAndSubmit = async (username) => {
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/sleeper username/i), username);
+    await user.click(screen.getByRole('button', { name: /^connect$/i }));
+};
+
+describe('ConnectSleeper', () => {
+    it('connects the account the username resolves to', async () => {
+        const { onConnect, resolveUsername } = renderConnect();
+
+        await typeAndSubmit('ryangh');
+
+        expect(resolveUsername).toHaveBeenCalledWith('ryangh');
+        expect(onConnect).toHaveBeenCalledWith(ACCOUNT);
+    });
+
+    // Leading/trailing whitespace is what you get from a paste or a phone
+    // keyboard's autocomplete, and Sleeper 404s on it.
+    it('trims the typed username before looking it up', async () => {
+        const { resolveUsername } = renderConnect();
+
+        await typeAndSubmit('  ryangh  ');
+
+        expect(resolveUsername).toHaveBeenCalledWith('ryangh');
+    });
+
+    // The two failure modes have to read differently. A typo is the common
+    // case and retrying it fails identically, so the message says to check the
+    // spelling; an unreachable API is the one worth trying again.
+    it('says to check the spelling when nobody owns the username', async () => {
+        const { onConnect } = renderConnect({ resolveUsername: vi.fn().mockResolvedValue(null) });
+
+        await typeAndSubmit('nobdy');
+
+        expect(await screen.findByRole('alert')).toHaveTextContent(/check the spelling/i);
+        expect(onConnect).not.toHaveBeenCalled();
+    });
+
+    it('reports an unreachable Sleeper as a retryable problem instead', async () => {
+        const { onConnect } = renderConnect({ resolveUsername: vi.fn().mockResolvedValue(undefined) });
+
+        await typeAndSubmit('ryangh');
+
+        expect(await screen.findByRole('alert')).toHaveTextContent(/couldn't reach sleeper/i);
+        expect(onConnect).not.toHaveBeenCalled();
+    });
+
+    it('does not look anything up for an empty username', async () => {
+        const { resolveUsername } = renderConnect();
+
+        await userEvent.setup().click(screen.getByRole('button', { name: /^connect$/i }));
+
+        expect(resolveUsername).not.toHaveBeenCalled();
+    });
+
+    // Sign-in is genuinely optional here - connecting a Sleeper account works
+    // signed out - so the offer is an aside, and it goes away once taken.
+    it('offers Google sign-in to a signed-out visitor', async () => {
+        const { onSignIn } = renderConnect();
+
+        await userEvent.setup().click(screen.getByRole('button', { name: /sign in with google/i }));
+
+        expect(onSignIn).toHaveBeenCalled();
+    });
+
+    it('does not offer sign-in to someone already signed in', () => {
+        renderConnect({ signedIn: true });
+
+        expect(screen.queryByRole('button', { name: /sign in with google/i })).not.toBeInTheDocument();
+    });
+});

--- a/src/Components/Drawer.jsx
+++ b/src/Components/Drawer.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useBodyScrollLock } from '../useBodyScrollLock.js';
 import { SECTIONS, PLANNED_SECTIONS } from '../sections.js';
 import { avatarInitials } from './avatarInitials.js';
@@ -24,10 +24,13 @@ const Drawer = ({
     leagueCount = 0,
     signedIn,
     signedInEmail,
+    sleeperUsername,
     onSignIn,
     onSignOut,
+    onDisconnectSleeper,
 }) => {
     const panelRef = useRef(null);
+    const [confirmingDisconnect, setConfirmingDisconnect] = useState(false);
 
     useBodyScrollLock();
 
@@ -125,6 +128,58 @@ const Drawer = ({
 
                 <div className="mt-auto flex flex-col gap-3">
                     <div className="bg-line-mid h-px w-full" />
+
+                    {/* The connected Sleeper account, kept visually separate
+                        from the sign-in block below because they are two
+                        different identities: this one decides whose leagues
+                        you are looking at, that one decides where your rank
+                        lists are saved. Disconnecting clears the account
+                        everywhere, not just on this device, which is why it
+                        asks first. */}
+                    {sleeperUsername ? (
+                        confirmingDisconnect ? (
+                            <div className="border-line rounded-row flex flex-col gap-2.5 border p-3">
+                                <p className="text-ink m-0 text-[13px]">
+                                    Disconnect “{sleeperUsername}”? Your saved rank lists stay.
+                                </p>
+                                <div className="flex gap-2">
+                                    <button
+                                        type="button"
+                                        onClick={() => {
+                                            setConfirmingDisconnect(false);
+                                            onDisconnectSleeper?.();
+                                            onClose();
+                                        }}
+                                        className="bg-danger text-ground min-h-11 rounded-full px-3.5 text-[13px] font-semibold"
+                                    >
+                                        Disconnect
+                                    </button>
+                                    <button
+                                        type="button"
+                                        onClick={() => setConfirmingDisconnect(false)}
+                                        className="border-line text-ink-muted min-h-11 rounded-full border px-3.5 text-[13px] font-semibold"
+                                    >
+                                        Cancel
+                                    </button>
+                                </div>
+                            </div>
+                        ) : (
+                            <div className="min-w-0">
+                                <p className="text-ink m-0 truncate text-[13px] font-medium">{sleeperUsername}</p>
+                                <p className="text-ink-quiet m-0 font-mono text-[10px]">
+                                    Sleeper ·{' '}
+                                    <button
+                                        type="button"
+                                        onClick={() => setConfirmingDisconnect(true)}
+                                        className="underline"
+                                    >
+                                        disconnect
+                                    </button>
+                                </p>
+                            </div>
+                        )
+                    ) : null}
+
                     {signedIn ? (
                         <div className="flex items-center gap-3">
                             <span className="bg-raised-2 border-line text-ink-muted flex h-8 w-8 shrink-0 items-center justify-center rounded-full border font-mono text-[11px] font-semibold">

--- a/src/Panels/DraftPanel.jsx
+++ b/src/Panels/DraftPanel.jsx
@@ -10,7 +10,7 @@ import ClockCard from '../Components/ClockCard';
 import DraftSourceSheet, { readLastMock, writeLastMock } from './DraftSourceSheet';
 import RankListSwitcher from '../Components/RankListSwitcher';
 import { managerLabel, pickNumberLabel } from './pickLabels.js';
-import { SLEEPER_API_URLS, SLEEPER_USER_ID } from '../urls';
+import { SLEEPER_API_URLS } from '../urls';
 import { fetchAvailability } from '../lib/sleeperApi.js';
 import { syncLiveDraft } from '../lib/liveDraft.js';
 import { pollIntervalMs } from '../lib/draftClock.js';
@@ -38,6 +38,7 @@ const DraftPanel = ({
     rosterInfo,
     rankingPlayersIdsList,
     myDisplayName,
+    sleeperUserId,
     updateDraftBoard,
     savedRankLists,
     savedRankListsLoading,
@@ -149,14 +150,18 @@ const DraftPanel = ({
     // What does go stale is the board itself - who is still to pick, and who
     // is already gone - and that is what `picksMade` changing means.
     useEffect(() => {
-        if (!isBestAvailableOpen || intelPlayerIds.length === 0) {
+        // No connected account means no "will he last to my pick" to answer -
+        // the whole response is relative to one manager's remaining picks -
+        // and sending `user_id=undefined` would ask the API a question about
+        // nobody rather than failing outright.
+        if (!isBestAvailableOpen || intelPlayerIds.length === 0 || !sleeperUserId) {
             return;
         }
         let cancelled = false;
 
         fetchAvailability({
             draftId: currentDraftId,
-            userId: SLEEPER_USER_ID,
+            userId: sleeperUserId,
             playerIds: intelPlayerIds,
         }).then((response) => {
             // Resolves to undefined on any failure, and intel is additive, so
@@ -170,7 +175,7 @@ const DraftPanel = ({
         return () => {
             cancelled = true;
         };
-    }, [isBestAvailableOpen, currentDraftId, picksMade, intelPlayerIds]);
+    }, [isBestAvailableOpen, currentDraftId, picksMade, intelPlayerIds, sleeperUserId]);
 
     const onTheClock = nextUnpickedPick(currentDraft.built_draft);
     // null, not a "nobody is up" sentence: ClockCard reads this as the signal

--- a/src/Panels/DraftPanel.test.jsx
+++ b/src/Panels/DraftPanel.test.jsx
@@ -27,6 +27,9 @@ const rosterData = decorateRosters({ rosterData: rosterDataRaw, managerData });
 const rosterInfo = buildRosterInfo({ rosterData, builtDraft: null });
 
 const DRAFT_ID = 'draft123';
+// The connected Sleeper account these tests act as - a prop now that the panel
+// no longer imports a hardcoded id.
+const SLEEPER_USER_ID = '521035584588267520';
 const FREE_AGENT = { id: '13307', name: 'Marlin Klein' };
 
 const jsonResponse = (data) => Promise.resolve({ ok: true, json: () => Promise.resolve(data) });
@@ -83,6 +86,10 @@ function renderPanel(overrides = {}) {
         playerInfo,
         rosterInfo,
         rankingPlayersIdsList: [rankEntry(FREE_AGENT.id)],
+        // Leaguemate intel is answered relative to one manager's remaining
+        // picks, so the panel asks for none without a connected account. This
+        // used to be a hardcoded constant inside the panel.
+        sleeperUserId: SLEEPER_USER_ID,
         updateDraftBoard,
         ...overrides,
     };

--- a/src/Panels/LeaguePanel.jsx
+++ b/src/Panels/LeaguePanel.jsx
@@ -12,6 +12,7 @@ const LeaguePanel = ({
     rankingPlayersIdsList,
     updateDraftBoard,
     myDisplayName,
+    sleeperUserId,
     addToRoster,
     fillSlot,
     savedRankLists,
@@ -54,6 +55,7 @@ const LeaguePanel = ({
                             rosterInfo={rosterInfo}
                             rankingPlayersIdsList={rankingPlayersIdsList}
                             myDisplayName={myDisplayName}
+                            sleeperUserId={sleeperUserId}
                             updateDraftBoard={updateDraftBoard}
                             savedRankLists={savedRankLists}
                             savedRankListsLoading={savedRankListsLoading}

--- a/src/lib/sleeperApi.js
+++ b/src/lib/sleeperApi.js
@@ -3,7 +3,8 @@ import { decorateRosters } from './rosterInfo.js';
 import { resolveLeagueSeason } from './sleeper.js';
 import APP_DB_URLS, { SLEEPER_API_URLS } from '../urls.js';
 const { ACTIVE_PLAYERS, AVAILABILITY, LEAGUE_INTEL, MANAGER_ACTIVITY } = APP_DB_URLS;
-const { LEAGUE, USER_LEAGUES, NFL_STATE, DRAFT, ROSTERS, SLEEPER_USERS, TRADED_PICKS, DRAFTS } = SLEEPER_API_URLS;
+const { LEAGUE, USER_LEAGUES, USER_BY_NAME, NFL_STATE, DRAFT, ROSTERS, SLEEPER_USERS, TRADED_PICKS, DRAFTS } =
+    SLEEPER_API_URLS;
 
 // Every function here returns its data instead of writing it to state. That is
 // the point of the module, not a stylistic preference: the two bugs in #96 and
@@ -43,18 +44,68 @@ export async function fetchLeagueSeason() {
 }
 
 /**
+ * Resolves a typed Sleeper username to the account behind it.
+ *
+ * Three-way on purpose, because the caller has three different things to say.
+ * A found account resolves to `{ userId, username }`; a username nobody owns
+ * resolves to `null`; a failed request resolves to `undefined` per this
+ * module's contract. "No such user" is not an error - it is the single most
+ * likely outcome of typing a name by hand, and the connect form tells you to
+ * check the spelling rather than offering a retry that would fail identically.
+ *
+ * Sleeper signals the not-found case with a 200 carrying a literal `null`
+ * body, not a 404, so it arrives here as a successful request with nothing in
+ * it. Checking the body is the only way to see it.
+ */
+export async function fetchSleeperUser(username) {
+    const account = await fetch(USER_BY_NAME(username))
+        .then(checkErrors)
+        .then((response) => response.json())
+        .catch((error) => {
+            console.error('Error resolving Sleeper username:', error);
+        });
+
+    if (account === undefined) {
+        return undefined;
+    }
+    if (!account || !account.user_id) {
+        return null;
+    }
+    // The id is kept as the string Sleeper sends. It is numeric and long
+    // enough to lose precision as a Number, and the whole app is keyed by it.
+    return { userId: String(account.user_id), username: account.display_name || username };
+}
+
+/**
+ * Every league the connected account is in for a season.
+ *
+ * Split out of the league bundle below, which used to fetch this alongside the
+ * rest. It has to come first now: with no hardcoded league id left, this list
+ * is what the app picks the starting league *from*, so it can no longer be one
+ * of the parallel requests that assumes a league was already chosen.
+ */
+export async function fetchUserLeagues({ userId, season }) {
+    return await fetch(USER_LEAGUES(userId, season))
+        .then(checkErrors)
+        .then((response) => response.json())
+        .catch((error) => {
+            console.error('Error fetching leagues for this Sleeper account:', error);
+        });
+}
+
+/**
  * The five league requests that always travel together, resolved in parallel
  * and returned as one object with rosters already decorated. Resolves to
  * `undefined` if any of them fails - a partial league is not useful, and
  * silently rendering one is how a wrong board reaches the screen.
  */
-export async function fetchLeagueBundle({ leagueID, season }) {
+export async function fetchLeagueBundle({ leagueID, season, userId }) {
     const LEAGUE_PATH = LEAGUE + leagueID + '/';
     const urls = [
         LEAGUE_PATH + ROSTERS,
         LEAGUE_PATH + SLEEPER_USERS,
         LEAGUE_PATH,
-        USER_LEAGUES(season),
+        USER_LEAGUES(userId, season),
         LEAGUE_PATH + DRAFTS,
     ];
 

--- a/src/lib/sleeperApi.test.js
+++ b/src/lib/sleeperApi.test.js
@@ -7,7 +7,9 @@ import {
     fetchLeagueBundle,
     fetchLeagueSeason,
     fetchPlayerData,
+    fetchSleeperUser,
     fetchTradedDraftPicks,
+    fetchUserLeagues,
 } from './sleeperApi.js';
 import rosterFlagsFixture from './__fixtures__/roster-flags-2026.json';
 
@@ -255,6 +257,66 @@ describe('sleeperApi', () => {
             global.fetch = vi.fn(() => jsonResponse(body));
 
             expect(await fetchAvailability({ draftId: 'draft123', userId: '99' })).toEqual(body);
+        });
+    });
+    describe('fetchSleeperUser', () => {
+        // The three outcomes are the whole point of this function: the connect
+        // form says something different for each, and collapsing any two of
+        // them tells the user to retry something that cannot succeed, or
+        // reports a typo as an outage.
+        it('resolves a username to the account behind it', async () => {
+            global.fetch = vi.fn(() => jsonResponse({ user_id: '521035584588267520', display_name: 'ryangh' }));
+
+            expect(await fetchSleeperUser('ryangh')).toEqual({ userId: '521035584588267520', username: 'ryangh' });
+        });
+
+        // Sleeper answers an unknown username with 200 and a literal `null`
+        // body rather than a 404, so this arrives as a *successful* request
+        // with nothing in it. Reading the status alone would call it a hit.
+        it('resolves to null for a username nobody owns', async () => {
+            global.fetch = vi.fn(() => jsonResponse(null));
+
+            expect(await fetchSleeperUser('nobody')).toBeNull();
+        });
+
+        it('resolves to undefined when the request fails, which is the retryable case', async () => {
+            global.fetch = vi.fn(() => Promise.reject(new Error('offline')));
+
+            expect(await fetchSleeperUser('ryangh')).toBeUndefined();
+        });
+
+        // Sleeper sends ids as JSON strings, and that is load-bearing rather
+        // than incidental: they are past Number.MAX_SAFE_INTEGER, so anything
+        // that routes one through a JS number has already silently changed the
+        // last digits and now names a different manager. Nothing here can undo
+        // that, so what this pins is that the string arrives verbatim.
+        it('passes the id through as the exact string Sleeper sent', async () => {
+            global.fetch = vi.fn(() => jsonResponse({ user_id: '521035584588267520', display_name: 'ryangh' }));
+
+            const { userId } = await fetchSleeperUser('ryangh');
+            expect(userId).toBe('521035584588267520');
+            expect(String(Number(userId))).not.toBe(userId);
+        });
+
+        it('falls back to the typed name when the account has no display name', async () => {
+            global.fetch = vi.fn(() => jsonResponse({ user_id: '1' }));
+
+            expect((await fetchSleeperUser('Typed_Name')).username).toBe('Typed_Name');
+        });
+    });
+
+    describe('fetchUserLeagues', () => {
+        it('asks for the leagues of the account it is given', async () => {
+            global.fetch = vi.fn(() => jsonResponse([{ league_id: '1' }]));
+
+            expect(await fetchUserLeagues({ userId: '999', season: '2026' })).toEqual([{ league_id: '1' }]);
+            expect(global.fetch.mock.calls[0][0]).toBe('https://api.sleeper.app/v1/user/999/leagues/nfl/2026');
+        });
+
+        it("resolves to undefined on failure, per this module's contract", async () => {
+            global.fetch = vi.fn(() => Promise.reject(new Error('offline')));
+
+            expect(await fetchUserLeagues({ userId: '999', season: '2026' })).toBeUndefined();
         });
     });
 });

--- a/src/lib/sleeperIdentity.js
+++ b/src/lib/sleeperIdentity.js
@@ -1,0 +1,175 @@
+import { checkErrors, fetchRequest } from './http.js';
+import APP_DB_URLS from '../urls.js';
+
+const { APP_USERS, TYPE_PARAMS } = APP_DB_URLS;
+
+// Which Sleeper account the app is pointed at. This is a second, independent
+// identity from the Firebase one: Firebase says who you are to *this app* and
+// owns your saved rank lists, while this says whose leagues, rosters and picks
+// to render. They are deliberately not the same thing - Sleeper has no OAuth,
+// so there is no way to prove the person holding a Google account owns the
+// Sleeper username they typed, and pretending otherwise would be a claim the
+// app cannot back up. Connecting an account is "show me this manager's
+// leagues", not "log in as them".
+//
+// Because of that split, a connected account has to survive with no Firebase
+// sign-in at all, which is what localStorage is for below. Signing in with
+// Google adds roaming on top, nothing more.
+
+export const SLEEPER_ACCOUNT_KEY = 'sleeper.account';
+
+// The key the account is stored under inside the `users/{uid}` record. That
+// record is also where every saved rank list lives, keyed by its route name,
+// so this name is reserved - see readSavedRankLists in App for the read side
+// that has to keep the two apart.
+export const REMOTE_ACCOUNT_KEY = 'sleeper_account';
+
+/**
+ * Narrows an arbitrary value to a usable account, or null. Both storage sides
+ * run everything they read through this: localStorage is user-editable, the
+ * database record predates this feature, and a half-written account is worse
+ * than none - it would send `undefined` into a Sleeper URL and 404 every
+ * league request with no obvious cause.
+ */
+export function normalizeAccount(value) {
+    if (!value || typeof value !== 'object') {
+        return null;
+    }
+    const { userId, username } = value;
+    // Sleeper ids are numeric but must stay strings: they exceed Number's safe
+    // integer range, so a round trip through a number silently corrupts the
+    // last digits and every request built from it quietly asks about someone
+    // else.
+    if (typeof userId !== 'string' || userId === '') {
+        return null;
+    }
+    return { userId, username: typeof username === 'string' && username ? username : null };
+}
+
+/**
+ * The connected account for a signed-out visitor, and the fallback for a
+ * signed-in one whose database record has nothing in it yet.
+ */
+export function readLocalAccount() {
+    try {
+        return normalizeAccount(JSON.parse(window.localStorage.getItem(SLEEPER_ACCOUNT_KEY)));
+    } catch (error) {
+        // Unparseable, or storage blocked entirely (Safari private mode throws
+        // on access, not just on write). Either way the app is simply not
+        // connected yet, which is a state it already renders.
+        console.error('Could not read the stored Sleeper account:', error);
+        return null;
+    }
+}
+
+export function writeLocalAccount(account) {
+    try {
+        if (account) {
+            window.localStorage.setItem(SLEEPER_ACCOUNT_KEY, JSON.stringify(account));
+        } else {
+            window.localStorage.removeItem(SLEEPER_ACCOUNT_KEY);
+        }
+        return true;
+    } catch (error) {
+        console.error('Could not store the Sleeper account:', error);
+        return false;
+    }
+}
+
+/**
+ * The signed-in user's account as the database has it. Resolves to `undefined`
+ * on failure rather than null, so callers can tell "the request failed" from
+ * "this user has not connected one" - the difference matters, because
+ * promoting a local account on a failed read would overwrite a good remote one
+ * with whatever this device happened to have.
+ */
+export async function readRemoteAccount(user) {
+    const result = await fetch(
+        APP_USERS + user.uid + '/' + REMOTE_ACCOUNT_KEY + TYPE_PARAMS + (await user.getIdToken()),
+    )
+        .then(checkErrors)
+        .then((response) => response.json())
+        .catch((error) => {
+            console.error('Could not read the saved Sleeper account:', error);
+            return undefined;
+        });
+    return result === undefined ? undefined : normalizeAccount(result);
+}
+
+export async function writeRemoteAccount(user, account) {
+    const url = APP_USERS + user.uid + '/' + REMOTE_ACCOUNT_KEY + TYPE_PARAMS + (await user.getIdToken());
+    const response = account ? await fetchRequest(url, 'PUT', account) : await fetchRequest(url, 'DELETE');
+    return Boolean(response && response.ok);
+}
+
+const LAST_LEAGUE_KEY = 'sleeper.lastLeague';
+
+/**
+ * The league this account was last looking at. Keyed by Sleeper user id, so
+ * two accounts used on one browser do not inherit each other's league.
+ *
+ * This exists because the starting league used to be a hardcoded id: you
+ * always reopened the app on the same league, and picking "whatever Sleeper
+ * lists first" instead would have quietly made that stop being true.
+ */
+export function readLastLeagueId(userId) {
+    try {
+        const byUser = JSON.parse(window.localStorage.getItem(LAST_LEAGUE_KEY));
+        const leagueId = byUser && typeof byUser === 'object' ? byUser[userId] : null;
+        return typeof leagueId === 'string' && leagueId ? leagueId : null;
+    } catch (error) {
+        console.error('Could not read the last league:', error);
+        return null;
+    }
+}
+
+export function writeLastLeagueId(userId, leagueId) {
+    try {
+        const raw = JSON.parse(window.localStorage.getItem(LAST_LEAGUE_KEY));
+        const byUser = raw && typeof raw === 'object' ? raw : {};
+        window.localStorage.setItem(LAST_LEAGUE_KEY, JSON.stringify({ ...byUser, [userId]: leagueId }));
+    } catch (error) {
+        console.error('Could not store the last league:', error);
+    }
+}
+
+/**
+ * Which league to open on: the one this account was last on, but only if they
+ * are still in it - a league that was left, or that has rolled over to a new
+ * season, is no longer in the list and would otherwise load into an error.
+ * Falls back to Sleeper's own first league, and to null when there are none.
+ */
+export function pickStartingLeague({ leagues, lastLeagueId }) {
+    if (!Array.isArray(leagues) || leagues.length === 0) {
+        return null;
+    }
+    const remembered = leagues.find((league) => league.league_id === lastLeagueId);
+    return remembered ? remembered.league_id : leagues[0].league_id;
+}
+
+/**
+ * Which account wins when a device has one stored locally and the signed-in
+ * user has one saved in the database, and what to write back afterwards.
+ *
+ * The remote one wins, because roaming is the only reason it exists: if you
+ * connected an account on your phone, opening the app on a laptop that was
+ * pointed somewhere else should follow your account, not have the laptop
+ * quietly overwrite it. When there is no remote one, the local account is
+ * promoted up instead, so connecting-then-signing-in doesn't lose the account
+ * you just typed.
+ *
+ * Pure and separate from the storage above so the precedence can be tested
+ * without a database or a browser - it is the part with actual behaviour in
+ * it, and the part that is easy to get backwards.
+ */
+export function reconcileAccounts({ local, remote }) {
+    // `undefined` means the read failed, which is not evidence that the user
+    // has no saved account - so do not promote over it.
+    if (remote === undefined) {
+        return { account: local || null, promote: false };
+    }
+    if (remote) {
+        return { account: remote, promote: false };
+    }
+    return { account: local || null, promote: Boolean(local) };
+}

--- a/src/lib/sleeperIdentity.test.js
+++ b/src/lib/sleeperIdentity.test.js
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest';
+import {
+    SLEEPER_ACCOUNT_KEY,
+    normalizeAccount,
+    pickStartingLeague,
+    readLastLeagueId,
+    readLocalAccount,
+    reconcileAccounts,
+    writeLastLeagueId,
+    writeLocalAccount,
+} from './sleeperIdentity.js';
+
+const ACCOUNT = { userId: '521035584588267520', username: 'ryangh' };
+const OTHER = { userId: '325371992242946048', username: 'kpresley' };
+
+describe('normalizeAccount', () => {
+    it('keeps a well-formed account', () => {
+        expect(normalizeAccount(ACCOUNT)).toEqual(ACCOUNT);
+    });
+
+    // The id is what every league URL is built from, so a missing or wrongly
+    // typed one has to fail here rather than reaching a request as `undefined`
+    // and 404ing with no obvious cause.
+    it.each([
+        ['null', null],
+        ['a string', 'ryangh'],
+        ['an account with no id', { username: 'ryangh' }],
+        ['an account with an empty id', { userId: '', username: 'ryangh' }],
+    ])('rejects %s', (_label, value) => {
+        expect(normalizeAccount(value)).toBeNull();
+    });
+
+    // Sleeper ids are past Number.MAX_SAFE_INTEGER, so a numeric one has
+    // already lost its last digits by the time it gets here - it would name a
+    // different manager, silently.
+    it('rejects a numeric id rather than coercing it', () => {
+        expect(normalizeAccount({ userId: 521035584588267520, username: 'ryangh' })).toBeNull();
+    });
+
+    it('tolerates a missing username, which is only ever displayed', () => {
+        expect(normalizeAccount({ userId: '123' })).toEqual({ userId: '123', username: null });
+    });
+});
+
+describe('local storage', () => {
+    beforeEach(() => {
+        window.localStorage.clear();
+        vi.spyOn(console, 'error').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        vi.restoreAllMocks();
+    });
+
+    it('round-trips a connected account', () => {
+        writeLocalAccount(ACCOUNT);
+        expect(readLocalAccount()).toEqual(ACCOUNT);
+    });
+
+    it('reads nothing when no account has been connected', () => {
+        expect(readLocalAccount()).toBeNull();
+    });
+
+    it('clears the account when written null', () => {
+        writeLocalAccount(ACCOUNT);
+        writeLocalAccount(null);
+        expect(readLocalAccount()).toBeNull();
+    });
+
+    // localStorage is user-editable and survives across app versions, so this
+    // is a real input, not a hypothetical one.
+    it('treats unparseable stored data as not connected', () => {
+        window.localStorage.setItem(SLEEPER_ACCOUNT_KEY, 'not json');
+        expect(readLocalAccount()).toBeNull();
+    });
+
+    it('treats a half-written account as not connected', () => {
+        window.localStorage.setItem(SLEEPER_ACCOUNT_KEY, JSON.stringify({ username: 'ryangh' }));
+        expect(readLocalAccount()).toBeNull();
+    });
+
+    it('reports failure rather than throwing when storage is unavailable', () => {
+        vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+            throw new Error('QuotaExceededError');
+        });
+        expect(writeLocalAccount(ACCOUNT)).toBe(false);
+    });
+
+    it('remembers the last league per account, so two accounts do not collide', () => {
+        writeLastLeagueId(ACCOUNT.userId, 'league-a');
+        writeLastLeagueId(OTHER.userId, 'league-b');
+
+        expect(readLastLeagueId(ACCOUNT.userId)).toBe('league-a');
+        expect(readLastLeagueId(OTHER.userId)).toBe('league-b');
+    });
+
+    it('has no last league for an account that has not picked one', () => {
+        expect(readLastLeagueId(ACCOUNT.userId)).toBeNull();
+    });
+});
+
+describe('pickStartingLeague', () => {
+    const leagues = [{ league_id: 'first' }, { league_id: 'second' }];
+
+    it('opens on the league this account was last on', () => {
+        expect(pickStartingLeague({ leagues, lastLeagueId: 'second' })).toBe('second');
+    });
+
+    // The remembered league can name one they have left, or last season's copy
+    // of one they are still in. Both are absent from the list, and loading
+    // either would land on an error page instead of a league.
+    it('falls back to the first league when the remembered one is gone', () => {
+        expect(pickStartingLeague({ leagues, lastLeagueId: 'deleted' })).toBe('first');
+    });
+
+    it('opens on the first league when nothing is remembered', () => {
+        expect(pickStartingLeague({ leagues, lastLeagueId: null })).toBe('first');
+    });
+
+    it('has nothing to open when the account is in no leagues', () => {
+        expect(pickStartingLeague({ leagues: [], lastLeagueId: null })).toBeNull();
+    });
+
+    // fetchUserLeagues resolves to undefined on failure, per the api module's
+    // contract, and this is the thing that receives it.
+    it('has nothing to open when the league request failed', () => {
+        expect(pickStartingLeague({ leagues: undefined, lastLeagueId: 'second' })).toBeNull();
+    });
+});
+
+describe('reconcileAccounts', () => {
+    // Roaming is the only reason the saved copy exists: a laptop pointed
+    // somewhere else must follow the signed-in account, not overwrite it.
+    it('prefers the saved account over the one on this device', () => {
+        expect(reconcileAccounts({ local: OTHER, remote: ACCOUNT })).toEqual({ account: ACCOUNT, promote: false });
+    });
+
+    it('promotes the local account when the user has none saved yet', () => {
+        expect(reconcileAccounts({ local: ACCOUNT, remote: null })).toEqual({ account: ACCOUNT, promote: true });
+    });
+
+    it('has nothing to do when neither side has one', () => {
+        expect(reconcileAccounts({ local: null, remote: null })).toEqual({ account: null, promote: false });
+    });
+
+    // The distinction this whole three-way exists for: `undefined` is a failed
+    // read, not an absent account. Promoting over it would overwrite a good
+    // saved account with whatever this device happened to have.
+    it('does not promote over a failed read of the saved account', () => {
+        expect(reconcileAccounts({ local: OTHER, remote: undefined })).toEqual({ account: OTHER, promote: false });
+    });
+
+    it('still renders the local account when the saved read failed', () => {
+        expect(reconcileAccounts({ local: ACCOUNT, remote: undefined }).account).toEqual(ACCOUNT);
+    });
+});

--- a/src/urls.js
+++ b/src/urls.js
@@ -16,8 +16,7 @@ const sleeperAPI = 'https://api.sleeper.app/';
 const V1 = 'v1/';
 const LEAGUE = 'league/';
 const DRAFT = 'draft/';
-const SLEEPER_USER_ID = '521035584588267520';
-const USER = 'user/' + SLEEPER_USER_ID + '/';
+const USER = 'user/';
 const ROSTERS = 'rosters/';
 const SLEEPER_USERS = 'users/';
 const LEAGUES = 'leagues/nfl/';
@@ -51,7 +50,14 @@ const APP_DB_URLS = {
 
 const SLEEPER_API_URLS = {
     LEAGUE: sleeperAPI + V1 + LEAGUE,
-    USER_LEAGUES: (season) => sleeperAPI + V1 + USER + LEAGUES + season,
+    // Both keyed by the connected Sleeper account rather than a constant: the
+    // app used to be pinned to one hardcoded user id, and every one of these
+    // is a place that pinning leaked into a URL.
+    USER_LEAGUES: (userId, season) => sleeperAPI + V1 + USER + userId + '/' + LEAGUES + season,
+    // Sleeper has no OAuth, so a username lookup is the whole "connect your
+    // account" handshake: this resolves the name someone types to the
+    // `user_id` every other request here is built from.
+    USER_BY_NAME: (username) => sleeperAPI + V1 + USER + encodeURIComponent(username),
     NFL_STATE: sleeperAPI + V1 + STATE,
     DRAFT: sleeperAPI + V1 + DRAFT,
     ROSTERS: ROSTERS,
@@ -62,4 +68,4 @@ const SLEEPER_API_URLS = {
 };
 
 export default APP_DB_URLS;
-export { SLEEPER_API_URLS, SLEEPER_USER_ID };
+export { SLEEPER_API_URLS };

--- a/src/urls.test.js
+++ b/src/urls.test.js
@@ -1,24 +1,39 @@
 import { describe, expect, it } from 'vitest';
-import APP_DB_URLS, { SLEEPER_API_URLS, SLEEPER_USER_ID } from './urls.js';
+import APP_DB_URLS, { SLEEPER_API_URLS } from './urls.js';
 
 describe('SLEEPER_API_URLS.USER_LEAGUES', () => {
-    // Pinned to the exact string the previous hardcoded ALL_LEAGUES_ACTIVE_YEAR
-    // produced, so swapping the hand-edited YEAR constant for a season derived
-    // from the API provably did not change the endpoint being called.
-    it('builds the same URL the hardcoded 2026 constant used to produce', () => {
-        expect(SLEEPER_API_URLS.USER_LEAGUES('2026')).toBe(
+    // Still pinned to the exact string the old hardcoded user id produced, with
+    // that id now passed in: the app went multi-user by taking the account as
+    // an argument, and this proves the endpoint itself did not move.
+    it('builds the same URL the hardcoded user id used to produce', () => {
+        expect(SLEEPER_API_URLS.USER_LEAGUES('521035584588267520', '2026')).toBe(
             'https://api.sleeper.app/v1/user/521035584588267520/leagues/nfl/2026',
         );
     });
 
-    it('varies only by season', () => {
-        expect(SLEEPER_API_URLS.USER_LEAGUES('2027')).toBe(
+    it('varies by season', () => {
+        expect(SLEEPER_API_URLS.USER_LEAGUES('521035584588267520', '2027')).toBe(
             'https://api.sleeper.app/v1/user/521035584588267520/leagues/nfl/2027',
         );
     });
 
-    it('is built from SLEEPER_USER_ID rather than a second copy of the id', () => {
-        expect(SLEEPER_API_URLS.USER_LEAGUES('2026')).toContain(SLEEPER_USER_ID);
+    it('varies by user, which is the whole point of it taking one', () => {
+        expect(SLEEPER_API_URLS.USER_LEAGUES('999', '2026')).toBe(
+            'https://api.sleeper.app/v1/user/999/leagues/nfl/2026',
+        );
+    });
+});
+
+describe('SLEEPER_API_URLS.USER_BY_NAME', () => {
+    it('builds the username lookup used to connect an account', () => {
+        expect(SLEEPER_API_URLS.USER_BY_NAME('ryangh')).toBe('https://api.sleeper.app/v1/user/ryangh');
+    });
+
+    // Sleeper usernames are typed by hand into a form, so they reach this
+    // function unsanitised - a name with a slash or a space in it would
+    // otherwise change which endpoint is called rather than 404 honestly.
+    it('escapes a username that would otherwise alter the path', () => {
+        expect(SLEEPER_API_URLS.USER_BY_NAME('a/b c')).toBe('https://api.sleeper.app/v1/user/a%2Fb%20c');
     });
 });
 


### PR DESCRIPTION
The Sleeper account was a hardcoded constant, so the app only ever rendered one person's leagues. It's now connected by username.

## Two identities, deliberately separate

| | Firebase | Sleeper (new) |
|---|---|---|
| Owns | saved rank lists | leagues, "my team", intel |
| Auth | anonymous → Google | public username lookup |
| Storage | Firebase uid | `localStorage` + RTDB (roams) |

Sleeper has no OAuth, so there's no way to prove a Google user owns the username they typed. Connecting is "show me this manager's leagues", not "log in as them", and the screen says so. Sign-in stays optional — it only adds roaming and saved lists.

Precedence when both exist (`reconcileAccounts`): remote wins, local is promoted when remote is absent, and a *failed* remote read never promotes over a good saved account.

The starting league is chosen from the leagues the account is actually in, remembering the last one per account so reopening the app still lands where the hardcoded id used to.

## Two bugs this turned up

- A failed league-list request reported "you aren't in any leagues" — wrong and unactionable mid-outage. Now distinct from an account genuinely in none.
- The saved account shares the `users/{uid}` record with every saved rank list, so an unfiltered read turned it into a phantom list in the switcher. Filtered by shape.

## Verification

Six gates pass; 625 tests (57 new). Driven against live Sleeper: bad username → "check the spelling"; `ryangh` → all five real leagues; league choice survived a reload; disconnect confirmed, cleared, and returned to the connect screen. No console errors.

11 sabotages. Nine caught immediately. Two passed and were real coverage gaps — both tests were vacuous, both fixed in the second commit, both now caught.

## One unverified thing

The RTDB rules for `users/{uid}/sleeper_account` weren't checkable from here. The account stays inside the `users/$uid` subtree so existing rules should cover it, and the write fails soft (roaming stops, localStorage still works). Worth confirming before relying on cross-device roaming.
