### PR TITLE
Stop the account sync failing silently

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -65,6 +65,8 @@ const DEFAULT_SAVED_RANK_LISTS = {
 const LEAGUE_LOAD_FAILED = "Couldn't load your league data. The Sleeper API may be unavailable.";
 const TRADED_PICKS_FAILED = "Couldn't load traded draft picks. The board shows every pick under its original owner.";
 const NO_LEAGUES = "This Sleeper account isn't in any leagues for the current season.";
+const ACCOUNT_SYNC_FAILED =
+    "Couldn't save your Sleeper account to your profile. It still works on this device, but won't follow you to others.";
 
 // The `users/{uid}` record is not only rank lists any more - the connected
 // Sleeper account is saved in the same subtree, so a signed-in user's record
@@ -123,6 +125,11 @@ class App extends React.Component {
         // different screens.
         sleeperAccount: null,
         accountResolved: false,
+        // The saved copy of the account could not be read or written while
+        // signed in - almost always a database-rules problem. Tracked because
+        // both failures are otherwise invisible: the app keeps working off
+        // localStorage and simply never roams.
+        accountSyncFailed: false,
         season: null,
         myDisplayName: null,
         savedRankLists: DEFAULT_SAVED_RANK_LISTS,
@@ -161,11 +168,18 @@ class App extends React.Component {
     resolveSleeperAccount = async (user) => {
         const local = readLocalAccount();
         if (user.isAnonymous) {
+            this.setState({ accountSyncFailed: false });
             return local;
         }
-        const { account, promote } = reconcileAccounts({ local, remote: await readRemoteAccount(user) });
-        if (promote) {
-            await writeRemoteAccount(user, account);
+        const remote = await readRemoteAccount(user);
+        // A failed read and "nothing saved yet" both leave a signed-in user on
+        // the connect screen, and used to be indistinguishable from there -
+        // the first is a problem to report, the second is just first use.
+        this.setState({ accountSyncFailed: remote === undefined });
+
+        const { account, promote } = reconcileAccounts({ local, remote });
+        if (promote && !(await writeRemoteAccount(user, account))) {
+            this.setState({ accountSyncFailed: true });
         }
         // Mirrored back down so the next signed-out visit to this device opens
         // on the same account rather than back on whatever it had before.
@@ -181,11 +195,19 @@ class App extends React.Component {
     // username you just typed.
     connectSleeperAccount = async (account) => {
         writeLocalAccount(account);
-        if (this.state.signedIn) {
-            await writeRemoteAccount(auth.currentUser, account);
-        }
-        this.setState({ sleeperAccount: account, leagueID: null, loadError: null, loading: LOADING.INITIAL }, () =>
-            this.loadLeague(this.state.playerInfo, account),
+        // Whether the save landed is reported, not swallowed. Failing quietly
+        // here is the worst version of this: the app works perfectly on this
+        // device, and the account silently never follows you anywhere else.
+        const accountSyncFailed = this.state.signedIn ? !(await writeRemoteAccount(auth.currentUser, account)) : false;
+        this.setState(
+            {
+                sleeperAccount: account,
+                accountSyncFailed,
+                leagueID: null,
+                loadError: null,
+                loading: LOADING.INITIAL,
+            },
+            () => this.loadLeague(this.state.playerInfo, account),
         );
     };
 
@@ -427,6 +449,18 @@ class App extends React.Component {
         this.setState({ loadError: null, loading: LOADING.INITIAL }, () => this.loadLeague(this.state.playerInfo));
     };
 
+    // The account save is the only thing retried here - the account itself is
+    // already connected and working off localStorage, so there is nothing to
+    // reload, only a write to attempt again.
+    retrySaveAccount = async () => {
+        const { signedIn, sleeperAccount } = this.state;
+        if (!signedIn || !sleeperAccount) {
+            this.setState({ accountSyncFailed: false });
+            return;
+        }
+        this.setState({ accountSyncFailed: !(await writeRemoteAccount(auth.currentUser, sleeperAccount)) });
+    };
+
     // Retries only the draft load, not the whole league: leagueData is already
     // in state and is not what failed, mirroring retryLeagueLoad's reasoning
     // about the player database above.
@@ -534,7 +568,9 @@ class App extends React.Component {
     // failure.
     signOut = async () => {
         if (await signOutUser()) {
-            this.setState({ rankingPlayersIdsList: [] });
+            // accountSyncFailed described the signed-in user's saved copy, so
+            // it stops applying the moment there is no signed-in user.
+            this.setState({ rankingPlayersIdsList: [], accountSyncFailed: false });
         }
     };
 
@@ -617,6 +653,7 @@ class App extends React.Component {
             season,
             sleeperAccount,
             accountResolved,
+            accountSyncFailed,
         } = this.state;
         if (loading === LOADING.INITIAL) {
             return <Spinner size="page" />;
@@ -635,6 +672,8 @@ class App extends React.Component {
                         onConnect={this.connectSleeperAccount}
                         resolveUsername={fetchSleeperUser}
                         signedIn={signedIn}
+                        signedInEmail={signedInEmail}
+                        syncFailed={accountSyncFailed}
                         onSignIn={this.googleSignIn}
                     />
                 </div>
@@ -709,13 +748,28 @@ class App extends React.Component {
                                 // rendered as a sibling would sit above the bar
                                 // instead of under it.
                                 banner={
-                                    draftWarning ? (
-                                        <ErrorBanner
-                                            message={draftWarning}
-                                            variant="warning"
-                                            onRetry={this.retryDraftLoad}
-                                        />
-                                    ) : null
+                                    <>
+                                        {/* Both are warnings about something
+                                            already on screen being incomplete,
+                                            so they stack rather than replace
+                                            each other - a failed account save
+                                            does not stop being true because
+                                            the traded picks also failed. */}
+                                        {accountSyncFailed ? (
+                                            <ErrorBanner
+                                                message={ACCOUNT_SYNC_FAILED}
+                                                variant="warning"
+                                                onRetry={this.retrySaveAccount}
+                                            />
+                                        ) : null}
+                                        {draftWarning ? (
+                                            <ErrorBanner
+                                                message={draftWarning}
+                                                variant="warning"
+                                                onRetry={this.retryDraftLoad}
+                                            />
+                                        ) : null}
+                                    </>
                                 }
                                 renderAside={this.renderBestAvailableRail}
                                 renderSection={(activeId) => {

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -878,6 +878,10 @@ describe('App, connecting a Sleeper account', () => {
         auth.currentUser.isAnonymous = true;
         auth.currentUser.email = null;
         authMockState.user = null;
+        // The app routes on the hash, and jsdom keeps one location for the
+        // whole file - so a test that navigates leaves every later test
+        // mounting on that section instead of the default one.
+        window.location.hash = '';
     });
 
     // Signs in for real, on both the object the app displays identity from and
@@ -1029,5 +1033,38 @@ describe('App, connecting a Sleeper account', () => {
         // this user has. An unfiltered read adds a third for the account,
         // labelled "dunno" because it has no pretty_name.
         expect([...switcher.options].map((option) => option.text)).toEqual(['-- Select saved ranks list', 'My Ranks']);
+    });
+    // A failed save is the one that must never be silent: the app keeps
+    // working perfectly off localStorage, so without a banner the only symptom
+    // is that the account never appears on any other device - noticed weeks
+    // later, if ever.
+    it('reports a Sleeper account that could not be saved to the profile', async () => {
+        signIn();
+
+        // Reads succeed, writes are refused - the shape a too-narrow database
+        // rule actually takes, and the reason this cannot be inferred from the
+        // read alone.
+        global.fetch = vi.fn((url, options) => {
+            if (url.includes('sleeper_account')) {
+                if (options && options.method === 'PUT') {
+                    return Promise.resolve({ ok: false, status: 401, statusText: 'Unauthorized' });
+                }
+                return jsonResponse(null);
+            }
+            if (url.includes('/users/test-uid')) {
+                return jsonResponse({});
+            }
+            return connectFetch(url);
+        });
+
+        render(<App />);
+        const user = userEvent.setup();
+        await user.type(await screen.findByLabelText(/sleeper username/i), 'ryangh');
+        await user.click(screen.getByRole('button', { name: /^connect$/i }));
+
+        // The league still loads: the account works on this device, and
+        // failing the save is not a reason to withhold what already works.
+        expect(await screen.findAllByText(/ryangh/, {}, { timeout: 5000 })).not.toHaveLength(0);
+        expect(screen.getByText(/couldn't save your sleeper account/i)).toBeInTheDocument();
     });
 });

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1034,6 +1034,30 @@ describe('App, connecting a Sleeper account', () => {
         // labelled "dunno" because it has no pretty_name.
         expect([...switcher.options].map((option) => option.text)).toEqual(['-- Select saved ranks list', 'My Ranks']);
     });
+    // The read-failure half of the same problem, and the one that actually
+    // bit: a denied read leaves a signed-in user on the connect screen with no
+    // account and no explanation, identical to ordinary first use. Only this
+    // path can tell them the difference.
+    it('says why it is still asking when the saved account could not be read', async () => {
+        signIn();
+
+        global.fetch = vi.fn((url) => {
+            if (url.includes('sleeper_account')) {
+                return Promise.resolve({ ok: false, status: 401, statusText: 'Unauthorized' });
+            }
+            if (url.includes('/users/test-uid')) {
+                return jsonResponse({});
+            }
+            return connectFetch(url);
+        });
+
+        render(<App />);
+
+        expect(await screen.findByRole('status')).toHaveTextContent(/couldn.t be read/i);
+        // Still usable - the failure is about roaming, not about this device.
+        expect(screen.getByLabelText(/sleeper username/i)).toBeInTheDocument();
+    });
+
     // A failed save is the one that must never be silent: the app keeps
     // working perfectly off localStorage, so without a banner the only symptom
     // is that the account never appears on any other device - noticed weeks

--- a/src/Components/ConnectSleeper.jsx
+++ b/src/Components/ConnectSleeper.jsx
@@ -12,11 +12,19 @@ const primaryPill = 'bg-mine text-ground min-h-11 rounded-full px-3.5 text-[13px
 // an omission: Sleeper has no auth API at all, so this is a public lookup of
 // public league data, and the copy says so rather than implying a login.
 //
+// Once signed in, the footer below has to keep saying something and say the
+// right thing. Signing in here looks like it should produce an account and
+// does not - there is nothing saved for a first-time user to load - and an
+// unexplained "still asking me for my username" reads as broken rather than as
+// first use. The third case is the one worth catching: if the saved copy could
+// not be read at all, this screen is not evidence of anything, and connecting
+// will not roam either.
+//
 // The three outcomes of that lookup are deliberately distinct. A name nobody
 // owns is the expected result of a typo and gets a "check the spelling"
 // message with no retry button, because retrying fails identically. A failed
 // request is the one worth retrying. A hit connects immediately.
-const ConnectSleeper = ({ onConnect, resolveUsername, signedIn, onSignIn }) => {
+const ConnectSleeper = ({ onConnect, resolveUsername, signedIn, signedInEmail, syncFailed, onSignIn }) => {
     const [username, setUsername] = useState('');
     const [status, setStatus] = useState(null);
     const [busy, setBusy] = useState(false);
@@ -106,7 +114,17 @@ const ConnectSleeper = ({ onConnect, resolveUsername, signedIn, onSignIn }) => {
                     </button>{' '}
                     to save rank lists and keep this account across devices.
                 </p>
-            ) : null}
+            ) : syncFailed ? (
+                <p role="status" className="text-danger m-0 px-1 text-[12px]">
+                    Signed in{signedInEmail ? ` as ${signedInEmail}` : ''}, but your saved Sleeper account couldn’t be
+                    read. Connecting still works on this device — it just won’t follow you to others.
+                </p>
+            ) : (
+                <p className="text-ink-quiet m-0 px-1 text-[12px]">
+                    Signed in{signedInEmail ? ` as ${signedInEmail}` : ''}. No Sleeper account saved yet — connect one
+                    and it’ll follow you to your other devices.
+                </p>
+            )}
         </div>
     );
 };

--- a/src/Components/ConnectSleeper.test.jsx
+++ b/src/Components/ConnectSleeper.test.jsx
@@ -10,6 +10,8 @@ const renderConnect = (overrides = {}) => {
         onConnect: vi.fn(),
         resolveUsername: vi.fn().mockResolvedValue(ACCOUNT),
         signedIn: false,
+        signedInEmail: null,
+        syncFailed: false,
         onSignIn: vi.fn(),
         ...overrides,
     };
@@ -86,5 +88,40 @@ describe('ConnectSleeper', () => {
         renderConnect({ signedIn: true });
 
         expect(screen.queryByRole('button', { name: /sign in with google/i })).not.toBeInTheDocument();
+    });
+    // Signing in here produces no account and cannot - there is nothing saved
+    // for a first-time user to load - so the screen has to say why it is still
+    // asking. Left unexplained it reads as the sign-in having failed.
+    describe('once signed in', () => {
+        it('explains that nothing is saved yet rather than going silent', () => {
+            renderConnect({ signedIn: true, signedInEmail: 'ryan@example.com' });
+
+            expect(screen.getByText(/no sleeper account saved yet/i)).toBeInTheDocument();
+            expect(screen.getByText(/ryan@example.com/)).toBeInTheDocument();
+        });
+
+        // The distinction the whole flag exists for: "nothing saved" and
+        // "could not read what is saved" look identical from this screen, and
+        // only the second one means connecting will not roam.
+        it('says so when the saved account could not be read at all', () => {
+            renderConnect({ signedIn: true, signedInEmail: 'ryan@example.com', syncFailed: true });
+
+            expect(screen.getByRole('status')).toHaveTextContent(/couldn.t be read/i);
+            expect(screen.queryByText(/no sleeper account saved yet/i)).not.toBeInTheDocument();
+        });
+
+        it('still connects normally in that state, since this device works', async () => {
+            const { onConnect } = renderConnect({ signedIn: true, syncFailed: true });
+
+            await typeAndSubmit('ryangh');
+
+            expect(onConnect).toHaveBeenCalledWith(ACCOUNT);
+        });
+
+        it('names no email when the account has none to show', () => {
+            renderConnect({ signedIn: true, signedInEmail: null });
+
+            expect(screen.getByText(/^Signed in\. No Sleeper account saved yet/)).toBeInTheDocument();
+        });
     });
 });


### PR DESCRIPTION
Follow-up to #153, from hitting this in the real app: signing in with Google appeared to do nothing — it still asked for a Sleeper username.

That's correct behaviour (nothing is saved for a first-time user to load), but the screen said nothing about it, so it read as a broken sign-in. Worse, a genuinely *denied* read looked identical, and a denied write was invisible too — the app keeps working off `localStorage` and just never roams.

## What changed

The connect screen now distinguishes three states instead of going blank once signed in:

| State | What it says |
|---|---|
| Signed out | offer to sign in (unchanged) |
| Signed in, nothing saved | "No Sleeper account saved yet — connect one and it'll follow you to your other devices" |
| Signed in, read failed | "…your saved Sleeper account couldn't be read. Connecting still works on this device — it just won't follow you to others" |

A save that doesn't land now raises a retryable warning banner instead of being swallowed. Nothing blocks: the account works on this device either way, which is exactly why the failure needed saying out loud.

This also makes the outstanding database-rules question from #153 diagnose itself — a too-narrow rule now shows up in the UI rather than needing the Network tab.

## Also

Resets the hash between tests in `App.test.jsx`. The app routes on the hash and jsdom keeps one location per file, so a test that navigates left every later test mounting on that section. That's what made a new test pass alone and fail in the suite.

## Verification

Six gates pass; 631 tests. Four sabotages: ignoring the write result, ignoring the read failure at the App level, and the connect screen ignoring `syncFailed` are all caught. The third initially passed — a real gap, since nothing checked App ever set the flag — and the test for it is the third commit.

The signed-out and already-connected paths are verified in the browser. The signed-in states are covered by tests only; driving a real Google sign-in isn't something I can do.
