### PR TITLE
Show how much of a player each leaguemate holds

### DIFF
--- a/src/Components/IntelDetail.jsx
+++ b/src/Components/IntelDetail.jsx
@@ -1,7 +1,7 @@
 import PositionTag from './PositionTag';
 import { TermTip } from './IntelTermTip';
 import { gapPhrase, gapTone, survivalPhrase, survivalTone } from './intelGlossary.js';
-import { managerSample, stationsFor, survivalAt } from '../lib/availability.js';
+import { managerSample, ownershipSample, stationsFor, survivalAt } from '../lib/availability.js';
 
 // The drill-down (docs/leaguemate-intel.md §3 Frontend).
 //
@@ -54,6 +54,55 @@ function evidenceFor(sample) {
             return `took him ${sample.times}× of ${sample.of} drafts · their ADP ${sample.adp}`;
     }
 }
+
+/**
+ * The holdings half of a manager row: "has 5 of 58 · 9%".
+ *
+ * Returns null rather than a zero when there is no roster data, which is the
+ * whole reason the API sends `ofLeagues: null` instead of 0 - a manager we
+ * cannot see and a manager who owns him nowhere are different, and only one
+ * of them is a fact about him.
+ */
+function holdingPhrase(sample) {
+    switch (sample.kind) {
+        case 'none':
+            return null;
+        case 'droppedAll':
+            return `has him in none of their ${sample.ofLeagues}`;
+        default:
+            return sample.percent === null
+                ? `has him in ${sample.owns} of ${sample.ofLeagues}`
+                : `has him in ${sample.owns} of ${sample.ofLeagues} · ${sample.percent}%`;
+    }
+}
+
+const ManagerRow = ({ entry, threshold }) => {
+    const holding = holdingPhrase(ownershipSample(entry, threshold));
+
+    // `times of of` was printed unconditionally, which reads as "0 of 0" for
+    // a manager who owns him and has no crawled drafts - and that is not a
+    // rare case, it is the one this whole read exists for.
+    const drafted = entry.of > 0 ? `${entry.times} of ${entry.of}` : null;
+
+    // Two lines rather than one. Measured at 375px with real data, the single
+    // line truncated on exactly the rows carrying the most information -
+    // "babaghanoush123 11 of 27 · has him in 14 of 39 · 36%" needed 304px of a
+    // 219px column, so the holdings half was the part that got cut. Giving it
+    // its own full-width line costs a row of height and loses nothing.
+    return (
+        <div className="py-0.5">
+            <div className="flex items-baseline justify-between gap-2">
+                <span className="text-ink-quiet truncate text-[12px]">
+                    {entry.manager} {drafted && <span className="text-ink-dim">{drafted}</span>}
+                </span>
+                <span className="text-ink-dim shrink-0 font-mono text-[10px] tabular-nums">
+                    {entry.picks.slice(0, 3).join('  ')}
+                </span>
+            </div>
+            {holding && <p className="text-ink-dim text-[11px] leading-tight">{holding}</p>}
+        </div>
+    );
+};
 
 const Station = ({ station, threshold, isLast }) => {
     const { probability, isMine, mate, tookCount, draftsSeen } = station;
@@ -227,21 +276,17 @@ const IntelDetail = ({ target, board, atPick, threshold, onBack }) => {
 
                 {perManager.length > 0 && (
                     <div className="border-line-mid border-t pt-2">
+                        {/*
+                         * "Everyone who has drafted him" until this listed
+                         * owners too, and a heading is a claim like any other
+                         * figure. Most entries here now arrive by ownership
+                         * rather than by a pick.
+                         */}
                         <p className="text-ink-dim mb-1 font-mono text-[10px] tracking-[.08em] uppercase">
-                            Everyone who has drafted him
+                            Who has drafted or holds him
                         </p>
                         {perManager.slice(0, 4).map((entry) => (
-                            <div key={entry.manager} className="flex items-baseline justify-between gap-2 py-0.5">
-                                <span className="text-ink-quiet truncate text-[12px]">
-                                    {entry.manager}{' '}
-                                    <span className="text-ink-dim">
-                                        {entry.times} of {entry.of}
-                                    </span>
-                                </span>
-                                <span className="text-ink-dim shrink-0 font-mono text-[10px] tabular-nums">
-                                    {entry.picks.slice(0, 3).join('  ')}
-                                </span>
-                            </div>
+                            <ManagerRow key={entry.manager} entry={entry} threshold={threshold} />
                         ))}
                         <p className="text-ink-dim mt-1 font-mono text-[9px]">round.slot @ overall pick</p>
                     </div>

--- a/src/Components/IntelDetail.test.jsx
+++ b/src/Components/IntelDetail.test.jsx
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import IntelDetail from './IntelDetail';
+
+// The manager list is the only part of this component that makes a claim in
+// words rather than a number, and the standing failure in this feature has
+// been the sentence rather than the maths - so that is what is covered here.
+//
+// The shapes are the ones production actually returns, taken from
+// `/availability` on 2026-08-09: `skeefe` holds a player in 1 of his 30
+// leagues with no crawled drafts at all, and `N8TEDAGR38T` has 25 drafts,
+// never took him, and owns him somewhere anyway.
+const threshold = { minDrafts: 8, minTimes: 3 };
+
+const target = {
+    id: '13353',
+    name: 'Chris Brazzell',
+    position: 'WR',
+    leagueAdp: 27,
+    sd: 6,
+    n: 12,
+    marketPick: 36,
+    adpGap: -9,
+    byPick: { 35: { adjSurvival: 0.5, baseSurvival: 0.5 } },
+    hazards: [],
+    notable: false,
+    perManager: [],
+};
+
+const board = [{ pick: 35, manager: 'atekipp', mine: false, drafts: 12 }];
+
+const renderWith = (perManager) =>
+    render(<IntelDetail target={{ ...target, perManager }} board={board} atPick={35} threshold={threshold} />);
+
+// The manager's own row, not the whole panel. Scoping matters here: the
+// component also renders a survival percentage and an ADP-gap sentence that
+// says "has him #36", both of which match the obvious loose queries and make
+// a passing assertion mean nothing.
+//
+// Found from the section heading rather than by climbing up from the name,
+// so it keeps returning the whole row: the row became two lines to stop the
+// holdings phrase truncating at 375px, and `closest('div')` from the name
+// then returned only the first of them.
+const rowFor = (manager) => {
+    const heading = screen.getByText(/Who has drafted or holds him/i);
+
+    return [...heading.parentElement.querySelectorAll(':scope > div')].find((row) =>
+        row.textContent.trim().startsWith(manager),
+    );
+};
+
+describe('IntelDetail manager rows', () => {
+    it('shows holdings for a manager with no crawled drafts, without printing "0 of 0"', () => {
+        renderWith([{ manager: 'skeefe', times: 0, of: 0, adp: null, picks: [], owns: 1, ofLeagues: 30 }]);
+
+        expect(screen.getByText(/has him in 1 of 30/)).toBeInTheDocument();
+        expect(screen.queryByText(/0 of 0/)).not.toBeInTheDocument();
+    });
+
+    it('shows the draft read and the holdings read together when both exist', () => {
+        renderWith([
+            { manager: 'baconstains', times: 1, of: 30, adp: 27.5, picks: ['2.4@16'], owns: 1, ofLeagues: 39 },
+        ]);
+
+        expect(screen.getByText(/1 of 30/)).toBeInTheDocument();
+        expect(screen.getByText(/has him in 1 of 39/)).toBeInTheDocument();
+    });
+
+    // The distinction the API sends `ofLeagues: null` to preserve. A manager
+    // whose leagues we cannot see must not read as one who owns him nowhere.
+    it('says nothing about holdings when there is no roster data', () => {
+        renderWith([{ manager: 'cja9689', times: 2, of: 12, adp: 30, picks: [], owns: 0, ofLeagues: null }]);
+
+        const row = rowFor('cja9689');
+        expect(row).toHaveTextContent('2 of 12');
+        expect(row).not.toHaveTextContent(/has him in/);
+        expect(row).not.toHaveTextContent(/none of their/);
+    });
+
+    it('states outright when a manager who drafted him holds him nowhere now', () => {
+        renderWith([{ manager: 'GetForked', times: 2, of: 10, adp: 24, picks: [], owns: 0, ofLeagues: 10 }]);
+
+        expect(screen.getByText(/has him in none of their 10/)).toBeInTheDocument();
+    });
+
+    // "50%" of two leagues is a coin flip with a decimal point.
+    it('withholds the percentage on a thin denominator but still shows the count', () => {
+        renderWith([{ manager: 'cunglomerate', times: 0, of: 0, adp: null, picks: [], owns: 1, ofLeagues: 2 }]);
+
+        const row = rowFor('cunglomerate');
+        expect(row).toHaveTextContent('has him in 1 of 2');
+        expect(row).not.toHaveTextContent('%');
+    });
+
+    it('shows it once the denominator is large enough to carry one', () => {
+        renderWith([{ manager: 'N8TEDAGR38T', times: 0, of: 25, adp: null, picks: [], owns: 5, ofLeagues: 58 }]);
+
+        expect(screen.getByText(/has him in 5 of 58 · 9%/)).toBeInTheDocument();
+    });
+
+    // The heading is a claim too: this list stopped being only drafters.
+    it('does not claim everyone listed has drafted him', () => {
+        renderWith([{ manager: 'skeefe', times: 0, of: 0, adp: null, picks: [], owns: 1, ofLeagues: 30 }]);
+
+        expect(screen.queryByText(/Everyone who has drafted him/i)).not.toBeInTheDocument();
+        expect(screen.getByText(/Who has drafted or holds him/i)).toBeInTheDocument();
+    });
+});

--- a/src/lib/availability.js
+++ b/src/lib/availability.js
@@ -135,6 +135,39 @@ export function managerSample({ times, of, adp, picks } = {}, threshold) {
     return { kind: 'countOnly', times, of };
 }
 
+/**
+ * How much can honestly be said about how much of a player a manager owns.
+ *
+ * The sibling of `managerSample` and deliberately separate from it: drafting
+ * and holding are different questions about the same person, and 94% of real
+ * ownership never appears in a draft at all (measured 2026-08-09). A manager
+ * can own him having never drafted him, or have drafted him twice and moved
+ * him on since.
+ *
+ * `ofLeagues` is null when we hold no roster data for that manager, which is
+ * not the same as owning him nowhere - so that case says nothing rather than
+ * printing a zero.
+ *
+ * A percentage is gated on the same `minDrafts` the draft ADP is gated on.
+ * `cunglomerate` is in two leagues we can see; "50%" of that is a coin flip
+ * with a decimal point, where "1 of 2" is just true.
+ */
+export function ownershipSample({ owns, ofLeagues } = {}, threshold) {
+    const { minDrafts } = threshold || {};
+
+    // No roster data for this manager at all. "0 of 0" is not a fact about
+    // him, and it is the shape most likely to be rendered as 0%.
+    if (!ofLeagues) return { kind: 'none' };
+
+    const percent = ofLeagues >= (minDrafts || Infinity) ? Math.round((100 * owns) / ofLeagues) : null;
+
+    // Drafted him at some point, holds him nowhere now. Worth stating - it
+    // is the difference between liking a player and committing to one.
+    if (!owns) return { kind: 'droppedAll', owns: 0, ofLeagues };
+
+    return { kind: 'owns', owns, ofLeagues, percent };
+}
+
 // "4.9@39" - round.slot @ overall (§4e). The overall pick is the only part
 // worth showing next to a name; the rest is receipts for the detail view.
 function pickNumber(pickString) {

--- a/src/lib/availability.test.js
+++ b/src/lib/availability.test.js
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { defaultAnalyzedPick, managerSample, pickOptions, stationsFor, survivalAt } from './availability.js';
+import {
+    defaultAnalyzedPick,
+    managerSample,
+    ownershipSample,
+    pickOptions,
+    stationsFor,
+    survivalAt,
+} from './availability.js';
 
 describe('defaultAnalyzedPick', () => {
     // docs/leaguemate-intel.md §3g gap 1b. "My next pick" was resolved as the
@@ -240,5 +247,46 @@ describe('managerSample', () => {
 
         expect(managerSample(entry, { minDrafts: 8, minTimes: 3 }).kind).toBe('full');
         expect(managerSample(entry, { minDrafts: 20, minTimes: 3 }).kind).toBe('countOnly');
+    });
+});
+
+describe('ownershipSample', () => {
+    // The holdings half of the copy rules. Same standing lesson as
+    // `managerSample`: the risk is never the number, it is the sentence.
+    const threshold = { minDrafts: 8, minTimes: 3 };
+
+    // The one that would otherwise render as "0%" or "0 of 0" - the shape
+    // the API deliberately sends as null so this case is distinguishable.
+    it('says nothing at all when we hold no roster data for them', () => {
+        expect(ownershipSample({ owns: 0, ofLeagues: null }, threshold)).toEqual({ kind: 'none' });
+        expect(ownershipSample({ owns: 0, ofLeagues: 0 }, threshold)).toEqual({ kind: 'none' });
+        expect(ownershipSample(undefined, threshold)).toEqual({ kind: 'none' });
+    });
+
+    it('distinguishes owning him nowhere from having no data', () => {
+        expect(ownershipSample({ owns: 0, ofLeagues: 39 }, threshold)).toEqual({
+            kind: 'droppedAll',
+            owns: 0,
+            ofLeagues: 39,
+        });
+    });
+
+    it('reports the count against the leagues we can actually see', () => {
+        const sample = ownershipSample({ owns: 5, ofLeagues: 58 }, threshold);
+
+        expect(sample.kind).toBe('owns');
+        expect(sample.owns).toBe(5);
+        expect(sample.ofLeagues).toBe(58);
+        expect(sample.percent).toBe(9);
+    });
+
+    // A percentage of two leagues is a coin flip with a decimal point.
+    it('withholds the percentage below the same threshold the draft ADP uses', () => {
+        expect(ownershipSample({ owns: 1, ofLeagues: 2 }, threshold).percent).toBeNull();
+        expect(ownershipSample({ owns: 1, ofLeagues: 8 }, threshold).percent).toBe(13);
+    });
+
+    it('withholds it entirely when no threshold is supplied, rather than guessing one', () => {
+        expect(ownershipSample({ owns: 1, ofLeagues: 500 }).percent).toBeNull();
     });
 });


### PR DESCRIPTION
Backend half is sleeper-player-be#44. This renders it.

The detail view could say how often a manager drafts a player, and not whether he has him now. Measured 2026-08-09, those are mostly different facts: **94% of real (manager, player) ownership never appears in a crawled draft**, and draft rate vs ownership rate correlates at only 0.785.

Against production data, at pick 39 on Chris Brazzell:

```
WHO HAS DRAFTED OR HOLDS HIM
GetForked    1 of 5                    4.4@46
has him in 1 of 10 · 10%
N8TEDAGR38T  0 of 25
has him in 1 of 58 · 2%
baconstains  1 of 30                  2.12@24
has him in 1 of 39 · 3%
skeefe
has him in 1 of 30 · 3%
```

`skeefe` is the case this exists for: no crawled drafts at all, so the draft read is silent, and 30 leagues of roster data. `N8TEDAGR38T` has 25 drafts, never took him, and holds him anyway.

## Three copy rules

- **No roster data says nothing**, rather than "0 of 0" — which is what the old unconditional `times of of` rendered for a manager with no crawled drafts. The API sends `ofLeagues: null` so this is distinguishable from owning him nowhere.
- **The percentage is gated on the same `minDrafts` the draft ADP is gated on.** `cunglomerate` is in 2 visible leagues; "50%" of that is a coin flip with a decimal point, where "1 of 2" is just true.
- **The heading was a claim too.** "Everyone who has drafted him" stopped being true once the list included owners.

## Layout

The row is two lines. Measured at 375px with real data, the single-line version truncated on exactly the rows carrying the most information — `babaghanoush123 11 of 27 · has him in 14 of 39 · 36%` wanted 304px of a 219px column, and the holdings half was what got cut. Re-measured after: nothing truncates, body does not overflow.

## Testing

New `IntelDetail.test.jsx` (7 cases) and 5 for `ownershipSample`, one per copy rule. Sabotaged three ways: null `ofLeagues` rendering as zero (2 failures), the percentage ungated (3), and the row printing `times of of` unconditionally (1).

Verified in a browser against the deployed API, not fixtures — the shapes in the tests are the ones production actually returns.

**Note:** `npm run test:run` and `npm run format:check` currently traverse `.claude/worktrees/rank-matching-refactor`, an untracked worktree from another session, and report 315 unrelated failures plus 79 formatting complaints. Gates were run scoped to `src`, where they are clean: lint 0 problems, prettier clean, typecheck clean, 643 tests passing, build fine.