### PR TITLE
Split rank-list parsing from player matching

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,182 +1,40 @@
-import Fuse from 'fuse.js';
+import { describeParsed, parseRankLine } from './lib/rankParse.js';
+import { matchPlayer, playerIndex } from './lib/rankMatch.js';
 
-const getHighestScore = (arr, fuseSearch) => {
-    const bestResult = arr
-        .map((item) => fuseSearch.search(item.replace(/[^a-zA-Z]/g, '')))
-        .filter((item) => item.length > 0)
-        .sort((a, b) => a[0]?.score - b[0]?.score);
-    return bestResult[0] && bestResult[0][0].score === 0 ? bestResult[0][0].item : null;
-};
-
+/**
+ * A pasted ranking list as ranked match candidates, plus the lines that
+ * matched nothing.
+ *
+ * The two hard parts each live in their own module now - reading a line
+ * (lib/rankParse.js) and finding the player it names (lib/rankMatch.js) - and
+ * what is left here is the part that was never in doubt: walk the lines, keep
+ * a rank counter, sort the outcomes into the two buckets the panel renders.
+ *
+ * A rank is spent on every line that named something, whether or not it was
+ * found: the miss list is numbered against the list the user pasted, so a
+ * player who could not be matched still occupies their place in it. Lines that
+ * parse to nothing at all - blanks, and rows that were only a rank number -
+ * are skipped without consuming one.
+ */
 const createRankings = (searchText, playerInfo) => {
-    const playerInfoArray = Object.values(playerInfo);
-    playerInfoArray.sort((a, b) => a.search_rank - b.search_rank);
-    const playerInfoFuseOptions = {
-        useExtendedSearch: true,
-        includeScore: true,
-        keys: ['search_last_name', 'search_first_name', 'team', 'position'],
-    };
-    const options = {
-        includeScore: true,
-    };
-    const positions = ['QB', 'RB', 'WR', 'TE', 'DEF', 'K'];
-    const teams = [
-        'CAR',
-        'MIN',
-        'TEN',
-        'GB',
-        'NO',
-        'NYG',
-        'KC',
-        'IND',
-        'LAC',
-        'DAL',
-        'BUF',
-        'CLE',
-        'SEA',
-        'ARI',
-        'LV',
-        'ATL',
-        'LAR',
-        'LA',
-        'FA',
-        'CIN',
-        'SF',
-        'JAX',
-        'JAC',
-        'WAS',
-        'CHI',
-        'PHI',
-        'BAL',
-        'TB',
-        'DEN',
-        'HOU',
-        'PIT',
-        'MIA',
-        'DET',
-        'NE',
-        'NYJ',
-        'ROOKIE',
-    ];
-    const playerInfoIndex = Fuse.createIndex(playerInfoFuseOptions.keys, playerInfoArray);
-    const playerInfoFuse = new Fuse(playerInfoArray, playerInfoFuseOptions, playerInfoIndex);
-    const teamsFuse = new Fuse(teams, options);
-
-    const addLineBreak = searchText.replace(/(?:\r\n|\r|\n)/g, '<br>');
-    const splitLineBreak = addLineBreak.split('<br>');
+    const index = playerIndex(playerInfo);
     const searchResultsArray = [];
-    let ranking = 1;
     const notFoundPlayers = [];
+    let ranking = 1;
 
-    splitLineBreak.forEach((line) => {
-        // Removing any numbers from the search string
-        line = line.replace(/[0-9]/g, '');
-        if (!line.trim()) {
-            return;
-        }
-        // Splitting the string
-        const splitString = line.split('');
-        // Making sure the first index isn't a period after removing numbers. Just in case we get "1., 2., 3."" etc
-        if (splitString[0] === '.') {
-            splitString.splice(0, 1, '');
-        }
-        // Sometimes ranks just have the first letter of the first name and the last name separated by a period. ex. "T.Brady"
-        // Want to remove this without removing for players that go by initials, ex. "J.K. Dobbins"
-        if (splitString[1] === '.' && splitString[3] !== '.') {
-            splitString.splice(1, 1, ' ');
-        } else if (splitString[1] === '.' && splitString[3] === '.' && splitString[4] !== ' ') {
-            splitString.splice(3, 1, '. ');
-        }
-        const lettersOnly = splitString.map((string) => string.replace(/[^a-zA-Z\s]/g, ''));
-        if (!lettersOnly.join('').trim()) {
-            return;
-        }
-        const nameAndTeam = lettersOnly.join('').trim();
-        // Splitting by spaces and removing whitespace
-        const firstLastTeamArrays = nameAndTeam.split(/\s/).map((item) => item.trim());
-        const searchArray = [];
-        let foundPositionStr;
-        let foundTeamStr;
-        // If there's more than 2 indexes, we want to see if they can help with our search by looking for player position and team initials
-        if (firstLastTeamArrays.length > 2) {
-            const positionIndex = firstLastTeamArrays.findIndex((item, index) => positions.includes(item) && index > 1);
-            if (positionIndex >= 0) {
-                foundPositionStr = firstLastTeamArrays.splice(positionIndex, 1)[0];
-                searchArray.unshift(foundPositionStr);
-            }
-            foundTeamStr = getHighestScore(firstLastTeamArrays, teamsFuse);
-            if (foundTeamStr) {
-                firstLastTeamArrays.splice(firstLastTeamArrays.indexOf(foundTeamStr), 1);
-                searchArray.unshift(foundTeamStr);
-            }
-        }
+    searchText.split(/\r\n|\r|\n/).forEach((line) => {
+        const parsed = parseRankLine(line);
+        if (!parsed) return;
 
-        searchArray.unshift(firstLastTeamArrays[0], firstLastTeamArrays[1]);
-
-        const results = playerInfoFuse.search({
-            $or: [
-                {
-                    $and: [
-                        { search_last_name: searchArray[1] },
-                        {
-                            $or: [{ search_first_name: searchArray[0] }, { search_first_name: `^${searchArray[0]}` }],
-                        },
-                        { position: `=${searchArray[3]}` },
-                        { team: `=${searchArray[2]}` },
-                    ],
-                },
-
-                {
-                    $and: [
-                        { search_last_name: searchArray[1] },
-                        {
-                            $or: [{ search_first_name: searchArray[0] }, { search_first_name: `^${searchArray[0]}` }],
-                        },
-                        { position: `=${searchArray[3]}` },
-                    ],
-                },
-
-                {
-                    $and: [
-                        { search_last_name: searchArray[1] },
-                        {
-                            $or: [{ search_first_name: searchArray[0] }, { search_first_name: `^${searchArray[0]}` }],
-                        },
-                        { team: `=${searchArray[2]}` },
-                    ],
-                },
-
-                {
-                    $and: [
-                        { search_last_name: searchArray[1] },
-                        {
-                            $or: [{ search_first_name: searchArray[0] }, { search_first_name: `^${searchArray[0]}` }],
-                        },
-                    ],
-                },
-            ],
-        });
-        let fResults = results
-            .filter((result) => positions.includes(result.item.position))
-            .map((result) => [result.item.player_id, result.score.toFixed(3)]);
-        if (fResults[0]) {
-            if (fResults.length > 5) {
-                fResults = fResults.filter((result) => fResults.indexOf(result) <= 4);
-            }
+        const matches = matchPlayer(parsed, index);
+        if (matches.length > 0) {
             searchResultsArray.push({
-                match_results: fResults,
-                ranking: ranking,
-                search_string: searchArray.join(' '),
+                match_results: matches,
+                ranking,
+                search_string: describeParsed(parsed),
             });
-            if (results[0].item.search_rank > 1000) {
-                console.log(
-                    `${results[0].item.full_name} ${results[0].item.position} ${results[0].item.team} Rank: ${ranking}`,
-                );
-            }
         } else {
-            notFoundPlayers.push(
-                `Couldn't find ${firstLastTeamArrays[0]} ${firstLastTeamArrays[1]} ${foundTeamStr}  ${foundPositionStr} Rank: ${ranking}`,
-            );
+            notFoundPlayers.push(`Couldn't find ${describeParsed(parsed)} Rank: ${ranking}`);
         }
         ranking += 1;
     });

--- a/src/helpers.test.js
+++ b/src/helpers.test.js
@@ -1,10 +1,81 @@
 import { describe, expect, it } from 'vitest';
 import createRankings from './helpers';
 
+const player = (id, first, last, team, position, rank) => ({
+    player_id: id,
+    search_first_name: first.toLowerCase(),
+    search_last_name: last.toLowerCase(),
+    full_name: `${first} ${last}`,
+    team,
+    position,
+    search_rank: rank,
+});
+
+const playerInfo = {
+    1: player('1', 'Bijan', 'Robinson', 'ATL', 'RB', 3),
+    2: player('2', 'Puka', 'Nacua', 'LA', 'WR', 12),
+    3: player('3', 'Brian', 'Robinson', 'WAS', 'RB', 60),
+};
+
+const winners = (results) => results.map((result) => result.match_results[0][0]);
+
 describe('createRankings', () => {
     it('returns empty result arrays for empty input', () => {
         const [searchResultsArray, notFoundPlayers] = createRankings('', {});
         expect(searchResultsArray).toEqual([]);
         expect(notFoundPlayers).toEqual([]);
+    });
+
+    it('ranks a pasted list in the order it was pasted', () => {
+        const [results] = createRankings('1. Bijan Robinson ATL RB\n2. Puka Nacua LA WR', playerInfo);
+        expect(winners(results)).toEqual(['1', '2']);
+        expect(results.map((result) => result.ranking)).toEqual([1, 2]);
+    });
+
+    it('carries the parsed line back for display', () => {
+        const [results] = createRankings('1. Bijan Robinson ATL RB', playerInfo);
+        expect(results[0].search_string).toBe('Bijan Robinson ATL RB');
+    });
+
+    it('reports a line it could not match, without breaking the paste', () => {
+        const [results, notFound] = createRankings('Bijan Robinson\nNobody Whatsoever\nPuka Nacua', playerInfo);
+        expect(winners(results)).toEqual(['1', '2']);
+        expect(notFound).toEqual(["Couldn't find Nobody Whatsoever Rank: 2"]);
+    });
+
+    // A miss still occupies its place in the list the user pasted, so the rank
+    // in the message is the rank they can see on screen.
+    it('spends a rank on a miss, so later players keep their true rank', () => {
+        const [results] = createRankings('Nobody Whatsoever\nPuka Nacua', playerInfo);
+        expect(results[0].ranking).toBe(2);
+    });
+
+    // The miss message used to interpolate the team and position raw, so a
+    // two-token name that missed rendered "undefined  undefined" to the user.
+    it('names only the fields the line carried in a miss message', () => {
+        const [, notFound] = createRankings('Nobody Whatsoever', playerInfo);
+        expect(notFound[0]).not.toMatch(/undefined|null/);
+    });
+
+    it.each([
+        ['blank lines', 'Bijan Robinson\n\n\nPuka Nacua'],
+        ['carriage returns', 'Bijan Robinson\r\nPuka Nacua'],
+        ['trailing whitespace lines', 'Bijan Robinson\nPuka Nacua\n   \n'],
+    ])('does not spend a rank on %s', (_label, text) => {
+        const [results, notFound] = createRankings(text, playerInfo);
+        expect(winners(results)).toEqual(['1', '2']);
+        expect(results.map((result) => result.ranking)).toEqual([1, 2]);
+        expect(notFound).toEqual([]);
+    });
+
+    it('reads a spreadsheet paste, where the columns arrive tab-separated', () => {
+        const [results, notFound] = createRankings('1\tBijan Robinson\tATL\tRB\n2\tPuka Nacua\tLA\tWR', playerInfo);
+        expect(winners(results)).toEqual(['1', '2']);
+        expect(notFound).toEqual([]);
+    });
+
+    it('keeps two players with the same surname apart by team', () => {
+        const [results] = createRankings('B. Robinson WAS\nB. Robinson ATL', playerInfo);
+        expect(winners(results)).toEqual(['3', '1']);
     });
 });

--- a/src/lib/rankMatch.js
+++ b/src/lib/rankMatch.js
@@ -1,0 +1,99 @@
+import Fuse from 'fuse.js';
+import { POSITIONS } from './rankParse.js';
+
+// Turning parsed fields into candidate players. This half owns the player
+// database and knows nothing about pasted text - see rankParse.js for the
+// other side of the seam.
+
+const FUSE_KEYS = ['search_last_name', 'search_first_name', 'team', 'position'];
+
+// Keyed on the `playerInfo` object itself, so a new payload gets a new index
+// and a stale one is collected with it.
+//
+// Worth doing, but not the win it looks like: building the index over an 11k
+// player pool measures at 11ms, against 2.5-10s for the searches that follow
+// it in a 200-line paste. The old code rebuilt it per call and that was never
+// what made pasting slow - see `queryFor` for what actually costs.
+const indexCache = new WeakMap();
+
+/**
+ * The searchable index over `playerInfo`, built at most once per payload.
+ *
+ * Sorted by `search_rank` because the order survives into the results: Fuse
+ * returns equal-scoring matches in index order, so two players who match a
+ * line equally well come back best-known-first.
+ */
+export function playerIndex(playerInfo) {
+    const cached = indexCache.get(playerInfo);
+    if (cached) return cached;
+
+    const players = Object.values(playerInfo);
+    players.sort((a, b) => a.search_rank - b.search_rank);
+    const fuse = new Fuse(
+        players,
+        { useExtendedSearch: true, includeScore: true, keys: FUSE_KEYS },
+        Fuse.createIndex(FUSE_KEYS, players),
+    );
+
+    indexCache.set(playerInfo, fuse);
+    return fuse;
+}
+
+/**
+ * The query for one parsed line: the surname and first name always, then the
+ * fields the line actually supplied, most specific first.
+ *
+ * Built from what is present rather than from fixed slots. The old code always
+ * emitted all four branches, filling the missing pieces with `undefined` - so
+ * a line carrying a position and no team searched `team: '=RB'` and
+ * `position: '=undefined'`, and three of its four branches could not match
+ * anything. Only the name-only fallback ever fired, which is why the bug
+ * looked like nothing more than mediocre matching.
+ *
+ * The search cost is close to linear in the branch count (measured: 15.9ms for
+ * one branch, 62.5ms for four, per line over an 11k pool), so dropping the
+ * branches a line cannot use is also the only real speed-up here: a 200-line
+ * paste of bare names went 9.55s -> 2.56s, and one with names and teams
+ * 9.67s -> 5.10s, with identical winners. A line carrying both fields still
+ * emits all four and is unchanged.
+ *
+ * That leaves the honest number bad: seconds, for a paste. The cost is the
+ * fuzzy surname match scanning every player, and an exact-surname prefilter
+ * measures at 1.7ms/line against 62.5. It is not done here because it would
+ * stop tolerating a misspelt surname, which is a matching-quality decision
+ * rather than a refactor.
+ */
+function queryFor({ first, last, team, position }) {
+    const name = [
+        { search_last_name: last },
+        { $or: [{ search_first_name: first }, { search_first_name: `^${first}` }] },
+    ];
+    const branches = [];
+
+    if (position && team) branches.push({ $and: [...name, { position: `=${position}` }, { team: `=${team}` }] });
+    if (position) branches.push({ $and: [...name, { position: `=${position}` }] });
+    if (team) branches.push({ $and: [...name, { team: `=${team}` }] });
+    branches.push({ $and: name });
+
+    return { $or: branches };
+}
+
+/** How many candidates a single line is allowed to offer for correction. */
+const MAX_CANDIDATES = 5;
+
+/**
+ * The players a parsed line could mean, best first, as `[player_id, score]`.
+ *
+ * Empty means the line matched nothing. Non-playing entries are filtered out
+ * by position rather than trusted from the payload, because the player pool
+ * carries coaches and retired players that no ranking list ever refers to.
+ */
+export function matchPlayer(parsed, index) {
+    if (!parsed?.last) return [];
+
+    return index
+        .search(queryFor(parsed))
+        .filter((result) => POSITIONS.includes(result.item.position))
+        .slice(0, MAX_CANDIDATES)
+        .map((result) => [result.item.player_id, result.score.toFixed(3)]);
+}

--- a/src/lib/rankMatch.test.js
+++ b/src/lib/rankMatch.test.js
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import { matchPlayer, playerIndex } from './rankMatch.js';
+import { parseRankLine } from './rankParse.js';
+
+const player = (id, first, last, team, position, rank) => ({
+    player_id: id,
+    search_first_name: first.toLowerCase(),
+    search_last_name: last.toLowerCase(),
+    full_name: `${first} ${last}`,
+    team,
+    position,
+    search_rank: rank,
+});
+
+// Two Robinsons and two Browns, because the whole job of the team and position
+// fields is telling players with the same surname apart.
+const playerInfo = {
+    1: player('1', 'Bijan', 'Robinson', 'ATL', 'RB', 3),
+    2: player('2', 'Brian', 'Robinson', 'WAS', 'RB', 60),
+    3: player('3', 'Marquise', 'Brown', 'KC', 'WR', 120),
+    4: player('4', 'Antonio', 'Brown', 'FA', 'WR', 900),
+    5: player('5', 'Puka', 'Nacua', 'LA', 'WR', 12),
+    6: player('6', 'Kyle', 'Shanahan', 'SF', 'HC', 9999),
+};
+
+const ids = (matches) => matches.map(([id]) => id);
+const matchLine = (line, info = playerInfo) => matchPlayer(parseRankLine(line), playerIndex(info));
+
+describe('playerIndex', () => {
+    it('builds the index once per payload', () => {
+        expect(playerIndex(playerInfo)).toBe(playerIndex(playerInfo));
+    });
+
+    it('builds a fresh index for a new payload', () => {
+        expect(playerIndex({ ...playerInfo })).not.toBe(playerIndex(playerInfo));
+    });
+});
+
+describe('matchPlayer', () => {
+    it('finds a player by first and last name', () => {
+        expect(ids(matchLine('Puka Nacua'))[0]).toBe('5');
+    });
+
+    it('finds a player by a first initial', () => {
+        expect(ids(matchLine('P. Nacua'))[0]).toBe('5');
+    });
+
+    it('uses the team to pick between two players sharing a surname', () => {
+        expect(ids(matchLine('B. Robinson WAS'))[0]).toBe('2');
+        expect(ids(matchLine('B. Robinson ATL'))[0]).toBe('1');
+    });
+
+    // The payoff for the parse fix. Under the old positional slots this line
+    // put `WR` in the team field and undefined in the position field, so all
+    // three qualified branches were dead and only the name-only fallback ran.
+    it('uses a position supplied without a team', () => {
+        expect(ids(matchLine('Marquise Brown WR'))).toContain('3');
+    });
+
+    it('returns the best-known player first when a line is ambiguous', () => {
+        // Both Browns match "Brown" alone; search_rank orders the index, and
+        // Fuse returns equal scores in index order.
+        expect(ids(matchLine('M. Brown'))[0]).toBe('3');
+    });
+
+    it('offers alternates for correction, not just the winner', () => {
+        // Bijan and Brian both answer to "B. Robinson", and the panel lets the
+        // user swap the winner for a runner-up - so a line that is genuinely
+        // ambiguous has to come back with more than one candidate.
+        expect(ids(matchLine('B. Robinson')).length).toBeGreaterThan(1);
+    });
+
+    it('caps the candidates it offers', () => {
+        const crowd = Object.fromEntries(
+            Array.from({ length: 12 }, (_, i) => [i, player(String(i), 'Mike', 'Williams', 'NYJ', 'WR', i)]),
+        );
+        expect(matchLine('Mike Williams', crowd).length).toBeLessThanOrEqual(5);
+    });
+
+    it('returns no match for a player who is not in the pool', () => {
+        expect(matchLine('Nobody Whatsoever')).toEqual([]);
+    });
+
+    // The pool carries coaches and staff, which no ranking list ever means.
+    it('never returns a non-playing entry', () => {
+        expect(ids(matchLine('Kyle Shanahan'))).not.toContain('6');
+    });
+
+    it('returns no match for a line with no surname', () => {
+        expect(
+            matchPlayer({ first: 'Bijan', last: undefined, team: null, position: null }, playerIndex(playerInfo)),
+        ).toEqual([]);
+    });
+
+    it('returns no match for a line that parsed to nothing', () => {
+        expect(matchPlayer(parseRankLine(''), playerIndex(playerInfo))).toEqual([]);
+    });
+
+    it('pairs every id with its score', () => {
+        expect(matchLine('Puka Nacua')[0]).toEqual(['5', expect.stringMatching(/^\d\.\d{3}$/)]);
+    });
+});

--- a/src/lib/rankParse.js
+++ b/src/lib/rankParse.js
@@ -1,0 +1,159 @@
+import Fuse from 'fuse.js';
+
+// Turning one pasted line into named fields. Text in, `{ first, last, team,
+// position }` out - and nothing about the player database in here at all.
+//
+// This is half of what used to be `createRankings`. The two halves were fused
+// into a single loop, and the seam is where the bugs lived: the old code
+// carried the parsed pieces in a positional `searchArray` whose slots meant
+// "first, last, team, position" only when every piece had been found. A line
+// with a position and no recognisable team put the position in the team slot
+// and `undefined` in the position slot (see `parseRankLine` below). Named
+// fields make that unrepresentable.
+
+export const POSITIONS = ['QB', 'RB', 'WR', 'TE', 'DEF', 'K'];
+
+// Both spellings of the two clubs Sleeper has been inconsistent about (LA/LAR,
+// JAX/JAC), plus the two non-clubs that appear in ranking exports: FA for an
+// unsigned player and ROOKIE for a pre-draft one. They are here because a
+// pasted line uses them exactly like a team abbreviation, so the parser has to
+// recognise them to strip them off the name.
+const TEAMS = [
+    'CAR',
+    'MIN',
+    'TEN',
+    'GB',
+    'NO',
+    'NYG',
+    'KC',
+    'IND',
+    'LAC',
+    'DAL',
+    'BUF',
+    'CLE',
+    'SEA',
+    'ARI',
+    'LV',
+    'ATL',
+    'LAR',
+    'LA',
+    'FA',
+    'CIN',
+    'SF',
+    'JAX',
+    'JAC',
+    'WAS',
+    'CHI',
+    'PHI',
+    'BAL',
+    'TB',
+    'DEN',
+    'HOU',
+    'PIT',
+    'MIA',
+    'DET',
+    'NE',
+    'NYJ',
+    'ROOKIE',
+];
+
+// Built once at module load rather than per paste. The list is static, so the
+// old code's rebuild-per-call was pure waste - though small waste, like the
+// player index in rankMatch.js. Neither is what makes a paste slow.
+const teamsFuse = new Fuse(TEAMS, { includeScore: true });
+
+/**
+ * The one token in `tokens` that is exactly a team abbreviation, or null.
+ *
+ * Exact only, despite going through Fuse: the `score === 0` test is what makes
+ * it exact. Fuzzy team matching would eat surnames - `Bell` is one edit from
+ * `BAL` - so the fuzziness here buys nothing and the strictness is the point.
+ */
+function findTeam(tokens) {
+    const best = tokens
+        .map((token) => teamsFuse.search(token.replace(/[^a-zA-Z]/g, '')))
+        .filter((results) => results.length > 0)
+        .sort((a, b) => a[0]?.score - b[0]?.score);
+    return best[0] && best[0][0].score === 0 ? best[0][0].item : null;
+}
+
+/**
+ * Strip the punctuation a ranking export puts between initials, without
+ * flattening a player who genuinely goes by them.
+ *
+ * `T.Brady` is one name with a separator; `J.K. Dobbins` is a first name that
+ * is two initials. Position 3 tells them apart: a second period there means
+ * initials, so the separator to fix is the space after them instead.
+ *
+ * Both rules read fixed offsets, so they only work if the name starts at
+ * offset 0. `20. T.Brady` does not: stripping the digits leaves `. T.Brady`,
+ * and the old code blanked the period in place instead of removing it, so
+ * every offset after it was one out and the initials rule silently missed. The
+ * caller trims the leading punctuation off first - see `parseRankLine`.
+ */
+function spaceOutInitials(chars) {
+    if (chars[1] === '.' && chars[3] !== '.') {
+        chars.splice(1, 1, ' ');
+    } else if (chars[1] === '.' && chars[3] === '.' && chars[4] !== ' ') {
+        chars.splice(3, 1, '. ');
+    }
+    return chars;
+}
+
+/**
+ * One pasted line as named fields, or `null` where the line carries no name at
+ * all (a blank, or a row that was nothing but its rank number).
+ *
+ * A null return is not a miss - it is a line that was never a player, and the
+ * caller must not spend a rank on it.
+ *
+ * `team` and `position` are null when the line did not carry them, which is
+ * the fix for the positional-slot bug described at the top of this file: the
+ * old code only looked for either when a line had more than two tokens, then
+ * unshifted whatever it found onto a shared array, so "Bijan Robinson RB"
+ * searched for a player on team `RB` at position `undefined`. It still matched
+ * him, but only via the last-resort name-only branch - every field the line
+ * actually supplied was being spent on a query that could not hit.
+ */
+export function parseRankLine(line) {
+    // Digits go first: a leading "1." rank, a trailing bye week and an ADP
+    // column are all noise, and none of them survive as letters.
+    const withoutDigits = line.replace(/[0-9]/g, '');
+    if (!withoutDigits.trim()) return null;
+
+    // The name has to start at offset 0 for the initials rules to line up, so
+    // whatever the rank number left behind - `. `, `) `, a tab - goes first.
+    const chars = spaceOutInitials(withoutDigits.replace(/^[^a-zA-Z]+/, '').split(''));
+    const lettersOnly = chars.map((char) => char.replace(/[^a-zA-Z\s]/g, '')).join('');
+    if (!lettersOnly.trim()) return null;
+
+    const tokens = lettersOnly
+        .trim()
+        .split(/\s/)
+        .map((token) => token.trim())
+        .filter(Boolean);
+
+    let team = null;
+    let position = null;
+
+    // Only past the second token: the first two are the name, and a surname
+    // like `Metcalf` or a first name like `Ken` must never be read as a
+    // position or a club.
+    if (tokens.length > 2) {
+        const positionIndex = tokens.findIndex((token, index) => POSITIONS.includes(token) && index > 1);
+        if (positionIndex >= 0) {
+            position = tokens.splice(positionIndex, 1)[0];
+        }
+        team = findTeam(tokens.slice(2));
+        if (team) {
+            tokens.splice(tokens.indexOf(team), 1);
+        }
+    }
+
+    return { first: tokens[0], last: tokens[1], team, position };
+}
+
+/** How a parsed line reads back to a user - the miss list is built from this. */
+export function describeParsed({ first, last, team, position }) {
+    return [first, last, team, position].filter(Boolean).join(' ');
+}

--- a/src/lib/rankParse.test.js
+++ b/src/lib/rankParse.test.js
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+import { describeParsed, parseRankLine } from './rankParse.js';
+
+describe('parseRankLine', () => {
+    it('reads a bare first and last name', () => {
+        expect(parseRankLine('Bijan Robinson')).toEqual({
+            first: 'Bijan',
+            last: 'Robinson',
+            team: null,
+            position: null,
+        });
+    });
+
+    it('strips a leading rank number and its period', () => {
+        expect(parseRankLine('1. Bijan Robinson')).toMatchObject({ first: 'Bijan', last: 'Robinson' });
+        expect(parseRankLine('12 Bijan Robinson')).toMatchObject({ first: 'Bijan', last: 'Robinson' });
+    });
+
+    it('picks up a team and a position', () => {
+        expect(parseRankLine('1. Bijan Robinson ATL RB')).toEqual({
+            first: 'Bijan',
+            last: 'Robinson',
+            team: 'ATL',
+            position: 'RB',
+        });
+    });
+
+    // The bug the positional `searchArray` hid: a line with a position and no
+    // recognisable team put the position where the team belonged, and left the
+    // position undefined. Named fields cannot express that.
+    it('keeps a position in the position field when there is no team', () => {
+        expect(parseRankLine('Bijan Robinson RB')).toEqual({
+            first: 'Bijan',
+            last: 'Robinson',
+            team: null,
+            position: 'RB',
+        });
+    });
+
+    it('keeps a team in the team field when there is no position', () => {
+        expect(parseRankLine('Bijan Robinson ATL')).toEqual({
+            first: 'Bijan',
+            last: 'Robinson',
+            team: 'ATL',
+            position: null,
+        });
+    });
+
+    it('expands an initial-and-surname pair written with a period', () => {
+        expect(parseRankLine('T.Brady')).toMatchObject({ first: 'T', last: 'Brady' });
+    });
+
+    // Both initials rules read fixed offsets, so a rank number's leftover
+    // punctuation used to shift the name out from under them: `20. T.Brady`
+    // parsed as the single token `TBrady`, which then crashed the whole paste
+    // (see the no-surname test below).
+    it.each([
+        ['20. T.Brady', 'a period and a space'],
+        ['20) T.Brady', 'a bracket'],
+        ['20 - T.Brady', 'a dash'],
+        ['20\tT.Brady', 'a tab'],
+    ])('expands initials in %s, written after %s', (line) => {
+        expect(parseRankLine(line)).toMatchObject({ first: 'T', last: 'Brady' });
+    });
+
+    it('still finds the team and position on a line with expanded initials', () => {
+        expect(parseRankLine('20. T.Brady TB QB')).toEqual({
+            first: 'T',
+            last: 'Brady',
+            team: 'TB',
+            position: 'QB',
+        });
+    });
+
+    // The old code hunted for the team across every token including the name,
+    // so a line whose *surname* had been mangled into a team code lost it -
+    // `TBrady TB QB` came back with one token and no last name at all.
+    it('never strips a team code out of the first two tokens', () => {
+        expect(parseRankLine('Josh Allen BUF')).toMatchObject({ first: 'Josh', last: 'Allen', team: 'BUF' });
+        expect(parseRankLine('TBrady TB QB')).toMatchObject({ first: 'TBrady', last: 'TB' });
+    });
+
+    it('returns a first name but no surname for a single-token line', () => {
+        // Not null - the line named something. The matcher turns a missing
+        // surname into a miss; the old code fed `undefined` to Fuse, which
+        // threw and took the entire paste down with it.
+        expect(parseRankLine('Nacua')).toMatchObject({ first: 'Nacua', last: undefined });
+    });
+
+    // The counterpart case: a first name that genuinely is two initials must
+    // survive as one token rather than being split at the first period.
+    it('keeps a two-initial first name together', () => {
+        expect(parseRankLine('J.K. Dobbins')).toMatchObject({ first: 'JK', last: 'Dobbins' });
+    });
+
+    it('separates two-initial names written without a space', () => {
+        expect(parseRankLine('J.K.Dobbins')).toMatchObject({ first: 'JK', last: 'Dobbins' });
+    });
+
+    it('drops the apostrophe in a name that has one', () => {
+        expect(parseRankLine("Ja'Marr Chase")).toMatchObject({ first: 'JaMarr', last: 'Chase' });
+    });
+
+    // Both spellings are in circulation for these two clubs, and a list uses
+    // whichever its source used.
+    it.each([
+        ['LA', 'LA'],
+        ['LAR', 'LAR'],
+        ['JAX', 'JAX'],
+        ['JAC', 'JAC'],
+    ])('recognises %s as a team', (abbreviation, expected) => {
+        expect(parseRankLine(`Puka Nacua ${abbreviation}`)).toMatchObject({ team: expected });
+    });
+
+    it('recognises the non-club markers a ranking export uses', () => {
+        expect(parseRankLine('Some Guy FA')).toMatchObject({ team: 'FA' });
+        expect(parseRankLine('Some Guy ROOKIE')).toMatchObject({ team: 'ROOKIE' });
+    });
+
+    // Team detection is exact despite going through a fuzzy index. `Bell` is
+    // one edit from `BAL`, and a surname eaten as a team is unrecoverable.
+    it('does not mistake a surname for the team it nearly spells', () => {
+        expect(parseRankLine('Kenneth Bell WR')).toMatchObject({ last: 'Bell', team: null });
+    });
+
+    it('never reads the first two tokens as a team or position', () => {
+        // `Ken` and `Metcalf` are the name, however much they look like codes.
+        expect(parseRankLine('DK Metcalf')).toEqual({ first: 'DK', last: 'Metcalf', team: null, position: null });
+    });
+
+    it.each([
+        ['an empty line', ''],
+        ['whitespace', '   '],
+        ['a bare rank number', '17'],
+        ['a rank number and punctuation', '17.'],
+    ])('returns null for %s', (_label, line) => {
+        expect(parseRankLine(line)).toBeNull();
+    });
+
+    it('tolerates a tab-separated line, as a spreadsheet paste produces', () => {
+        expect(parseRankLine('1\tBijan Robinson\tATL\tRB')).toEqual({
+            first: 'Bijan',
+            last: 'Robinson',
+            team: 'ATL',
+            position: 'RB',
+        });
+    });
+});
+
+describe('describeParsed', () => {
+    it('reads back every field the line supplied', () => {
+        expect(describeParsed({ first: 'Bijan', last: 'Robinson', team: 'ATL', position: 'RB' })).toBe(
+            'Bijan Robinson ATL RB',
+        );
+    });
+
+    // The miss list is built from this, and it used to interpolate the missing
+    // pieces raw - so a two-word name that matched nothing was reported to the
+    // user as "Couldn't find Bijan Robinson undefined  undefined Rank: 1".
+    it('omits the fields the line did not carry, rather than printing undefined', () => {
+        expect(describeParsed({ first: 'Bijan', last: 'Robinson', team: null, position: null })).toBe('Bijan Robinson');
+    });
+});


### PR DESCRIPTION
`createRankings` was one 175-line function in `src/helpers.js` with a single test covering empty input. Parsing a pasted line and finding the player it names are now `src/lib/rankParse.js` and `src/lib/rankMatch.js`, and `helpers.js` orchestrates them.

The seam turned up three bugs the fused version could hold.

**A single bad line crashed the whole paste.** When a line's name reduces to one token, the old code passed `undefined` to Fuse as the surname, which throws. `20. T.Brady TB QB` does exactly that: both initials rules read fixed character offsets, and the `. ` left behind by the rank number shifted the name out from under them, so it parsed as the one token `TBrady`. Pasting a list containing that line rendered nothing at all. Leading punctuation is trimmed before the offsets are read, and a missing surname is now a miss rather than a throw.

**Three of four query branches were dead on most lines.** Parsed fields were carried in a positional array whose slots only lined up when every field was found, so `Bijan Robinson RB` searched for a player on team `RB` at position `undefined`. Only the name-only fallback ever fired, which made the bug look like nothing worse than mediocre matching. The query is built from the fields the line actually supplied.

**The miss list printed its own internals.** A two-word name that matched nothing read `Couldn't find Bijan Robinson undefined  undefined Rank: 1`.

Also drops a debug `console.log` that fired on every match ranked past 1000.

## Verification

Checked against the deployed player pool (9,379 players from `/api/legacy/players`) rather than fixtures, line by line against the previous implementation:

- 22 of 23 lines produce identical results; the 23rd is the crash, which now resolves to Tom Brady.
- The full 23-line paste went from throwing to 23 matched, 0 missed.

Dropping the dead branches is also the only real speed-up here — search cost is close to linear in branch count. A 200-line paste over an 11k pool:

| line shape | before | after |
| --- | --- | --- |
| name only | 9.55s | 2.56s |
| name + team | 9.67s | 5.10s |
| name + team + position | 9.77s | 10.05s |

Winners identical in all three. Memoizing the player index (also in this change) is worth ~11ms and was never what made a paste slow.

That leaves the honest number bad: a long paste still takes seconds. The cost is the fuzzy surname match scanning every player, and an exact-surname prefilter measures 1.7ms/line against 62.5 — but it stops tolerating a misspelt surname, so it is a matching-quality decision rather than a refactor, and it is not in here.

54 new tests across the three modules, each sabotage-checked. `A.J. Brown` still mismatches to `Marquise Brown`; that is unchanged from before and is the kind of thing an alias table would fix.
