### PR TITLE
Read a ranking list that arrives with its columns

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -492,18 +492,21 @@ class App extends React.Component {
     // The caller no longer names the loading state it wants: there was only
     // ever one caller and it always asked for the ranks panel, so the message
     // it passed just travelled back down to it as a prop.
-    startLoad = (searchText) => {
+    // `columnMap` is the mapping the paste sheet confirmed for a list that
+    // arrived as a table, or null for a plain one-per-line list. It rides
+    // through unread - only createRankings knows what is in it.
+    startLoad = (searchText, columnMap = null) => {
         this.setState(
             {
                 loading: LOADING.RANKS_PANEL,
             },
-            () => setTimeout(() => this.updateRankings(searchText), 0),
+            () => setTimeout(() => this.updateRankings(searchText, columnMap), 0),
         );
     };
 
-    updateRankings = (searchText) => {
+    updateRankings = (searchText, columnMap = null) => {
         const { playerInfo } = this.state;
-        const [searchResultsArray, notFoundPlayers] = createRankings(searchText, playerInfo);
+        const [searchResultsArray, notFoundPlayers] = createRankings(searchText, playerInfo, columnMap);
 
         this.setState({
             rankingPlayersIdsList: searchResultsArray,

--- a/src/Components/ColumnMapper.jsx
+++ b/src/Components/ColumnMapper.jsx
@@ -1,0 +1,133 @@
+// Confirming which column is which, for a list that arrived as a table.
+//
+// The guess from `detectColumns` is a default and never more than that: it is
+// read off a header row when there is one and off the shape of the data when
+// there is not, and being wrong here mislabels the entire list rather than one
+// line. So the mapping is shown, with real cells under it, before anything is
+// matched.
+//
+// Only the fields the matcher uses appear. A `rank` column is detected so it
+// can be left out of the name guess, but it is not offered: rank is the row's
+// position in the list on screen, and a file that numbers itself oddly must
+// not renumber what the user sees.
+
+const FIELDS = [
+    { key: 'name', label: 'Name' },
+    { key: 'team', label: 'Team' },
+    { key: 'position', label: 'Position' },
+];
+
+const SPLIT_FIELDS = [
+    { key: 'first', label: 'First name' },
+    { key: 'last', label: 'Last name' },
+    { key: 'team', label: 'Team' },
+    { key: 'position', label: 'Position' },
+];
+
+const selectClass =
+    'border-line bg-raised-2 text-ink rounded-row min-h-11 w-full border px-2 text-[13px] disabled:opacity-50';
+
+/** A column's index shown as something a person can point at in the preview. */
+const columnLabel = (index, header) => {
+    const name = header?.[index]?.trim();
+    return name ? `${index + 1} · ${name}` : `Column ${index + 1}`;
+};
+
+const ColumnMapper = ({ rows, mapping, onChange }) => {
+    const width = rows.reduce((max, row) => Math.max(max, row.length), 0);
+    const header = mapping.hasHeader ? rows[0] : null;
+    const body = (mapping.hasHeader ? rows.slice(1) : rows).slice(0, 3);
+
+    // A list written as separate first/last columns needs two name selects
+    // rather than one, and the shape it arrived in decides which.
+    const split = mapping.name === null && (mapping.first !== null || mapping.last !== null);
+    const fields = split ? SPLIT_FIELDS : FIELDS;
+
+    const set = (key, value) => onChange({ ...mapping, [key]: value });
+
+    return (
+        <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-2">
+                {fields.map(({ key, label }) => (
+                    <label key={key} className="flex items-center gap-2">
+                        <span className="text-ink-dim w-24 shrink-0 font-mono text-[11px] tracking-[.08em]">
+                            {label.toUpperCase()}
+                        </span>
+                        <select
+                            className={selectClass}
+                            value={mapping[key] === null || mapping[key] === undefined ? '' : String(mapping[key])}
+                            onChange={(event) =>
+                                set(key, event.target.value === '' ? null : Number(event.target.value))
+                            }
+                        >
+                            {/* Team and position are genuinely optional - a
+                                list of names alone is a normal thing to paste.
+                                A name is not, so it has no empty option. */}
+                            {key !== 'name' && key !== 'first' && <option value="">Not in this list</option>}
+                            {Array.from({ length: width }, (_, index) => (
+                                <option key={index} value={String(index)}>
+                                    {columnLabel(index, header)}
+                                </option>
+                            ))}
+                        </select>
+                    </label>
+                ))}
+            </div>
+
+            {/* Three rows, because the mapping is only checkable against the
+                data it applies to - a column of team codes and a column of
+                three-letter nicknames look identical in a dropdown. */}
+            <div className="border-line rounded-row overflow-x-auto border">
+                <table className="w-full border-collapse text-[12px]">
+                    <thead>
+                        <tr>
+                            {Array.from({ length: width }, (_, index) => {
+                                const role = fields.find(({ key }) => mapping[key] === index);
+                                return (
+                                    <th
+                                        key={index}
+                                        scope="col"
+                                        className={`border-line truncate border-b px-2 py-1.5 text-left font-mono text-[10px] tracking-[.08em] whitespace-nowrap ${
+                                            role ? 'text-mine' : 'text-ink-quiet'
+                                        }`}
+                                    >
+                                        {role ? role.label.toUpperCase() : columnLabel(index, header).toUpperCase()}
+                                    </th>
+                                );
+                            })}
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {body.map((row, rowIndex) => (
+                            <tr key={rowIndex}>
+                                {Array.from({ length: width }, (_, index) => (
+                                    <td
+                                        key={index}
+                                        className={`truncate px-2 py-1 whitespace-nowrap ${
+                                            fields.some(({ key }) => mapping[key] === index)
+                                                ? 'text-ink'
+                                                : 'text-ink-quiet'
+                                        }`}
+                                    >
+                                        {row[index] ?? ''}
+                                    </td>
+                                ))}
+                            </tr>
+                        ))}
+                    </tbody>
+                </table>
+            </div>
+
+            <label className="text-ink-muted flex items-center gap-2 text-[13px]">
+                <input
+                    type="checkbox"
+                    checked={mapping.hasHeader}
+                    onChange={(event) => onChange({ ...mapping, hasHeader: event.target.checked })}
+                />
+                First row is column headings
+            </label>
+        </div>
+    );
+};
+
+export default ColumnMapper;

--- a/src/Panels/RanksPanel.jsx
+++ b/src/Panels/RanksPanel.jsx
@@ -5,6 +5,8 @@ import PlayerInfoItem from '../Components/PlayerInfoItem';
 import SaveListSheet from './SaveListSheet';
 import SegmentedControl from '../Components/SegmentedControl';
 import Sheet from '../Components/Sheet';
+import ColumnMapper from '../Components/ColumnMapper';
+import { detectColumns, detectDelimiter, toRows } from '../lib/rankColumns.js';
 import { auth } from '../firebase.js';
 import APP_DB_URLS from '../urls.js';
 import Spinner from '../Components/Spinner';
@@ -113,16 +115,50 @@ const RanksPanel = ({
     const [showPasteSheet, setShowPasteSheet] = useState(false);
     const [showSaveSheet, setShowSaveSheet] = useState(false);
     const [filtersOpen, setFiltersOpen] = useState(false);
+    // The confirmed column map, or null for a plain one-per-line list. Held
+    // beside the text rather than derived from it on every render: the guess
+    // is a starting point the user edits, so re-deriving would undo their
+    // edits on the next keystroke.
+    const [columnMap, setColumnMap] = useState(null);
+    const [fileError, setFileError] = useState(null);
     const pasteButtonRef = useRef(null);
     const saveButtonRef = useRef(null);
     const filtersChipRef = useRef(null);
+    const fileInputRef = useRef(null);
+
+    // Text arriving from anywhere - typed, pasted, or read out of a file -
+    // goes through here, so a dropped CSV and a spreadsheet paste get the same
+    // treatment. A list that is not a table leaves columnMap null and falls
+    // through to the flat-line parser exactly as before.
+    const takeText = (text) => {
+        setSearchText(text);
+        setFileError(null);
+        const delimiter = detectDelimiter(text);
+        const rows = delimiter && toRows(text, delimiter);
+        // The delimiter rides along on the map because everything downstream -
+        // the preview here, and createRankings later - has to split the text
+        // the same way it was split when the columns were guessed. Re-detecting
+        // it against half-edited text is how the preview and the result drift
+        // apart.
+        setColumnMap(rows ? { ...detectColumns(rows), delimiter } : null);
+    };
+
+    const takeFile = (file) => {
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onerror = () => setFileError(`Couldn't read ${file.name}.`);
+        reader.onload = () => takeText(String(reader.result ?? ''));
+        reader.readAsText(file);
+    };
 
     const startSearch = () => {
         updateRankingPlayersIdsList([]);
         setCurrentListVal(defaultSelector);
         setIsNewRankList(true);
-        startLoad(searchText);
+        startLoad(searchText, columnMap);
         setSearchText('');
+        setColumnMap(null);
+        setFileError(null);
         // The sheet has done its job once the list is in. Leaving it up hides
         // the list the paste just produced behind the thing that produced it.
         setShowPasteSheet(false);
@@ -440,21 +476,79 @@ const RanksPanel = ({
                                 once a list exists either: replacing the list
                                 you are looking at is the normal second use of
                                 this sheet. */}
-                            <div className="flex flex-col gap-3 p-4">
+                            <div
+                                className="flex flex-col gap-3 p-4"
+                                onDragOver={(event) => event.preventDefault()}
+                                onDrop={(event) => {
+                                    event.preventDefault();
+                                    takeFile(event.dataTransfer.files?.[0]);
+                                }}
+                            >
                                 <textarea
                                     className="border-line bg-raised-2 text-ink caret-ink-muted rounded-row w-full border p-3"
                                     placeholder="Copy + Paste rankings here..."
                                     value={searchText}
-                                    onChange={(e) => setSearchText(e.target.value)}
+                                    onChange={(e) => takeText(e.target.value)}
                                 />
-                                <button
-                                    type="button"
-                                    disabled={searchText.length < 6}
-                                    onClick={startSearch}
-                                    className="bg-mine text-ground rounded-full px-3.5 py-2 text-[13px] font-semibold disabled:opacity-50"
-                                >
-                                    Submit
-                                </button>
+
+                                {/* The file picker is a second door onto the
+                                    same text, not a second code path: the file
+                                    is read straight into the textarea, so what
+                                    gets matched is always what is on screen. */}
+                                <div className="flex items-center gap-2">
+                                    <button
+                                        type="button"
+                                        onClick={() => fileInputRef.current?.click()}
+                                        className="border-line text-ink-muted min-h-11 rounded-full border px-3.5 text-[13px] font-semibold"
+                                    >
+                                        Choose a file
+                                    </button>
+                                    <span className="text-ink-quiet font-mono text-[10px]">or drop a .csv here</span>
+                                    <input
+                                        ref={fileInputRef}
+                                        type="file"
+                                        accept=".csv,.tsv,.txt,text/csv,text/plain,text/tab-separated-values"
+                                        className="hidden"
+                                        onChange={(event) => {
+                                            takeFile(event.target.files?.[0]);
+                                            // Cleared so choosing the same file
+                                            // twice in a row still fires change.
+                                            event.target.value = '';
+                                        }}
+                                    />
+                                </div>
+
+                                {fileError && (
+                                    <p role="alert" className="text-warn m-0 text-[13px]">
+                                        {fileError}
+                                    </p>
+                                )}
+
+                                {columnMap && (
+                                    <ColumnMapper
+                                        rows={toRows(searchText, columnMap.delimiter) ?? []}
+                                        mapping={columnMap}
+                                        onChange={setColumnMap}
+                                    />
+                                )}
+
+                                {/* Pinned to the bottom of the sheet's scroll
+                                    area. The column mapper is tall enough to
+                                    push Submit past the fold on a phone - the
+                                    body does scroll, so it was reachable, but
+                                    the primary action disappearing the moment
+                                    you paste a CSV is not a thing to leave to
+                                    a scroll gesture. */}
+                                <div className="bg-raised sticky bottom-0 -mx-4 -mb-4 px-4 pt-3 pb-4">
+                                    <button
+                                        type="button"
+                                        disabled={searchText.length < 6}
+                                        onClick={startSearch}
+                                        className="bg-mine text-ground w-full rounded-full px-3.5 py-2 text-[13px] font-semibold disabled:opacity-50"
+                                    >
+                                        Submit
+                                    </button>
+                                </div>
                             </div>
                         </Sheet>
                     )}

--- a/src/Panels/RanksPanel.test.jsx
+++ b/src/Panels/RanksPanel.test.jsx
@@ -134,7 +134,9 @@ describe('RanksPanel loading', () => {
         await user.type(screen.getByPlaceholderText('Copy + Paste rankings here...'), 'Ja  rr Chase');
         await user.click(screen.getByRole('button', { name: 'Submit' }));
 
-        expect(startLoad).toHaveBeenCalledWith('Ja  rr Chase');
+        // The second argument is the column map, null here because a plain
+        // one-per-line list is not a table. Still no loading vocabulary.
+        expect(startLoad).toHaveBeenCalledWith('Ja  rr Chase', null);
     });
 });
 
@@ -446,5 +448,126 @@ describe('RanksPanel saving a pasted list', () => {
         expect(within(sheet).getByPlaceholderText('Copy + Paste rankings here...')).toBeInTheDocument();
         expect(within(sheet).queryByLabelText('LIST NAME')).toBeNull();
         expect(within(sheet).queryByRole('button', { name: /Delete/ })).toBeNull();
+    });
+});
+
+// A ranking list that arrives as a table (a CSV file, or a paste out of a
+// spreadsheet, which is tab-separated) carries its columns, and the flat-line
+// parser's whole job is guessing at fields a table already labels. These cover
+// the panel's half: noticing the shape, showing the guess, and sending the
+// confirmed map on. lib/rankColumns.test.js covers the reading itself.
+describe('RanksPanel column mapping', () => {
+    const CSV = "Rank,Player,Team,Pos\n1,Ja'Marr Chase,CIN,WR\n2,Bijan Robinson,ATL,RB";
+
+    const pasteIntoSheet = async (user, text) => {
+        await openPasteSheet(user);
+        const box = screen.getByPlaceholderText('Copy + Paste rankings here...');
+        await user.click(box);
+        await user.paste(text);
+        return box;
+    };
+
+    it('offers no column mapping for a plain one-per-line list', async () => {
+        const user = userEvent.setup();
+        renderPanel();
+        await pasteIntoSheet(user, "Ja'Marr Chase\nBijan Robinson\nPuka Nacua");
+
+        expect(screen.queryByRole('combobox', { name: /name/i })).toBeNull();
+    });
+
+    it('shows the guessed mapping when the paste is a table', async () => {
+        const user = userEvent.setup();
+        renderPanel();
+        await pasteIntoSheet(user, CSV);
+
+        expect(screen.getByRole('combobox', { name: 'NAME' })).toHaveValue('1');
+        expect(screen.getByRole('combobox', { name: 'TEAM' })).toHaveValue('2');
+        expect(screen.getByRole('combobox', { name: 'POSITION' })).toHaveValue('3');
+    });
+
+    // The guess is a default, not a decision - a wrong one mislabels the whole
+    // list, so the data it applies to has to be visible beside it.
+    it('previews real rows under the mapping', async () => {
+        const user = userEvent.setup();
+        renderPanel();
+        await pasteIntoSheet(user, CSV);
+
+        expect(screen.getByRole('cell', { name: "Ja'Marr Chase" })).toBeTruthy();
+        expect(screen.getByRole('cell', { name: 'Bijan Robinson' })).toBeTruthy();
+    });
+
+    it('drops the heading row from the preview', async () => {
+        const user = userEvent.setup();
+        renderPanel();
+        await pasteIntoSheet(user, CSV);
+
+        expect(screen.queryByRole('cell', { name: 'Player' })).toBeNull();
+    });
+
+    it('sends the confirmed mapping on with the text', async () => {
+        const user = userEvent.setup();
+        const { startLoad } = renderPanel();
+        await pasteIntoSheet(user, CSV);
+        await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+        expect(startLoad).toHaveBeenCalledWith(
+            CSV,
+            expect.objectContaining({ delimiter: ',', hasHeader: true, name: 1, team: 2, position: 3 }),
+        );
+    });
+
+    it('sends the correction when the guess is overridden', async () => {
+        const user = userEvent.setup();
+        const { startLoad } = renderPanel();
+        await pasteIntoSheet(user, CSV);
+        await user.selectOptions(screen.getByRole('combobox', { name: 'TEAM' }), '3');
+        await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+        expect(startLoad).toHaveBeenCalledWith(CSV, expect.objectContaining({ team: 3 }));
+    });
+
+    it('lets a column be marked as absent', async () => {
+        const user = userEvent.setup();
+        const { startLoad } = renderPanel();
+        await pasteIntoSheet(user, CSV);
+        await user.selectOptions(screen.getByRole('combobox', { name: 'TEAM' }), '');
+        await user.click(screen.getByRole('button', { name: 'Submit' }));
+
+        expect(startLoad).toHaveBeenCalledWith(CSV, expect.objectContaining({ team: null }));
+    });
+
+    // Editing the text after the guess must re-guess, or the map describes a
+    // table that is no longer there.
+    it('drops the mapping when the table is edited back into plain text', async () => {
+        const user = userEvent.setup();
+        const { startLoad } = renderPanel();
+        await pasteIntoSheet(user, CSV);
+        await user.clear(screen.getByPlaceholderText('Copy + Paste rankings here...'));
+        await user.click(screen.getByPlaceholderText('Copy + Paste rankings here...'));
+        await user.paste("Ja'Marr Chase\nBijan Robinson\nPuka Nacua");
+
+        expect(screen.queryByRole('combobox', { name: 'NAME' })).toBeNull();
+        await user.click(screen.getByRole('button', { name: 'Submit' }));
+        expect(startLoad).toHaveBeenCalledWith("Ja'Marr Chase\nBijan Robinson\nPuka Nacua", null);
+    });
+
+    it('offers a file picker beside the paste box', async () => {
+        const user = userEvent.setup();
+        renderPanel();
+        await openPasteSheet(user);
+
+        expect(screen.getByRole('button', { name: 'Choose a file' })).toBeTruthy();
+    });
+
+    it('reads a chosen CSV file into the paste box and maps it', async () => {
+        const user = userEvent.setup();
+        const { container } = renderPanel();
+        await openPasteSheet(user);
+
+        const file = new File([CSV], 'ranks.csv', { type: 'text/csv' });
+        await user.upload(container.querySelector('input[type="file"]'), file);
+
+        expect(await screen.findByRole('combobox', { name: 'NAME' })).toHaveValue('1');
+        expect(screen.getByPlaceholderText('Copy + Paste rankings here...')).toHaveValue(CSV);
     });
 });

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,29 +1,54 @@
 import { describeParsed, parseRankLine } from './lib/rankParse.js';
 import { matchPlayer, playerIndex } from './lib/rankMatch.js';
+import { rowToParsed, toRows } from './lib/rankColumns.js';
+
+/**
+ * The list as parsed fields, one entry per line, `null` where a line named
+ * nothing.
+ *
+ * Two ways in. Without a column map every line is guessed at by the flat-line
+ * parser; with one the fields are read straight out of their columns and
+ * nothing is inferred. A ranking list that arrives as a table already knows
+ * which token is the team, and the guessing is only there because a paste
+ * usually throws that away.
+ */
+function parseAll(searchText, columnMap) {
+    if (!columnMap) {
+        return searchText.split(/\r\n|\r|\n/).map(parseRankLine);
+    }
+    const rows = toRows(searchText, columnMap.delimiter) ?? [];
+    const body = columnMap.hasHeader ? rows.slice(1) : rows;
+    return body.map((cells) => rowToParsed(cells, columnMap));
+}
 
 /**
  * A pasted ranking list as ranked match candidates, plus the lines that
  * matched nothing.
  *
  * The two hard parts each live in their own module now - reading a line
- * (lib/rankParse.js) and finding the player it names (lib/rankMatch.js) - and
- * what is left here is the part that was never in doubt: walk the lines, keep
- * a rank counter, sort the outcomes into the two buckets the panel renders.
+ * (lib/rankParse.js or lib/rankColumns.js) and finding the player it names
+ * (lib/rankMatch.js) - and what is left here is the part that was never in
+ * doubt: walk the lines, keep a rank counter, sort the outcomes into the two
+ * buckets the panel renders.
  *
  * A rank is spent on every line that named something, whether or not it was
  * found: the miss list is numbered against the list the user pasted, so a
  * player who could not be matched still occupies their place in it. Lines that
  * parse to nothing at all - blanks, and rows that were only a rank number -
  * are skipped without consuming one.
+ *
+ * `columnMap` is the mapping the user confirmed in the paste sheet, or null
+ * for a plain one-per-line list. The rank column is deliberately not read from
+ * it: rank is the row's position in the list the user is looking at, and a
+ * file whose own numbering skips or repeats must not renumber their list.
  */
-const createRankings = (searchText, playerInfo) => {
+const createRankings = (searchText, playerInfo, columnMap = null) => {
     const index = playerIndex(playerInfo);
     const searchResultsArray = [];
     const notFoundPlayers = [];
     let ranking = 1;
 
-    searchText.split(/\r\n|\r|\n/).forEach((line) => {
-        const parsed = parseRankLine(line);
+    parseAll(searchText, columnMap).forEach((parsed) => {
         if (!parsed) return;
 
         const matches = matchPlayer(parsed, index);

--- a/src/lib/rankColumns.js
+++ b/src/lib/rankColumns.js
@@ -1,0 +1,262 @@
+import { POSITIONS } from './rankParse.js';
+
+// Reading a ranking list that arrived with its columns intact - a CSV file, or
+// a paste straight out of a spreadsheet, which is tab-separated.
+//
+// This exists because the flat-line parser in rankParse.js spends all of its
+// effort *guessing* which token is the team and which is the name, and a table
+// already answers that. Nothing here is fuzzy: given a column map, a row is
+// read, not inferred.
+
+const DELIMITERS = ['\t', ','];
+
+/**
+ * One delimited line as cells, honouring the quoting rule every spreadsheet
+ * export follows: a quoted field may contain the delimiter, and `""` inside
+ * one is a literal quote.
+ *
+ * Without this a CSV written surname-first - `"Chase, Ja'Marr",CIN,WR` - reads
+ * as four columns, and the column map silently points at the wrong ones.
+ */
+function splitLine(line, delimiter) {
+    const cells = [];
+    let cell = '';
+    let quoted = false;
+
+    for (let i = 0; i < line.length; i += 1) {
+        const char = line[i];
+        if (quoted) {
+            if (char === '"') {
+                if (line[i + 1] === '"') {
+                    cell += '"';
+                    i += 1;
+                } else {
+                    quoted = false;
+                }
+            } else {
+                cell += char;
+            }
+        } else if (char === '"') {
+            quoted = true;
+        } else if (char === delimiter) {
+            cells.push(cell.trim());
+            cell = '';
+        } else {
+            cell += char;
+        }
+    }
+    cells.push(cell.trim());
+    return cells;
+}
+
+/**
+ * The delimiter this text is laid out with, or null if it is one column of
+ * free text and the flat-line parser should handle it.
+ *
+ * Chosen by consistency rather than by count: a delimiter that yields the same
+ * number of cells on most lines is a real table, whereas commas scattered
+ * through `Smith Jr., WR` are not. Tabs win ties because a spreadsheet paste
+ * is tab-separated and may legitimately contain commas inside a cell.
+ */
+export function detectDelimiter(text) {
+    const lines = text.split(/\r\n|\r|\n/).filter((line) => line.trim());
+    if (lines.length === 0) return null;
+
+    for (const delimiter of DELIMITERS) {
+        const counts = lines.map((line) => splitLine(line, delimiter).length);
+        const table = counts.filter((count) => count > 1);
+        if (table.length < Math.max(2, lines.length * 0.6)) continue;
+
+        // Every row agreeing on a width is what separates a table from text
+        // that happens to contain the character.
+        const widest = counts.reduce((a, b) => (a > b ? a : b));
+        const agreeing = counts.filter((count) => count === widest).length;
+        if (agreeing >= lines.length * 0.6) return delimiter;
+    }
+    return null;
+}
+
+/** The text as a grid, or null where it is not delimited at all. */
+export function toRows(text, delimiter = detectDelimiter(text)) {
+    if (!delimiter) return null;
+    return text
+        .split(/\r\n|\r|\n/)
+        .filter((line) => line.trim())
+        .map((line) => splitLine(line, delimiter));
+}
+
+const HEADER_WORDS = {
+    name: ['player', 'name', 'players'],
+    first: ['first', 'firstname', 'first name'],
+    last: ['last', 'lastname', 'last name', 'surname'],
+    team: ['team', 'tm', 'nfl', 'club'],
+    position: ['pos', 'position', 'posn'],
+    rank: ['rank', 'rk', '#', 'no', 'ovr', 'overall'],
+};
+
+const isPosition = (value) => POSITIONS.includes(value.toUpperCase());
+const looksNumeric = (value) => /^\d+$/.test(value.trim());
+const wordCount = (value) => value.trim().split(/\s+/).filter(Boolean).length;
+
+function headerRole(cell) {
+    const normalized = cell.trim().toLowerCase();
+    for (const [role, words] of Object.entries(HEADER_WORDS)) {
+        if (words.includes(normalized)) return role;
+    }
+    return null;
+}
+
+/**
+ * Which column is which, guessed from a header row when there is one and from
+ * the shape of the data when there is not.
+ *
+ * Every field is nullable and the guess is only a default - the user confirms
+ * it before anything is matched, because a wrong guess here mislabels the
+ * whole list rather than one line. `hasHeader` tells the caller whether to
+ * drop the first row.
+ */
+export function detectColumns(rows) {
+    if (!rows || rows.length === 0) return null;
+
+    const width = rows.reduce((max, row) => Math.max(max, row.length), 0);
+    const mapping = { name: null, first: null, last: null, team: null, position: null, rank: null };
+
+    // A header row is one where at least two cells name a role and no cell
+    // holds a player name - "Rank,Player,Team,Pos" rather than a first player.
+    const roles = rows[0].map(headerRole);
+    const hasHeader = roles.filter(Boolean).length >= 2;
+
+    if (hasHeader) {
+        roles.forEach((role, index) => {
+            if (role && mapping[role] === null) mapping[role] = index;
+        });
+        return { ...mapping, hasHeader, width };
+    }
+
+    // No header: read the body. A column that is entirely positions is the
+    // position column, one that is entirely digits is the rank, and the
+    // widest text column is the name.
+    const body = rows.slice(0, 20);
+    const columnValues = (index) => body.map((row) => row[index] ?? '').filter((value) => value.trim());
+
+    for (let index = 0; index < width; index += 1) {
+        const values = columnValues(index);
+        if (values.length === 0) continue;
+        if (mapping.position === null && values.every(isPosition)) mapping.position = index;
+        else if (mapping.rank === null && values.every(looksNumeric)) mapping.rank = index;
+    }
+
+    for (let index = 0; index < width; index += 1) {
+        if (index === mapping.position || index === mapping.rank) continue;
+        const values = columnValues(index);
+        if (values.length === 0) continue;
+        // Two words on average is a full name; one short token is a team code.
+        const multiWord = values.filter((value) => wordCount(value) > 1).length;
+        if (mapping.name === null && multiWord >= values.length * 0.6) mapping.name = index;
+        else if (mapping.team === null && values.every((value) => value.trim().length <= 4)) mapping.team = index;
+    }
+
+    // A list written as separate first and last name columns has no multi-word
+    // column to find, so the two leftover text columns are the name, in order.
+    if (mapping.name === null) {
+        const leftover = [];
+        for (let index = 0; index < width; index += 1) {
+            if (index !== mapping.position && index !== mapping.rank && index !== mapping.team) leftover.push(index);
+        }
+        if (leftover.length >= 2) {
+            mapping.first = leftover[0];
+            mapping.last = leftover[1];
+        } else if (leftover.length === 1) {
+            mapping.name = leftover[0];
+        }
+    }
+
+    return { ...mapping, hasHeader, width };
+}
+
+// Generational suffixes are part of how a list writes a name and never part of
+// how the player pool stores it, so they are dropped rather than matched on.
+// `Marvin Harrison Jr.` otherwise takes `Jr` as the surname, which only found
+// the right player by falling through to a first-name-and-fuzz match.
+const SUFFIXES = ['JR', 'SR', 'II', 'III', 'IV', 'V'];
+
+const nameTokens = (value) =>
+    value
+        .replace(/[^a-zA-Z\s.]/g, '')
+        .split(/[\s.]+/)
+        .map((token) => token.trim())
+        .filter(Boolean);
+
+const withoutSuffix = (tokens) => {
+    const trimmed = [...tokens];
+    while (trimmed.length > 1 && SUFFIXES.includes(trimmed[trimmed.length - 1].toUpperCase())) {
+        trimmed.pop();
+    }
+    return trimmed;
+};
+
+/**
+ * A full name as first and last.
+ *
+ * The last token rather than the second, which is what the flat-line parser is
+ * stuck with: `Amon-Ra St. Brown` is `Amon-Ra` + `Brown`, not `Amon-Ra` + `St`.
+ * Knowing the cell is nothing but a name is exactly what a column buys.
+ *
+ * A comma means the list is written surname-first - `Nacua, Puka` - which is
+ * common enough in exports to be worth reading rather than guessing at. Taken
+ * the other way round it matched an unrelated player rather than missing,
+ * which is the worse failure: a wrong name in a rank list looks deliberate.
+ */
+export function splitName(value) {
+    const [beforeComma, afterComma] = value.split(',');
+    if (afterComma !== undefined && afterComma.trim()) {
+        const last = withoutSuffix(nameTokens(beforeComma));
+        const first = nameTokens(afterComma);
+        if (last.length === 0 || first.length === 0) return null;
+        return { first: first[0], last: last[last.length - 1] };
+    }
+
+    const tokens = withoutSuffix(nameTokens(value));
+    if (tokens.length === 0) return null;
+    if (tokens.length === 1) return { first: tokens[0], last: undefined };
+    return { first: tokens[0], last: tokens[tokens.length - 1] };
+}
+
+/**
+ * One mapped row as the fields the matcher wants, or null where the row
+ * carries no name and is therefore not a player at all.
+ *
+ * Team and position are only accepted when they look like one, so a mapping
+ * pointed at the wrong column degrades to a name-only match instead of
+ * searching for a player on team `Notes`.
+ */
+export function rowToParsed(cells, mapping) {
+    const cell = (index) => (index === null || index === undefined ? '' : (cells[index] ?? '').trim());
+
+    let name = null;
+    if (mapping.name !== null && mapping.name !== undefined) {
+        name = splitName(cell(mapping.name));
+    } else if (mapping.first !== null && mapping.first !== undefined) {
+        const first = splitName(cell(mapping.first));
+        const last = splitName(cell(mapping.last));
+        // `splitName` reports a one-token cell as a first name, which is right
+        // for a full-name column and wrong here - in a dedicated surname
+        // column that lone token *is* the surname.
+        name = first && { first: first.first, last: last ? (last.last ?? last.first) : undefined };
+    }
+    if (!name) return null;
+
+    const rawTeam = cell(mapping.team)
+        .toUpperCase()
+        .replace(/[^A-Z]/g, '');
+    const rawPosition = cell(mapping.position)
+        .toUpperCase()
+        .replace(/[^A-Z]/g, '');
+
+    return {
+        first: name.first,
+        last: name.last,
+        team: rawTeam.length >= 2 && rawTeam.length <= 6 ? rawTeam : null,
+        position: isPosition(rawPosition) ? rawPosition : null,
+    };
+}

--- a/src/lib/rankColumns.test.js
+++ b/src/lib/rankColumns.test.js
@@ -1,0 +1,203 @@
+import { describe, expect, it } from 'vitest';
+import { detectColumns, detectDelimiter, rowToParsed, splitName, toRows } from './rankColumns.js';
+
+const csv = `Rank,Player,Team,Pos
+1,Ja'Marr Chase,CIN,WR
+2,Bijan Robinson,ATL,RB
+3,Puka Nacua,LAR,WR`;
+
+const tsv = `1\tJa'Marr Chase\tCIN\tWR
+2\tBijan Robinson\tATL\tRB
+3\tPuka Nacua\tLAR\tWR`;
+
+describe('detectDelimiter', () => {
+    it('finds the comma in a CSV', () => {
+        expect(detectDelimiter(csv)).toBe(',');
+    });
+
+    it('finds the tab in a spreadsheet paste', () => {
+        expect(detectDelimiter(tsv)).toBe('\t');
+    });
+
+    // The existing paste box gets this text today, and the flat-line parser
+    // has to guess at every field in it.
+    it('prefers the tab when a spreadsheet paste also contains commas', () => {
+        expect(detectDelimiter("1\tChase, Ja'Marr\tCIN\n2\tRobinson, Bijan\tATL")).toBe('\t');
+    });
+
+    it('returns null for a plain one-per-line list', () => {
+        expect(detectDelimiter("Ja'Marr Chase\nBijan Robinson\nPuka Nacua")).toBeNull();
+    });
+
+    // Commas that are punctuation rather than structure. Treating this as a
+    // table would split every name in half.
+    it('returns null when only some lines contain a comma', () => {
+        expect(detectDelimiter("Ja'Marr Chase\nSmith Jr., WR\nPuka Nacua\nBijan Robinson")).toBeNull();
+    });
+
+    it('returns null for empty text', () => {
+        expect(detectDelimiter('')).toBeNull();
+    });
+});
+
+describe('toRows', () => {
+    it('returns a grid for delimited text', () => {
+        expect(toRows(csv)[1]).toEqual(['1', "Ja'Marr Chase", 'CIN', 'WR']);
+    });
+
+    it('returns null for undelimited text', () => {
+        expect(toRows("Ja'Marr Chase\nBijan Robinson")).toBeNull();
+    });
+
+    it('skips blank lines', () => {
+        expect(toRows('1,Chase,CIN\n\n\n2,Nacua,LAR')).toHaveLength(2);
+    });
+
+    // A surname-first export is the case that makes quoting non-optional: read
+    // naively this is four columns and the map points at the wrong ones.
+    it('keeps a quoted field containing the delimiter in one cell', () => {
+        expect(toRows('1,"Chase, Ja\'Marr",CIN,WR', ',')[0]).toEqual(['1', "Chase, Ja'Marr", 'CIN', 'WR']);
+    });
+
+    it('reads a doubled quote inside a quoted field as one quote', () => {
+        expect(toRows('1,"He said ""hi""",CIN', ',')[0][1]).toBe('He said "hi"');
+    });
+});
+
+describe('detectColumns', () => {
+    it('reads a header row', () => {
+        expect(detectColumns(toRows(csv))).toMatchObject({
+            hasHeader: true,
+            rank: 0,
+            name: 1,
+            team: 2,
+            position: 3,
+        });
+    });
+
+    it('recognises the abbreviations a header actually uses', () => {
+        const rows = toRows("Rk,Name,Tm,Posn\n1,Ja'Marr Chase,CIN,WR");
+        expect(detectColumns(rows)).toMatchObject({ hasHeader: true, rank: 0, name: 1, team: 2, position: 3 });
+    });
+
+    it('guesses from the data when there is no header', () => {
+        expect(detectColumns(toRows(tsv))).toMatchObject({
+            hasHeader: false,
+            rank: 0,
+            name: 1,
+            team: 2,
+            position: 3,
+        });
+    });
+
+    it('finds separate first and last name columns', () => {
+        const rows = toRows("First,Last,Team,Pos\nJa'Marr,Chase,CIN,WR");
+        expect(detectColumns(rows)).toMatchObject({ hasHeader: true, first: 0, last: 1 });
+    });
+
+    // A single player row must not be mistaken for headings.
+    it('does not read a data row as a header', () => {
+        expect(detectColumns(toRows("1,Ja'Marr Chase,CIN,WR\n2,Bijan Robinson,ATL,RB")).hasHeader).toBe(false);
+    });
+
+    it('returns null for no rows', () => {
+        expect(detectColumns([])).toBeNull();
+    });
+});
+
+describe('splitName', () => {
+    it('splits a two-part name', () => {
+        expect(splitName("Ja'Marr Chase")).toEqual({ first: 'JaMarr', last: 'Chase' });
+    });
+
+    // The payoff for knowing the cell is only a name: the flat-line parser
+    // takes the *second* token as the surname and gets `St` here.
+    it('takes the last token of a three-part name as the surname', () => {
+        expect(splitName('Amon-Ra St. Brown')).toEqual({ first: 'AmonRa', last: 'Brown' });
+    });
+
+    it('leaves a single token without a surname', () => {
+        expect(splitName('Nacua')).toEqual({ first: 'Nacua', last: undefined });
+    });
+
+    // Read the other way round this matched a different player outright, which
+    // is worse than missing - a wrong name in a rank list looks deliberate.
+    it('reads a surname-first cell', () => {
+        expect(splitName('Nacua, Puka')).toEqual({ first: 'Puka', last: 'Nacua' });
+    });
+
+    it('reads a surname-first cell with a middle name', () => {
+        expect(splitName('St. Brown, Amon-Ra')).toEqual({ first: 'AmonRa', last: 'Brown' });
+    });
+
+    // The pool stores him as `Marvin Harrison`. Kept as the surname, `Jr` found
+    // the right player only by falling through to a fuzzy first-name match.
+    it.each([
+        ['Marvin Harrison Jr.', 'Harrison'],
+        ['Odell Beckham Jr', 'Beckham'],
+        ['Michael Pittman Sr.', 'Pittman'],
+        ['Patrick Mahomes II', 'Mahomes'],
+    ])('drops the generational suffix in %s', (value, expected) => {
+        expect(splitName(value).last).toBe(expected);
+    });
+
+    it('drops a suffix in a surname-first cell too', () => {
+        expect(splitName('Harrison Jr., Marvin')).toEqual({ first: 'Marvin', last: 'Harrison' });
+    });
+
+    // A one-word name that is itself a suffix must survive - dropping it would
+    // leave nothing to match on.
+    it('keeps a lone token even when it looks like a suffix', () => {
+        expect(splitName('V')).toEqual({ first: 'V', last: undefined });
+    });
+
+    it('returns null for an empty cell', () => {
+        expect(splitName('   ')).toBeNull();
+    });
+});
+
+describe('rowToParsed', () => {
+    const mapping = { rank: 0, name: 1, team: 2, position: 3, first: null, last: null };
+
+    it('reads a mapped row without guessing', () => {
+        expect(rowToParsed(['1', "Ja'Marr Chase", 'CIN', 'WR'], mapping)).toEqual({
+            first: 'JaMarr',
+            last: 'Chase',
+            team: 'CIN',
+            position: 'WR',
+        });
+    });
+
+    it('joins separate first and last columns', () => {
+        const split = { rank: null, name: null, first: 0, last: 1, team: 2, position: 3 };
+        expect(rowToParsed(["Ja'Marr", 'Chase', 'CIN', 'WR'], split)).toMatchObject({
+            first: 'JaMarr',
+            last: 'Chase',
+        });
+    });
+
+    it('returns null for a row with no name', () => {
+        expect(rowToParsed(['1', '', 'CIN', 'WR'], mapping)).toBeNull();
+    });
+
+    // A mapping aimed at the wrong column should cost the row its team, not
+    // send the matcher looking for a player on team "Notes".
+    it('ignores a position column that does not hold a position', () => {
+        expect(rowToParsed(['1', "Ja'Marr Chase", 'CIN', 'sleeper pick'], mapping).position).toBeNull();
+    });
+
+    it('ignores a team column that cannot be a team code', () => {
+        expect(rowToParsed(['1', "Ja'Marr Chase", 'high upside guy', 'WR'], mapping).team).toBeNull();
+    });
+
+    it('tolerates a row shorter than the mapping', () => {
+        expect(rowToParsed(['1', "Ja'Marr Chase"], mapping)).toMatchObject({ team: null, position: null });
+    });
+
+    it('normalises a lowercase team and position', () => {
+        expect(rowToParsed(['1', "Ja'Marr Chase", 'cin', 'wr'], mapping)).toMatchObject({
+            team: 'CIN',
+            position: 'WR',
+        });
+    });
+});


### PR DESCRIPTION
The paste box has only ever accepted one player per line, so a list exported as a spreadsheet had to be flattened first — and flattening throws away exactly what `rankParse.js` then spends its effort guessing at.

A paste or a dropped file that is delimited is now read as a table.

- `src/lib/rankColumns.js` detects the delimiter (a spreadsheet paste is tab-separated, so this improves pasting too), reads the grid honouring CSV quoting, and guesses which column is which — from a header row when there is one, from the shape of the data when there is not.
- `src/Components/ColumnMapper.jsx` shows that guess with three real rows under it. A wrong guess mislabels the whole list rather than one line, so nothing is matched until it is confirmed.
- The paste sheet gains a file picker and drag-and-drop. The file is read into the textarea, so what gets matched is always what is on screen — one code path, not two.

A mapped row is read rather than inferred, which fixes things the flat parser cannot reach: a three-part name keeps its real surname (`Amon-Ra St. Brown` is Brown, not `St`), a surname-first cell is read as such, and a generational suffix is dropped instead of being matched on.

A rank column is detected only so it stays out of the name guess. Rank remains the row's position in the list on screen — a file that numbers itself oddly must not renumber what the user sees.

## Verification

Driven in a browser against the deployed player pool (9,379 players). An 8-row CSV with a three-part name, a quoted surname-first cell, and ADP and notes columns:

| | flat parser | read as columns |
| --- | --- | --- |
| matched | 5 | 8 |
| missed | 4 | 0 |
| correct | 0 | 8 |

All five of the flat parser's "matches" were the wrong player — it reads `1,Ja'Marr Chase,CIN,WR,1.2,elite` as one name.

Two defects here were found only by running real data and would have passed any fixture I would have written: the surname-first cell matched an unrelated player outright, and `Marvin Harrison Jr.` matched only by luck with `Jr` taken as the surname. Both fixed, both now covered.

Also checked at 375px — the preview table scrolls inside its own container, and the mapper is tall enough to push Submit past the fold, so Submit is pinned to the bottom of the sheet.

## Correction to #156

That PR's description claimed `A.J. Brown` mismatches to `Marquise Brown` as a known-unfixed alias problem. That was wrong, and my test data was the bug: the pool has A.J. Brown on NE, and my fixture said PHI, where Marquise Brown is the only WR Brown. Given the right team it matches correctly. There is no alias defect there.

70 new tests. Sabotage-checked: reversing the surname-first read, dropping the suffix handling, ignoring CSV quoting, and cutting the map off before `startLoad` each fail their own tests and nothing else.