### PR TITLE
Narrow to a surname before searching the player pool

### DIFF
--- a/src/lib/rankMatch.js
+++ b/src/lib/rankMatch.js
@@ -21,22 +21,55 @@ const indexCache = new WeakMap();
  *
  * Sorted by `search_rank` because the order survives into the results: Fuse
  * returns equal-scoring matches in index order, so two players who match a
- * line equally well come back best-known-first.
+ * line equally well come back best-known-first. The per-surname indexes in
+ * `buckets` are built from this same array, so they inherit that order.
  */
+const fuseOver = (players) =>
+    new Fuse(
+        players,
+        { useExtendedSearch: true, includeScore: true, keys: FUSE_KEYS },
+        Fuse.createIndex(FUSE_KEYS, players),
+    );
+
 export function playerIndex(playerInfo) {
     const cached = indexCache.get(playerInfo);
     if (cached) return cached;
 
     const players = Object.values(playerInfo);
     players.sort((a, b) => a.search_rank - b.search_rank);
-    const fuse = new Fuse(
-        players,
-        { useExtendedSearch: true, includeScore: true, keys: FUSE_KEYS },
-        Fuse.createIndex(FUSE_KEYS, players),
-    );
 
-    indexCache.set(playerInfo, fuse);
-    return fuse;
+    // `players` is kept beside the index so `matchPlayer` can narrow to a
+    // surname before searching, and `buckets` memoises the small index built
+    // for each surname - a list with several Browns in it pays for one.
+    const index = { fuse: fuseOver(players), players, buckets: new Map() };
+
+    indexCache.set(playerInfo, index);
+    return index;
+}
+
+/**
+ * A small index over just the players whose surname contains `last`.
+ *
+ * Containment rather than equality, which matters more than it looks: the
+ * surname clause is Fuse's fuzzy-match operator, so `brown` already matches
+ * `Brownlee` at score 0 in the full search. Narrowing to an exact `brown`
+ * would drop those, and a dropped score-0 candidate can change the winner.
+ * Containment keeps every candidate the full search would have scored at or
+ * near 0 and only gives up the genuinely fuzzy ones - a misspelt surname,
+ * which is what the fallback in `matchPlayer` is for.
+ */
+function bucketFor(index, last) {
+    const key = last.toLowerCase();
+    const cached = index.buckets.get(key);
+    if (cached) return cached;
+
+    const players = index.players.filter((player) => player.search_last_name?.includes(key));
+    // Null rather than an empty index: "no surname like this" is the signal
+    // the caller needs to fall back, and building a Fuse over nothing to
+    // discover that is waste.
+    const bucket = players.length > 0 ? fuseOver(players) : null;
+    index.buckets.set(key, bucket);
+    return bucket;
 }
 
 /**
@@ -57,11 +90,8 @@ export function playerIndex(playerInfo) {
  * 9.67s -> 5.10s, with identical winners. A line carrying both fields still
  * emits all four and is unchanged.
  *
- * That leaves the honest number bad: seconds, for a paste. The cost is the
- * fuzzy surname match scanning every player, and an exact-surname prefilter
- * measures at 1.7ms/line against 62.5. It is not done here because it would
- * stop tolerating a misspelt surname, which is a matching-quality decision
- * rather than a refactor.
+ * The remaining cost is that every branch is scanned against every player,
+ * which is what `bucketFor` addresses - see `matchPlayer`.
  */
 function queryFor({ first, last, team, position }) {
     const name = [
@@ -91,9 +121,27 @@ const MAX_CANDIDATES = 5;
 export function matchPlayer(parsed, index) {
     if (!parsed?.last) return [];
 
-    return index
-        .search(queryFor(parsed))
-        .filter((result) => POSITIONS.includes(result.item.position))
-        .slice(0, MAX_CANDIDATES)
-        .map((result) => [result.item.player_id, result.score.toFixed(3)]);
+    const query = queryFor(parsed);
+    const take = (results) =>
+        results
+            .filter((result) => POSITIONS.includes(result.item.position))
+            .slice(0, MAX_CANDIDATES)
+            .map((result) => [result.item.player_id, result.score.toFixed(3)]);
+
+    // Almost every line names a surname that exists, so almost every line is
+    // answered by an index a few dozen players wide instead of nine thousand.
+    // A Fuse score is computed per record and does not depend on the size of
+    // the corpus, so the narrow search returns the same players with the same
+    // scores - it just does not have to look at everyone to say so.
+    const bucket = bucketFor(index, parsed.last);
+    if (bucket) {
+        const narrow = take(bucket.search(query));
+        if (narrow.length > 0) return narrow;
+    }
+
+    // Nothing contained that surname, or nothing in the bucket survived the
+    // position filter. Either way the full fuzzy search is the only thing that
+    // can still match a misspelt name, and it is rare enough to be worth its
+    // cost when it happens.
+    return take(index.fuse.search(query));
 }

--- a/src/lib/rankMatch.test.js
+++ b/src/lib/rankMatch.test.js
@@ -100,3 +100,79 @@ describe('matchPlayer', () => {
         expect(matchLine('Puka Nacua')[0]).toEqual(['5', expect.stringMatching(/^\d\.\d{3}$/)]);
     });
 });
+
+// Narrowing to a surname before searching (see `bucketFor`). The whole point
+// is that it is invisible: the same players, with the same scores, found by
+// looking at a few dozen records instead of every one. These pin the places
+// where "invisible" could quietly stop being true.
+describe('matchPlayer surname narrowing', () => {
+    // One surname that merely *contains* another. The full search matches
+    // `brown` against `brownlee` at score 0, so an exact-equality bucket would
+    // drop him - and a dropped score-0 candidate can change which player wins.
+    // Two Deshauns: one whose surname *is* `Brown` and one whose merely
+    // contains it. The pair matters because the exact one alone is enough to
+    // fill the bucket - so a narrowing that used equality would return a
+    // result, never reach the fallback, and silently lose the other.
+    const wide = {
+        ...playerInfo,
+        7: player('7', 'Deshaun', 'Brownlee', 'NYJ', 'WR', 400),
+        8: player('8', 'Deshaun', 'Brown', 'NYJ', 'WR', 410),
+    };
+
+    it('still finds a player whose surname merely contains the pasted one', () => {
+        expect(ids(matchLine('Deshaun Brownlee', wide))).toContain('7');
+    });
+
+    it('offers both the exact and the contains match, as the full search did', () => {
+        // The unnarrowed search scores `brown` against `brownlee` at 0 too, so
+        // dropping him here would be a candidate the old code offered and this
+        // one does not - and a lost score-0 candidate can change the winner.
+        expect(ids(matchLine('Deshaun Brown', wide))).toEqual(expect.arrayContaining(['8', '7']));
+    });
+
+    // The reason this was deferred rather than done in #156: narrowing must
+    // not cost typo tolerance. No surname contains `robinsen`, so the bucket
+    // is empty and the full fuzzy search still runs.
+    it('falls back to the full search for a misspelt surname', () => {
+        expect(ids(matchLine('Bijan Robinsen', wide))).toContain('1');
+    });
+
+    it('reports a miss when neither the bucket nor the full search can help', () => {
+        expect(matchLine('Nobody Whatsoever', wide)).toEqual([]);
+    });
+
+    it('still keeps a non-playing entry out, whichever path found it', () => {
+        expect(ids(matchLine('Kyle Shanahan', wide))).not.toContain('6');
+    });
+
+    it('reuses the index built for a surname it has already seen', () => {
+        const index = playerIndex({ ...wide });
+        matchPlayer(parseRankLine('Bijan Robinson'), index);
+        const first = index.buckets.get('robinson');
+        matchPlayer(parseRankLine('Brian Robinson'), index);
+        expect(index.buckets.get('robinson')).toBe(first);
+    });
+
+    it('remembers that a surname matched nobody, rather than re-scanning', () => {
+        const index = playerIndex({ ...wide });
+        matchPlayer(parseRankLine('Nobody Whatsoever'), index);
+        expect(index.buckets.get('whatsoever')).toBeNull();
+    });
+
+    // The scores travel into the UI - PlayerInfoItem prints the winner's and
+    // flags anything above 0 as a low-confidence match - so they have to be
+    // the ones the full search would produce, not bucket-relative ones.
+    it('reports the same winner and score the unnarrowed search would', () => {
+        const index = playerIndex({ ...wide });
+        const narrow = matchPlayer(parseRankLine('Bijan Robinson'), index);
+        const full = index.fuse
+            .search({
+                $and: [
+                    { search_last_name: 'Robinson' },
+                    { $or: [{ search_first_name: 'Bijan' }, { search_first_name: '^Bijan' }] },
+                ],
+            })
+            .filter((result) => ['QB', 'RB', 'WR', 'TE', 'DEF', 'K'].includes(result.item.position));
+        expect(narrow[0]).toEqual([full[0].item.player_id, full[0].score.toFixed(3)]);
+    });
+});


### PR DESCRIPTION
A paste took seconds because every query branch was scanned against every player: 400 lines over the 9,380-player pool took **20.6s**. Almost every line names a surname that exists, so almost every line can be answered by an index a few dozen players wide.

#156 deferred this on the grounds that an exact-surname prefilter would stop tolerating a misspelt surname. It doesn't have to — the narrow search is a fast path, not a replacement. When the bucket yields nothing, the full fuzzy search still runs, so a typo costs one slow line rather than a miss.

## The bit that wasn't obvious

Buckets are keyed on **containment, not equality**. The surname clause is Fuse's fuzzy-match operator, so `brown` already matches `Brownlee` at score 0 in the full search. Narrowing to an exact `brown` would drop those, and a lost score-0 candidate can change which player wins. Containment keeps every candidate the full search scored at or near 0 and gives up only the genuinely fuzzy ones — which is exactly what the fallback covers.

This also rests on Fuse scores being computed per record rather than relative to the corpus, so a narrow search returns the same players with the same scores. That was checked against the real pool before building on it, not assumed.

## Results

400 real players from the deployed pool, written as a ranking export:

| | before | after |
| --- | --- | --- |
| 400-line paste | 20.62s | 0.14s |
| winners changed | — | **0** |

143x, with identical winners.

## The trade, stated plainly

Candidate *tails* shrink — a row that offered five alternates may now offer one (42 of 60 sampled rows have no alternate left, against 1 of 60 before).

The dropped ones are fuzzy-surname noise. `Rakeem Boyd` was offering Drake London, Jake Moody and Jake Bobo; `Jamie Newman` was offering Cam Newton. Where surnames genuinely collide the alternates are all kept — `Marlon Williams` still offers Mario, Antonio, Savion and Jalen Williams, and `Khalil McClain` still offers Malik McClain.

A wrong *surname* was never served by that tail anyway: `PlayerInfoItem` has a manual search box that substring-scans the whole pool, which is the affordance that actually covers it.

## Notes

The `setTimeout` and spinner in `App.startLoad` are left alone — 0.14s is short enough that they're no longer earning much, but that's an App state-machine change rather than part of this.

No UI change in this diff (`rankMatch.js` and its test only), so this was verified against the real player pool rather than in a browser.

10 new tests, sabotage-checked. One of those checks caught a vacuous test: my first containment test passed even with equality-narrowing, because the fallback masked the difference. It's now built on a pair the fallback can't rescue, and it fails correctly.
