### PR TITLE
Let an unmatched line be fixed where it is reported

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,6 +31,7 @@ import {
     writeLocalAccount,
     writeRemoteAccount,
 } from './lib/sleeperIdentity.js';
+import { insertAtRank, resolvedEntry } from './lib/rankList.js';
 import { addPlayerToRoster, removePlayerFromLineup, toRosterSlots } from './lib/roster.js';
 import { buildLineupSet, memoizeRosterInfo } from './lib/rosterInfo.js';
 import { resolveMyDisplayName } from './lib/sleeper.js';
@@ -530,6 +531,23 @@ class App extends React.Component {
         this.setState({ rankingPlayersIdsList: newRankingPlayersIdsList });
     };
 
+    // A line the matcher could not place, resolved by hand. Until now a miss
+    // was a dead end: the panel listed it and there was nothing to do about it
+    // but re-paste the whole list with the name spelt differently.
+    //
+    // Functional setState because the two pieces have to move together - the
+    // player joins the list in the same commit the miss leaves it, or a fast
+    // second pick reads a stale list and drops the first one.
+    resolveMissingPlayer = (miss, playerId) => {
+        this.setState((prevState) => ({
+            rankingPlayersIdsList: insertAtRank(
+                prevState.rankingPlayersIdsList,
+                resolvedEntry({ playerId, ranking: miss.ranking, searchString: miss.search_string }),
+            ),
+            notFoundPlayers: prevState.notFoundPlayers.filter((item) => item.ranking !== miss.ranking),
+        }));
+    };
+
     addToRoster = (player) => {
         this.setState((prevState) => addPlayerToRoster({ player, rosterSlots: prevState.rosterSlots }));
     };
@@ -701,6 +719,7 @@ class App extends React.Component {
                 startLoad={this.startLoad}
                 addToRoster={this.addToRoster}
                 updatePlayerId={this.updatePlayerId}
+                resolveMissingPlayer={this.resolveMissingPlayer}
                 notFoundPlayers={notFoundPlayers}
                 rankingPlayersIdsList={rankingPlayersIdsList}
                 myDisplayName={myDisplayName}

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -1092,3 +1092,74 @@ describe('App, connecting a Sleeper account', () => {
         expect(screen.getByText(/couldn't save your sleeper account/i)).toBeInTheDocument();
     });
 });
+
+// Fixing a pasted line the matcher could not place. The pieces are covered
+// apart - insertAtRank in lib/rankList.test.js, the control in
+// RanksPanel.test.jsx - but App.resolveMissingPlayer is the glue that has to
+// move both halves at once, and glue in this file has hidden bugs before.
+describe('App, fixing an unmatched line', () => {
+    beforeEach(() => {
+        localStorage.setItem('sleeper.account', JSON.stringify({ userId: SLEEPER_USER_ID, username: 'ryangh' }));
+        global.fetch = vi.fn(mockFetch);
+    });
+
+    afterEach(() => {
+        // This file keeps one jsdom location for every test in it, so a test
+        // that navigates leaves every later one mounting on that section.
+        window.location.hash = '';
+        localStorage.clear();
+    });
+
+    const pasteAndResolve = async (user) => {
+        render(<App />);
+        await screen.findAllByText(/ryangh/, {}, { timeout: 5000 });
+        await user.click(screen.getAllByRole('button', { name: 'Ranks' })[0]);
+        await user.click(screen.getByRole('button', { name: 'Paste list' }));
+
+        const box = screen.getByPlaceholderText('Copy + Paste rankings here...');
+        await user.click(box);
+        // A real player, then a name nobody has. The second line is the miss,
+        // and it takes rank 2.
+        await user.paste(`1. ${SWAPPED_PLAYER.name}\n2. Zzzz Qqqqmore`);
+        await user.click(screen.getByRole('button', { name: 'Submit' }));
+    };
+
+    it('offers a search for the line it could not place', async () => {
+        const user = userEvent.setup();
+        await pasteAndResolve(user);
+
+        expect(await screen.findByText('1 pasted line matched nothing')).toBeTruthy();
+        expect(screen.getByRole('textbox', { name: /Find a player for/ })).toBeTruthy();
+    });
+
+    it('puts the player picked into the list and drops the miss', async () => {
+        const user = userEvent.setup();
+        await pasteAndResolve(user);
+
+        await screen.findByText('1 pasted line matched nothing');
+        const box = screen.getByRole('textbox', { name: /Find a player for/ });
+        await user.click(box);
+        await user.paste('Marlin');
+        await user.click(await screen.findByRole('button', { name: /Marlin Klein/ }));
+
+        // Both halves, in one commit: the player is in the list and the miss
+        // is gone. Either one alone is a bug this test exists to catch.
+        expect(screen.getByRole('group', { name: /^Marlin Klein, / })).toBeTruthy();
+        expect(screen.queryByText(/matched nothing/)).toBeNull();
+    });
+
+    it('gives the resolved player the rank the miss was holding', async () => {
+        const user = userEvent.setup();
+        await pasteAndResolve(user);
+
+        await screen.findByText('1 pasted line matched nothing');
+        await user.click(screen.getByRole('textbox', { name: /Find a player for/ }));
+        await user.paste('Marlin');
+        await user.click(await screen.findByRole('button', { name: /Marlin Klein/ }));
+
+        // The rank renders as ListRow's leading ordinal - a bare numeral,
+        // not the "Rank: n" label, which only appears in the editing branch.
+        const row = screen.getByRole('group', { name: /^Marlin Klein, / });
+        expect(within(row).getByText('2')).toBeTruthy();
+    });
+});

--- a/src/Components/PlayerInfoItem.jsx
+++ b/src/Components/PlayerInfoItem.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import ListRow from './ListRow';
 import PositionTag from './PositionTag';
+import PlayerSearch from './PlayerSearch';
 import { playerAccessibleName, playerAvailabilityText } from './playerInfoLabels.js';
 import { isInLineup, isTaken, rosteredBy } from '../lib/rosterInfo.js';
 
@@ -17,7 +18,6 @@ const PlayerInfoItem = ({
     myDisplayName,
 }) => {
     const [editingPlayer, setEditingPlayer] = useState(false);
-    const [searchValue, setSearchValue] = useState('');
     const taken = isTaken(rosterInfo, player.player_id);
     const rosteredByName = rosteredBy(rosterInfo, player.player_id);
     const inLineup = isInLineup(lineupSet, player.player_id);
@@ -104,44 +104,11 @@ const PlayerInfoItem = ({
                                     <i>&quot;{searchData.search_string}&quot; </i> - Search score:{' '}
                                     {searchData.match_results[0][1]}
                                 </p>
-                                <input
-                                    type="text"
-                                    onChange={(e) => setSearchValue(e.target.value)}
+                                <PlayerSearch
+                                    playerInfo={playerInfo}
+                                    onPick={updatePlayerInfo}
                                     placeholder="Manually update player"
-                                    className="border-line text-ink bg-raised-2 rounded-row w-full border px-2 py-1 text-sm"
                                 />
-                                {searchValue.length > 2 && (
-                                    <div className="flex max-h-[100px] flex-col gap-1 overflow-y-scroll">
-                                        {Object.values(playerInfo)
-                                            .filter((candidate) =>
-                                                candidate.full_name
-                                                    ? candidate.full_name
-                                                          .toLowerCase()
-                                                          .includes(searchValue.toLowerCase()) &&
-                                                      ['QB', 'RB', 'WR', 'TE'].includes(candidate.position)
-                                                    : null,
-                                            )
-                                            .sort((a, b) => a.search_rank - b.search_rank)
-                                            .map((candidate) => (
-                                                <button
-                                                    type="button"
-                                                    key={candidate.player_id}
-                                                    onClick={() => updatePlayerInfo(candidate.player_id)}
-                                                    className="border-line text-ink hover:border-ink-muted rounded-row flex w-full items-center gap-2 border px-2 py-1 text-left text-sm"
-                                                >
-                                                    <span className="min-w-0 flex-1 truncate">
-                                                        {candidate.full_name}
-                                                    </span>
-                                                    <PositionTag position={candidate.position} />
-                                                    {candidate.team && (
-                                                        <span className="text-ink-muted shrink-0 text-xs">
-                                                            {candidate.team}
-                                                        </span>
-                                                    )}
-                                                </button>
-                                            ))}
-                                    </div>
-                                )}
                             </div>
                         )}
                     </div>

--- a/src/Components/PlayerSearch.jsx
+++ b/src/Components/PlayerSearch.jsx
@@ -1,0 +1,73 @@
+import { useState } from 'react';
+import PositionTag from './PositionTag';
+
+// Finding a player by typing their name. Pulled out of PlayerInfoItem's
+// editing branch, which had the only copy of it: the miss list needs exactly
+// the same control, and the alternative was a second copy that would drift.
+//
+// This is the affordance that actually covers a wrong surname. The candidate
+// list on a matched row only ever holds players the matcher already found, so
+// when it found the wrong person entirely - or nobody - a free search over the
+// whole pool is the way out.
+
+// Ranking lists are about players you can start. The pool also carries
+// kickers, defences, coaches and retired players, and none of them have ever
+// been what someone is reaching for here.
+const SEARCHABLE_POSITIONS = ['QB', 'RB', 'WR', 'TE'];
+
+/** How many characters before searching - below this every list is noise. */
+const MIN_QUERY = 3;
+
+export const findPlayers = (playerInfo, query) => {
+    const needle = query.trim().toLowerCase();
+    if (needle.length < MIN_QUERY) return [];
+    return Object.values(playerInfo)
+        .filter(
+            (candidate) =>
+                candidate.full_name &&
+                SEARCHABLE_POSITIONS.includes(candidate.position) &&
+                candidate.full_name.toLowerCase().includes(needle),
+        )
+        .sort((a, b) => a.search_rank - b.search_rank);
+};
+
+const PlayerSearch = ({ playerInfo, onPick, placeholder = 'Search for a player', label }) => {
+    const [query, setQuery] = useState('');
+    const results = findPlayers(playerInfo, query);
+
+    return (
+        <div className="flex flex-col gap-1">
+            <input
+                type="text"
+                value={query}
+                aria-label={label ?? placeholder}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder={placeholder}
+                className="border-line text-ink bg-raised-2 rounded-row w-full border px-2 py-1 text-sm"
+            />
+            {results.length > 0 && (
+                <div className="flex max-h-[100px] flex-col gap-1 overflow-y-auto">
+                    {results.map((candidate) => (
+                        <button
+                            type="button"
+                            key={candidate.player_id}
+                            onClick={() => {
+                                onPick(candidate.player_id);
+                                setQuery('');
+                            }}
+                            className="border-line text-ink hover:border-ink-muted rounded-row flex w-full items-center gap-2 border px-2 py-1 text-left text-sm"
+                        >
+                            <span className="min-w-0 flex-1 truncate">{candidate.full_name}</span>
+                            <PositionTag position={candidate.position} />
+                            {candidate.team && (
+                                <span className="text-ink-muted shrink-0 text-xs">{candidate.team}</span>
+                            )}
+                        </button>
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default PlayerSearch;

--- a/src/Panels/RanksPanel.jsx
+++ b/src/Panels/RanksPanel.jsx
@@ -6,6 +6,7 @@ import SaveListSheet from './SaveListSheet';
 import SegmentedControl from '../Components/SegmentedControl';
 import Sheet from '../Components/Sheet';
 import ColumnMapper from '../Components/ColumnMapper';
+import PlayerSearch from '../Components/PlayerSearch';
 import { detectColumns, detectDelimiter, toRows } from '../lib/rankColumns.js';
 import { auth } from '../firebase.js';
 import APP_DB_URLS from '../urls.js';
@@ -89,6 +90,7 @@ const RanksPanel = ({
     rankingPlayersIdsList,
     addToRoster,
     updatePlayerId,
+    resolveMissingPlayer,
     notFoundPlayers,
     myDisplayName,
     savedRankLists,
@@ -584,18 +586,37 @@ const RanksPanel = ({
                             />
                         ))}
                         {notFoundPlayers.length > 0 && (
-                            <div className="flex flex-col gap-1 px-1 pt-3">
+                            <div className="flex flex-col gap-2 px-1 pt-4">
                                 <p className="text-ink-dim m-0 font-mono text-[11px]">
                                     {notFoundPlayers.length} pasted line{notFoundPlayers.length === 1 ? '' : 's'}{' '}
                                     matched nothing
                                 </p>
-                                {notFoundPlayers.map((item, index) => (
-                                    <p
-                                        key={`${item}-${index}`}
-                                        className="text-ink-dim m-0 truncate font-mono text-[11px]"
+                                {/* A miss used to be a sentence and nothing
+                                    more, so the only way to fix one was to
+                                    re-paste the whole list with the name spelt
+                                    differently. Each one carries the rank it
+                                    was going to occupy, so a player picked
+                                    here drops into that slot. */}
+                                {notFoundPlayers.map((item) => (
+                                    <div
+                                        key={item.ranking}
+                                        className="border-line rounded-row flex flex-col gap-1.5 border border-dashed p-2.5"
                                     >
-                                        {item}
-                                    </p>
+                                        <span className="flex items-baseline justify-between gap-2">
+                                            <span className="text-ink-muted truncate text-[13px]">
+                                                {item.search_string}
+                                            </span>
+                                            <span className="text-ink-quiet shrink-0 font-mono text-[10px] tracking-[.08em]">
+                                                RANK {item.ranking}
+                                            </span>
+                                        </span>
+                                        <PlayerSearch
+                                            playerInfo={playerInfo}
+                                            onPick={(playerId) => resolveMissingPlayer(item, playerId)}
+                                            placeholder="Find this player…"
+                                            label={`Find a player for “${item.search_string}”`}
+                                        />
+                                    </div>
                                 ))}
                             </div>
                         )}

--- a/src/Panels/RanksPanel.test.jsx
+++ b/src/Panels/RanksPanel.test.jsx
@@ -62,6 +62,7 @@ function renderPanel(overrides = {}) {
         addToRoster: vi.fn(),
         updatePlayerId: vi.fn(),
         notFoundPlayers: [],
+        resolveMissingPlayer: vi.fn(),
         myDisplayName: MY_DISPLAY_NAME,
         // savedRankLists/updateSavedRankLists are lifted to App (see
         // App.jsx's loadSavedRankLists/updateSavedRankLists) - RanksPanel now
@@ -569,5 +570,74 @@ describe('RanksPanel column mapping', () => {
 
         expect(await screen.findByRole('combobox', { name: 'NAME' })).toHaveValue('1');
         expect(screen.getByPlaceholderText('Copy + Paste rankings here...')).toHaveValue(CSV);
+    });
+});
+
+// A pasted line the matcher could not place used to be a sentence and nothing
+// else - the only way to act on one was to re-paste the whole list. Each miss
+// now carries the rank it was going to occupy and offers a search against it.
+describe('RanksPanel unmatched lines', () => {
+    const miss = { ranking: 2, search_string: 'Nobdy Whatsoever' };
+
+    // Marlin Klein is the free agent from the fixture at the top of this file.
+    const searchFor = async (user, text) => {
+        const box = screen.getByRole('textbox', { name: /Find a player for/ });
+        await user.click(box);
+        await user.paste(text);
+        return box;
+    };
+
+    it('says how many lines matched nothing', () => {
+        renderPanel({ notFoundPlayers: [miss] });
+
+        expect(screen.getByText('1 pasted line matched nothing')).toBeTruthy();
+    });
+
+    it('shows what the line said and the rank it was going to take', () => {
+        renderPanel({ notFoundPlayers: [miss] });
+
+        expect(screen.getByText('Nobdy Whatsoever')).toBeTruthy();
+        expect(screen.getByText('RANK 2')).toBeTruthy();
+    });
+
+    it('offers a search against the line, not just a report of it', () => {
+        renderPanel({ notFoundPlayers: [miss] });
+
+        expect(screen.getByRole('textbox', { name: 'Find a player for “Nobdy Whatsoever”' })).toBeTruthy();
+    });
+
+    it('resolves the miss with the player picked', async () => {
+        const user = userEvent.setup();
+        // Empty list: the fixture's own rows render player names too, and the
+        // point here is the name offered by the search.
+        const { resolveMissingPlayer } = renderPanel({ notFoundPlayers: [miss], rankingPlayersIdsList: [] });
+
+        await searchFor(user, 'Marlin');
+        await user.click(screen.getByRole('button', { name: /Marlin Klein/ }));
+
+        expect(resolveMissingPlayer).toHaveBeenCalledWith(miss, FREE_AGENT.id);
+    });
+
+    it('waits for a real query before listing anyone', async () => {
+        const user = userEvent.setup();
+        renderPanel({ notFoundPlayers: [miss], rankingPlayersIdsList: [] });
+
+        await searchFor(user, 'Ma');
+
+        expect(screen.queryByRole('button', { name: /Marlin Klein/ })).toBeNull();
+    });
+
+    it('gives each miss its own search', () => {
+        renderPanel({
+            notFoundPlayers: [miss, { ranking: 5, search_string: 'Someone Else' }],
+        });
+
+        expect(screen.getAllByRole('textbox', { name: /Find a player for/ })).toHaveLength(2);
+    });
+
+    it('says nothing at all when every line matched', () => {
+        renderPanel({ notFoundPlayers: [] });
+
+        expect(screen.queryByText(/matched nothing/)).toBeNull();
     });
 });

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -59,7 +59,11 @@ const createRankings = (searchText, playerInfo, columnMap = null) => {
                 search_string: describeParsed(parsed),
             });
         } else {
-            notFoundPlayers.push(`Couldn't find ${describeParsed(parsed)} Rank: ${ranking}`);
+            // An object rather than the sentence it used to be. A miss is
+            // something the user can now resolve by hand, and resolving it
+            // needs the rank it was going to occupy - which a formatted
+            // string had thrown away.
+            notFoundPlayers.push({ ranking, search_string: describeParsed(parsed) });
         }
         ranking += 1;
     });

--- a/src/helpers.test.js
+++ b/src/helpers.test.js
@@ -40,7 +40,15 @@ describe('createRankings', () => {
     it('reports a line it could not match, without breaking the paste', () => {
         const [results, notFound] = createRankings('Bijan Robinson\nNobody Whatsoever\nPuka Nacua', playerInfo);
         expect(winners(results)).toEqual(['1', '2']);
-        expect(notFound).toEqual(["Couldn't find Nobody Whatsoever Rank: 2"]);
+        expect(notFound).toEqual([{ ranking: 2, search_string: 'Nobody Whatsoever' }]);
+    });
+
+    // The rank is what makes a miss fixable rather than just reported: the
+    // panel offers a search against it, and the player picked drops into this
+    // slot. A formatted sentence had thrown it away.
+    it('carries the rank a miss was going to occupy', () => {
+        const [, notFound] = createRankings('Bijan Robinson\nNobody Whatsoever\nPuka Nacua', playerInfo);
+        expect(notFound[0].ranking).toBe(2);
     });
 
     // A miss still occupies its place in the list the user pasted, so the rank
@@ -50,11 +58,11 @@ describe('createRankings', () => {
         expect(results[0].ranking).toBe(2);
     });
 
-    // The miss message used to interpolate the team and position raw, so a
+    // The miss label used to interpolate the team and position raw, so a
     // two-token name that missed rendered "undefined  undefined" to the user.
-    it('names only the fields the line carried in a miss message', () => {
+    it('names only the fields the line carried in a miss label', () => {
         const [, notFound] = createRankings('Nobody Whatsoever', playerInfo);
-        expect(notFound[0]).not.toMatch(/undefined|null/);
+        expect(notFound[0].search_string).not.toMatch(/undefined|null/);
     });
 
     it.each([

--- a/src/lib/rankList.js
+++ b/src/lib/rankList.js
@@ -1,0 +1,52 @@
+// Putting a resolved player back into the rank list.
+//
+// `ranking` is the list's identity: `updatePlayerId` finds the row to edit or
+// delete by it, so two rows sharing one is a real bug rather than a cosmetic
+// one - an edit lands on whichever came first. That is the constraint this
+// file exists to hold.
+
+/**
+ * `entry` inserted so the list stays ordered by rank and no two rows share a
+ * rank.
+ *
+ * A miss holds the rank it was going to occupy, and while nothing has been
+ * deleted that rank is a genuine gap - a list that missed line 3 is numbered
+ * 1, 2, 4, 5, and putting the resolved player at 3 fills it exactly. So ranks
+ * are left alone wherever they are already increasing, which is what keeps the
+ * *other* pending misses pointing at the right place: collapsing the list to
+ * 1..n here would renumber a row into the slot a miss at rank 7 still owns.
+ *
+ * Deleting a row does renumber to 1..n (see `updatePlayerId`), so after a
+ * delete a pending miss can land on a rank that now exists. Only then does
+ * anything shift, and only the rows at or after the collision, by the least
+ * amount that restores uniqueness.
+ */
+export function insertAtRank(entries, entry) {
+    const rankOf = (item) => Number(item.ranking);
+    const at = entries.findIndex((item) => rankOf(item) >= rankOf(entry));
+    const placed = at === -1 ? [...entries, entry] : [...entries.slice(0, at), entry, ...entries.slice(at)];
+
+    let previous = 0;
+    return placed.map((item) => {
+        const ranking = Math.max(rankOf(item), previous + 1);
+        previous = ranking;
+        return ranking === rankOf(item) ? item : { ...item, ranking };
+    });
+}
+
+/**
+ * The rank-list row for a player the user picked by hand.
+ *
+ * Scored 0.000 because they chose it: the score is the matcher's confidence,
+ * and a human pointing at a name is the one case where there is nothing to be
+ * unconfident about. PlayerInfoItem reads any score above 0 as a low-
+ * confidence match and outlines the row in warning colour, so anything else
+ * here would flag a row the user had just fixed.
+ */
+export function resolvedEntry({ playerId, ranking, searchString }) {
+    return {
+        match_results: [[playerId, '0.000']],
+        ranking,
+        search_string: searchString,
+    };
+}

--- a/src/lib/rankList.test.js
+++ b/src/lib/rankList.test.js
@@ -1,0 +1,90 @@
+import { describe, expect, it } from 'vitest';
+import { insertAtRank, resolvedEntry } from './rankList.js';
+
+const at = (ranking) => ({ ranking, match_results: [[`p${ranking}`, '0.000']], search_string: `player ${ranking}` });
+const ranks = (entries) => entries.map((entry) => entry.ranking);
+
+describe('insertAtRank', () => {
+    // The ordinary case: line 3 missed, so the list is numbered 1, 2, 4, 5 and
+    // the resolved player fills the hole they left.
+    it('fills the gap the miss left, changing nothing else', () => {
+        const entries = [at(1), at(2), at(4), at(5)];
+        expect(ranks(insertAtRank(entries, at(3)))).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    // The property that makes the above safe to do row by row: resolving one
+    // miss must not renumber a row into the slot another miss still owns.
+    it('leaves a later gap alone for the miss that still owns it', () => {
+        const entries = [at(1), at(2), at(4), at(5), at(8)];
+        expect(ranks(insertAtRank(entries, at(3)))).toEqual([1, 2, 3, 4, 5, 8]);
+    });
+
+    it('appends when the miss ranks after everything', () => {
+        expect(ranks(insertAtRank([at(1), at(2)], at(9)))).toEqual([1, 2, 9]);
+    });
+
+    it('inserts at the front when the miss ranks first', () => {
+        expect(ranks(insertAtRank([at(2), at(3)], at(1)))).toEqual([1, 2, 3]);
+    });
+
+    it('inserts into an empty list', () => {
+        expect(ranks(insertAtRank([], at(4)))).toEqual([4]);
+    });
+
+    // Deleting a row renumbers the list to 1..n, so a miss can come back to a
+    // rank that now exists. Two rows sharing a rank would break the edit and
+    // delete controls, which find their row by it.
+    it('shifts the collision out of the way when the rank is taken', () => {
+        const entries = [at(1), at(2), at(3)];
+        expect(ranks(insertAtRank(entries, at(3)))).toEqual([1, 2, 3, 4]);
+    });
+
+    it('puts the resolved player first when it collides', () => {
+        const entries = [at(1), at(2), at(3)];
+        expect(insertAtRank(entries, resolvedEntry({ playerId: 'x', ranking: 3, searchString: 'x' }))[2]).toMatchObject(
+            {
+                match_results: [['x', '0.000']],
+            },
+        );
+    });
+
+    it('shifts only as far as it must', () => {
+        // 4 is free once 3 moves nothing, so 5 and 9 stay put.
+        const entries = [at(1), at(2), at(3), at(5), at(9)];
+        expect(ranks(insertAtRank(entries, at(3)))).toEqual([1, 2, 3, 4, 5, 9]);
+    });
+
+    it('never leaves two rows on the same rank', () => {
+        const entries = [at(1), at(2), at(3), at(4)];
+        const result = insertAtRank(entries, at(2));
+        expect(new Set(ranks(result)).size).toBe(result.length);
+    });
+
+    it('does not mutate the list it was given', () => {
+        const entries = [at(1), at(3)];
+        insertAtRank(entries, at(2));
+        expect(ranks(entries)).toEqual([1, 3]);
+    });
+
+    it('tolerates ranks that arrive as strings', () => {
+        // createRankings emits numbers, but a saved list round-trips through
+        // Firebase, which is not fussy about which it gives back.
+        const entries = [
+            { ...at(1), ranking: '1' },
+            { ...at(1), ranking: '4' },
+        ];
+        expect(ranks(insertAtRank(entries, at(2)))).toEqual(['1', 2, '4']);
+    });
+});
+
+describe('resolvedEntry', () => {
+    it('scores a hand-picked player as certain', () => {
+        // Above 0 renders as a low-confidence match, which would flag the row
+        // the user had just fixed.
+        expect(resolvedEntry({ playerId: '42', ranking: 3, searchString: 'Bijan Robinson' })).toEqual({
+            match_results: [['42', '0.000']],
+            ranking: 3,
+            search_string: 'Bijan Robinson',
+        });
+    });
+});


### PR DESCRIPTION
A pasted line the matcher couldn't place was a dead end. The panel listed it as a sentence, and the only way to act on one was to re-paste the whole list with the name spelt differently.

Each miss now renders with a player search against it, and the player picked drops into the rank slot the miss was holding.

`notFoundPlayers` carries objects rather than formatted strings — fixing a miss needs the rank it was going to occupy, and the sentence had thrown that away.

The search itself is `PlayerInfoItem`'s, extracted to `Components/PlayerSearch`. It had the only copy of this control and the miss list needs exactly the same one; the alternative was a second copy that would drift.

## Where the care went

`ranking` is the list's identity — `updatePlayerId` finds the row to edit or delete by it — so two rows sharing one is a real bug rather than a cosmetic one. `lib/rankList.js` holds that constraint:

- **Ranks are left alone wherever they're already increasing.** A list that missed line 3 is numbered 1, 2, 4, 5, and the resolved player fills the 3 exactly. This is what keeps the *other* pending misses pointing at the right slot — collapsing to 1..n on every resolve would renumber a row into the gap a miss at rank 7 still owns.
- **Deleting a row does renumber to 1..n**, so after a delete a pending miss can come back to a rank that now exists. Only then does anything shift, and only the rows at or after the collision, by the least amount that restores uniqueness.

A hand-picked player scores `0.000`. The score is the matcher's confidence, and a human pointing at a name has nothing to be unconfident about — anything above 0 renders as a low-confidence match and would outline in warning colour the row the user had just fixed.

## Verification

Driven in a browser at 375px, not only tested. Resolving the miss at rank 2 put the player above the existing row at rank 3, the header went "1 player" → "2 players", and the second miss kept **RANK 4** — the gap-preservation property holding in the real UI rather than only in a unit test.

23 new tests across `rankList`, `RanksPanel` and `App`. Three sabotages, each caught by its own tests and nothing else: renumbering contiguously, dropping the collision guard, and letting `App` drop the miss without inserting the player.

The `App` tests are the ones worth having — `resolveMissingPlayer` is glue that has to move both halves in one commit, and glue in that file has hidden bugs before.
