### PR TITLE
Read the tiers a pasted list is already written in

### DIFF
--- a/src/Panels/RanksPanel.jsx
+++ b/src/Panels/RanksPanel.jsx
@@ -8,6 +8,7 @@ import Sheet from '../Components/Sheet';
 import ColumnMapper from '../Components/ColumnMapper';
 import PlayerSearch from '../Components/PlayerSearch';
 import { detectColumns, detectDelimiter, toRows } from '../lib/rankColumns.js';
+import { groupByTier } from '../lib/rankTiers.js';
 import { auth } from '../firebase.js';
 import APP_DB_URLS from '../urls.js';
 import Spinner from '../Components/Spinner';
@@ -352,6 +353,27 @@ const RanksPanel = ({
         )
         .filter((results) => (filters.showRookiesOnly ? playerInfo[results.match_results[0][0]].years_exp < 1 : true));
 
+    // Grouped after filtering, not before: a position chip can empty a tier
+    // out of the middle of a list, and a heading over nothing is worse than no
+    // heading. Null for a list that has no tier structure.
+    const tierGroups = groupByTier(filteredResults);
+
+    const renderRow = (results, i) => (
+        <PlayerInfoItem
+            key={`${results.match_results[0]}${i}`}
+            player={playerInfo[results.match_results[0][0]]}
+            playerInfo={playerInfo}
+            rosterInfo={rosterInfo}
+            lineupSet={lineupSet}
+            isNewRankList={isNewRankList}
+            addToRoster={addToRoster}
+            updatePlayerId={updatePlayerId}
+            searchData={results}
+            adpData={adp?.[results.match_results[0][0]]?.[adpType] ?? null}
+            myDisplayName={myDisplayName}
+        />
+    );
+
     const adpTypeLabel = adpType ? ADP_TYPE_LABELS[adpType] : null;
 
     const nonDefaultFilterCount =
@@ -570,21 +592,32 @@ const RanksPanel = ({
                     )}
 
                     <div className="flex flex-col gap-0.5 px-2">
-                        {filteredResults.map((results, i) => (
-                            <PlayerInfoItem
-                                key={`${results.match_results[0]}${i}`}
-                                player={playerInfo[results.match_results[0][0]]}
-                                playerInfo={playerInfo}
-                                rosterInfo={rosterInfo}
-                                lineupSet={lineupSet}
-                                isNewRankList={isNewRankList}
-                                addToRoster={addToRoster}
-                                updatePlayerId={updatePlayerId}
-                                searchData={results}
-                                adpData={adp?.[results.match_results[0][0]]?.[adpType] ?? null}
-                                myDisplayName={myDisplayName}
-                            />
-                        ))}
+                        {/* Tiers are groups of the same rows, not different
+                            rows, so the row itself is written once and the
+                            grouped and ungrouped shapes both reach for it.
+                            `tierGroups` is null for a list with no tier
+                            structure, which renders exactly as it always
+                            has - no heading, not even one. */}
+                        {tierGroups
+                            ? tierGroups.map((group) => (
+                                  <section key={group.tier} aria-label={group.label} className="flex flex-col gap-0.5">
+                                      {/* The count is pushed to the far edge
+                                          rather than set beside the label: a
+                                          numeral trailing "TIER 2 · SOLID
+                                          STARTERS" by one space reads as part
+                                          of the name of the tier. */}
+                                      <h4 className="border-line-quiet bg-ground sticky top-0 z-10 m-0 flex items-baseline gap-2 border-b px-1.5 py-1.5">
+                                          <span className="text-ink-dim min-w-0 truncate font-mono text-[11px] font-semibold tracking-[.12em] uppercase">
+                                              {group.label}
+                                          </span>
+                                          <span className="text-ink-quiet ml-auto shrink-0 font-mono text-[10px] tracking-[.08em]">
+                                              {group.entries.length}
+                                          </span>
+                                      </h4>
+                                      {group.entries.map(renderRow)}
+                                  </section>
+                              ))
+                            : filteredResults.map(renderRow)}
                         {notFoundPlayers.length > 0 && (
                             <div className="flex flex-col gap-2 px-1 pt-4">
                                 <p className="text-ink-dim m-0 font-mono text-[11px]">

--- a/src/Panels/RanksPanel.test.jsx
+++ b/src/Panels/RanksPanel.test.jsx
@@ -641,3 +641,82 @@ describe('RanksPanel unmatched lines', () => {
         expect(screen.queryByText(/matched nothing/)).toBeNull();
     });
 });
+
+// Tiers render as groups of the same rows, not different rows. The property
+// that matters most is the negative one: a list with no tier structure has to
+// look exactly as it did before any of this existed.
+describe('RanksPanel tiers', () => {
+    const tiered = (playerId, ranking, tier, tier_label) => ({
+        match_results: [[playerId, '0.000']],
+        ranking: String(ranking),
+        search_string: 'a pasted rank line',
+        tier,
+        tier_label,
+    });
+
+    // FREE_AGENT and MY_PLAYER both survive the default filters;
+    // OTHERS_PLAYER does not, which is what the emptied-tier case leans on.
+    const twoTiers = [
+        tiered(FREE_AGENT.id, 1, 1, 'Tier 1 \u00b7 Elite'),
+        tiered(MY_PLAYER.id, 2, 2, 'Tier 2 \u00b7 Solid'),
+    ];
+
+    it('heads each tier with its label', () => {
+        renderPanel({ rankingPlayersIdsList: twoTiers });
+
+        expect(screen.getByRole('heading', { name: /Tier 1 \u00b7 Elite/ })).toBeTruthy();
+        expect(screen.getByRole('heading', { name: /Tier 2 \u00b7 Solid/ })).toBeTruthy();
+    });
+
+    it('counts the players in each tier', () => {
+        renderPanel({
+            rankingPlayersIdsList: [
+                tiered(FREE_AGENT.id, 1, 1, 'Tier 1'),
+                tiered(MY_PLAYER.id, 2, 1, 'Tier 1'),
+                tiered(OTHERS_PLAYER.id, 3, 2, 'Tier 2'),
+            ],
+        });
+
+        const tierOne = screen.getByRole('region', { name: 'Tier 1' });
+        expect(within(tierOne).getByRole('heading').textContent).toContain('2');
+    });
+
+    it('puts each player under their own tier', () => {
+        renderPanel({ rankingPlayersIdsList: twoTiers });
+
+        expect(within(screen.getByRole('region', { name: /Tier 1/ })).getByText(FREE_AGENT.name)).toBeTruthy();
+        expect(within(screen.getByRole('region', { name: /Tier 2/ })).getByText(MY_PLAYER.name)).toBeTruthy();
+    });
+
+    // The reason grouping happens after filtering rather than before.
+    it('drops a tier the filters have emptied, rather than heading nothing', () => {
+        renderPanel({
+            rankingPlayersIdsList: [tiered(FREE_AGENT.id, 1, 1, 'Tier 1'), tiered(OTHERS_PLAYER.id, 2, 2, 'Tier 2')],
+        });
+
+        // Tier 2 holds only someone else's player, hidden by default.
+        expect(screen.getByRole('region', { name: 'Tier 1' })).toBeTruthy();
+        expect(screen.queryByRole('region', { name: 'Tier 2' })).toBeNull();
+    });
+
+    it('keeps the surviving tiers apart when the ones between are filtered out', () => {
+        renderPanel({
+            rankingPlayersIdsList: [
+                tiered(FREE_AGENT.id, 1, 1, 'Tier 1'),
+                tiered(OTHERS_PLAYER.id, 2, 2, 'Tier 2'),
+                tiered(MY_PLAYER.id, 3, 3, 'Tier 3'),
+            ],
+        });
+
+        expect(screen.getByRole('region', { name: 'Tier 1' })).toBeTruthy();
+        expect(screen.getByRole('region', { name: 'Tier 3' })).toBeTruthy();
+    });
+
+    // An untiered list renders as it always has - no heading, not even one.
+    it('draws no tier heading for a list without tiers', () => {
+        renderPanel();
+
+        expect(screen.queryByRole('heading', { name: /Tier/ })).toBeNull();
+        expect(screen.getByText(FREE_AGENT.name)).toBeTruthy();
+    });
+});

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,24 +1,43 @@
-import { describeParsed, parseRankLine } from './lib/rankParse.js';
+import { describeParsed, parseRankLine, readTierMarker } from './lib/rankParse.js';
 import { matchPlayer, playerIndex } from './lib/rankMatch.js';
 import { rowToParsed, toRows } from './lib/rankColumns.js';
+import { TierRun } from './lib/rankTiers.js';
 
 /**
- * The list as parsed fields, one entry per line, `null` where a line named
- * nothing.
+ * The list as a stream of what each line turned out to be: a player, a tier
+ * heading, a blank, or nothing worth a rank.
  *
  * Two ways in. Without a column map every line is guessed at by the flat-line
  * parser; with one the fields are read straight out of their columns and
  * nothing is inferred. A ranking list that arrives as a table already knows
  * which token is the team, and the guessing is only there because a paste
  * usually throws that away.
+ *
+ * Blanks are told apart from junk here, where they used to be lumped together
+ * as "skip": a blank line is how an untitled list separates its tiers, and it
+ * cannot mean that if it has already been discarded. The mapped path has no
+ * equivalent - `toRows` drops empty rows, and no column is offered for tiers -
+ * so a table is always one tier.
  */
-function parseAll(searchText, columnMap) {
-    if (!columnMap) {
-        return searchText.split(/\r\n|\r|\n/).map(parseRankLine);
+function readAll(searchText, columnMap) {
+    if (columnMap) {
+        const rows = toRows(searchText, columnMap.delimiter) ?? [];
+        const body = columnMap.hasHeader ? rows.slice(1) : rows;
+        return body.map((cells) => {
+            const parsed = rowToParsed(cells, columnMap);
+            return parsed ? { kind: 'player', parsed } : { kind: 'skip' };
+        });
     }
-    const rows = toRows(searchText, columnMap.delimiter) ?? [];
-    const body = columnMap.hasHeader ? rows.slice(1) : rows;
-    return body.map((cells) => rowToParsed(cells, columnMap));
+
+    return searchText.split(/\r\n|\r|\n/).map((line) => {
+        if (!line.trim()) return { kind: 'blank' };
+
+        const tier = readTierMarker(line);
+        if (tier) return { kind: 'tier', tier };
+
+        const parsed = parseRankLine(line);
+        return parsed ? { kind: 'player', parsed } : { kind: 'skip' };
+    });
 }
 
 /**
@@ -34,8 +53,8 @@ function parseAll(searchText, columnMap) {
  * A rank is spent on every line that named something, whether or not it was
  * found: the miss list is numbered against the list the user pasted, so a
  * player who could not be matched still occupies their place in it. Lines that
- * parse to nothing at all - blanks, and rows that were only a rank number -
- * are skipped without consuming one.
+ * parse to nothing at all - blanks, tier headings, and rows that were only a
+ * rank number - are skipped without consuming one.
  *
  * `columnMap` is the mapping the user confirmed in the paste sheet, or null
  * for a plain one-per-line list. The rank column is deliberately not read from
@@ -44,31 +63,44 @@ function parseAll(searchText, columnMap) {
  */
 const createRankings = (searchText, playerInfo, columnMap = null) => {
     const index = playerIndex(playerInfo);
+    const items = readAll(searchText, columnMap);
+    const tiers = new TierRun(items);
     const searchResultsArray = [];
     const notFoundPlayers = [];
     let ranking = 1;
 
-    parseAll(searchText, columnMap).forEach((parsed) => {
-        if (!parsed) return;
+    items.forEach((item) => {
+        if (item.kind === 'tier') {
+            tiers.heading(item.tier);
+            return;
+        }
+        if (item.kind === 'blank') {
+            tiers.blank();
+            return;
+        }
+        if (item.kind !== 'player') return;
 
-        const matches = matchPlayer(parsed, index);
+        const tier = tiers.forNextPlayer();
+        const matches = matchPlayer(item.parsed, index);
         if (matches.length > 0) {
             searchResultsArray.push({
                 match_results: matches,
                 ranking,
-                search_string: describeParsed(parsed),
+                search_string: describeParsed(item.parsed),
+                ...tier,
             });
         } else {
             // An object rather than the sentence it used to be. A miss is
             // something the user can now resolve by hand, and resolving it
             // needs the rank it was going to occupy - which a formatted
-            // string had thrown away.
-            notFoundPlayers.push({ ranking, search_string: describeParsed(parsed) });
+            // string had thrown away. It carries its tier for the same
+            // reason: the player picked joins the tier the line was in.
+            notFoundPlayers.push({ ranking, search_string: describeParsed(item.parsed), ...tier });
         }
         ranking += 1;
     });
 
-    return [searchResultsArray, notFoundPlayers];
+    return [tiers.settle(searchResultsArray), tiers.settle(notFoundPlayers)];
 };
 
 export default createRankings;

--- a/src/helpers.test.js
+++ b/src/helpers.test.js
@@ -87,3 +87,109 @@ describe('createRankings', () => {
         expect(winners(results)).toEqual(['3', '1']);
     });
 });
+
+// Tiered lists are ordinary, and both of the ways a list marks them - a
+// heading, or a blank line between groups - were things the parser threw away.
+// A heading was worse than thrown away: `Tier 1` parsed to the name `Tier` and
+// landed in the miss list.
+describe('createRankings tiers', () => {
+    const tiersOf = (results) => results.map((result) => [result.ranking, result.tier, result.tier_label]);
+
+    it('reads tier headings and keeps them out of the list', () => {
+        const [results, notFound] = createRankings(
+            'Tier 1\nBijan Robinson\nPuka Nacua\nTier 2\nB. Robinson WAS',
+            playerInfo,
+        );
+        expect(tiersOf(results)).toEqual([
+            [1, 1, 'Tier 1'],
+            [2, 1, 'Tier 1'],
+            [3, 2, 'Tier 2'],
+        ]);
+        // The headings used to be reported as players nobody could find.
+        expect(notFound).toEqual([]);
+    });
+
+    it('does not spend a rank on a tier heading', () => {
+        const [results] = createRankings('Tier 1\nBijan Robinson\nTier 2\nPuka Nacua', playerInfo);
+        expect(results.map((result) => result.ranking)).toEqual([1, 2]);
+    });
+
+    it('keeps a descriptive heading as the tier label', () => {
+        const [results] = createRankings('Tier 1 - Elite\nBijan Robinson\nTier 2: Solid\nPuka Nacua', playerInfo);
+        expect(results.map((result) => result.tier_label)).toEqual(['Tier 1 \u00b7 Elite', 'Tier 2 \u00b7 Solid']);
+    });
+
+    it('divides on blank lines when the list has no headings', () => {
+        const [results] = createRankings('Bijan Robinson\nPuka Nacua\n\nB. Robinson WAS', playerInfo);
+        expect(tiersOf(results)).toEqual([
+            [1, 1, 'Tier 1'],
+            [2, 1, 'Tier 1'],
+            [3, 2, 'Tier 2'],
+        ]);
+    });
+
+    it('collapses a run of blank lines into one division', () => {
+        const [results] = createRankings('Bijan Robinson\n\n\n\nPuka Nacua', playerInfo);
+        expect(results.map((result) => result.tier)).toEqual([1, 2]);
+    });
+
+    it('ignores blank lines at the top and bottom', () => {
+        // A real second tier in the middle, so the single-tier stripping below
+        // does not hide what this is checking: the leading and trailing blanks
+        // must not open tiers of their own.
+        const [results] = createRankings('\n\nBijan Robinson\nPuka Nacua\n\nB. Robinson WAS\n\n', playerInfo);
+        expect(results.map((result) => result.tier)).toEqual([1, 1, 2]);
+    });
+
+    // In a list with headings, the blank lines are typography. The case that
+    // proves it has to be a blank *between two players inside* a tier - one
+    // sitting next to a heading is absorbed by the heading either way, so it
+    // cannot tell the two rules apart.
+    it('does not also divide on blanks once the list has headings', () => {
+        const [results] = createRankings('Tier 1\nBijan Robinson\n\nPuka Nacua\nTier 2\nB. Robinson WAS', playerInfo);
+        expect(tiersOf(results)).toEqual([
+            [1, 1, 'Tier 1'],
+            [2, 1, 'Tier 1'],
+            [3, 2, 'Tier 2'],
+        ]);
+    });
+
+    it('lets a heading absorb the blank lines written around it', () => {
+        const [results] = createRankings('Tier 1\nBijan Robinson\n\nTier 2\n\nPuka Nacua', playerInfo);
+        expect(results.map((result) => result.tier)).toEqual([1, 2]);
+    });
+
+    // A heading above the first player is naming tier 1, not creating an empty
+    // tier in front of it.
+    it('names tier 1 from a heading that sits above the first player', () => {
+        const [results] = createRankings('Tier 1 - Studs\nBijan Robinson\nTier 2\nPuka Nacua', playerInfo);
+        expect(results.map((result) => result.tier)).toEqual([1, 2]);
+    });
+
+    // The property that keeps every untiered list byte-identical to what it
+    // was before tiers existed - the same fields get saved to Firebase, and
+    // the panel has nothing to draw a divider from.
+    it('leaves an untiered list with no tier fields at all', () => {
+        const [results] = createRankings('Bijan Robinson\nPuka Nacua', playerInfo);
+        expect(results[0]).not.toHaveProperty('tier');
+        expect(results[0]).not.toHaveProperty('tier_label');
+    });
+
+    it('leaves a list with one heading untiered, because one tier is just a list', () => {
+        const [results] = createRankings('Tier 1\nBijan Robinson\nPuka Nacua', playerInfo);
+        expect(results[0]).not.toHaveProperty('tier');
+    });
+
+    // A miss carries its tier so the player picked to resolve it joins the
+    // tier the pasted line was sitting in.
+    it('gives a miss the tier its line was in', () => {
+        const [, notFound] = createRankings('Tier 1\nBijan Robinson\nTier 2\nNobody Whatsoever', playerInfo);
+        expect(notFound[0]).toMatchObject({ ranking: 2, tier: 2, tier_label: 'Tier 2' });
+    });
+
+    it('treats a table as a single untiered list', () => {
+        const map = { name: 1, first: null, last: null, team: 2, position: null, hasHeader: false, delimiter: ',' };
+        const [results] = createRankings('1,Bijan Robinson,ATL\n2,Puka Nacua,LA', playerInfo, map);
+        expect(results[0]).not.toHaveProperty('tier');
+    });
+});

--- a/src/lib/rankParse.js
+++ b/src/lib/rankParse.js
@@ -157,3 +157,29 @@ export function parseRankLine(line) {
 export function describeParsed({ first, last, team, position }) {
     return [first, last, team, position].filter(Boolean).join(' ');
 }
+
+/**
+ * The tier a line announces, or null where it is not announcing one.
+ *
+ * Tiered lists are ordinary, and until now every one of their headings was
+ * read as a player: `Tier 1` parses to the name `Tier` and lands in the miss
+ * list, and `Tier 2 - Elite` parses to `Tier Elite` and could match somebody.
+ * So this is a fix for tiered pastes as much as it is a feature.
+ *
+ * The word `tier` and a number are both required. A bare `T3` is not enough -
+ * ranking lists are full of `RB1`-shaped labels, and guessing wrong here costs
+ * a real player rather than a heading. Surrounding punctuation is stripped, so
+ * `--- Tier 4 ---`, `TIER 3:` and `Tier 2 - Elite` all read.
+ */
+export function readTierMarker(line) {
+    const trimmed = line.replace(/^[^a-zA-Z0-9]+/, '').replace(/[^a-zA-Z0-9]+$/, '');
+    const match = trimmed.match(/^tier\s*[:#-]?\s*(\d+)\s*[:.\-–—]?\s*(.*)$/i);
+    if (!match) return null;
+
+    const [, number, rest] = match;
+    const descriptor = rest.trim();
+    return {
+        number: Number(number),
+        label: descriptor ? `Tier ${number} · ${descriptor}` : `Tier ${number}`,
+    };
+}

--- a/src/lib/rankParse.test.js
+++ b/src/lib/rankParse.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { describeParsed, parseRankLine } from './rankParse.js';
+import { describeParsed, parseRankLine, readTierMarker } from './rankParse.js';
 
 describe('parseRankLine', () => {
     it('reads a bare first and last name', () => {
@@ -159,5 +159,40 @@ describe('describeParsed', () => {
     // user as "Couldn't find Bijan Robinson undefined  undefined Rank: 1".
     it('omits the fields the line did not carry, rather than printing undefined', () => {
         expect(describeParsed({ first: 'Bijan', last: 'Robinson', team: null, position: null })).toBe('Bijan Robinson');
+    });
+});
+
+describe('readTierMarker', () => {
+    it.each([
+        ['Tier 1', 1, 'Tier 1'],
+        ['TIER 3:', 3, 'Tier 3'],
+        ['tier 2', 2, 'Tier 2'],
+        ['--- Tier 4 ---', 4, 'Tier 4'],
+        ['** Tier 5 **', 5, 'Tier 5'],
+        ['Tier #6', 6, 'Tier 6'],
+    ])('reads %s', (line, number, label) => {
+        expect(readTierMarker(line)).toEqual({ number, label });
+    });
+
+    it.each([
+        ['Tier 2 - Elite', 'Tier 2 \u00b7 Elite'],
+        ['Tier 1: Studs', 'Tier 1 \u00b7 Studs'],
+        ['Tier 7 Dart throws', 'Tier 7 \u00b7 Dart throws'],
+    ])('keeps the descriptor in %s', (line, label) => {
+        expect(readTierMarker(line).label).toBe(label);
+    });
+
+    // The word and the number are both required. Ranking lists are full of
+    // `RB1`-shaped labels, and reading one of those as a heading would cost a
+    // real player rather than a heading.
+    it.each([
+        ['a bare abbreviation', 'T3'],
+        ['a positional label', 'RB1'],
+        ['the word with no number', 'Tier'],
+        ['a name that starts with the word', 'Tiernan Smith'],
+        ['a player line', "1. Ja'Marr Chase CIN WR"],
+        ['an empty line', ''],
+    ])('does not read %s as a tier', (_label, line) => {
+        expect(readTierMarker(line)).toBeNull();
     });
 });

--- a/src/lib/rankTiers.js
+++ b/src/lib/rankTiers.js
@@ -1,0 +1,108 @@
+// Working out which tier each player in a pasted list belongs to.
+//
+// Two ways a list says it: a heading (`Tier 3`, `--- Tier 2 - Elite ---`), or
+// a blank line between groups. Both are things the parser used to throw away -
+// a heading became a bogus player and a blank became nothing at all.
+
+/**
+ * The tier state of one pass over a pasted list.
+ *
+ * A run rather than a pure function because tiers are inherently positional:
+ * what tier a player is in depends on every heading and blank above them, and
+ * the caller is already walking the list once to count ranks. This keeps that
+ * one walk and holds the awkward parts - which blanks count, when a heading
+ * opens a tier rather than renaming one - in a place they can be tested.
+ */
+export class TierRun {
+    constructor(items) {
+        // A blank line only divides tiers in a list that has no headings. In
+        // one that has them the headings are the structure, and the blank
+        // lines around them are just typography - counting both would open a
+        // second, empty tier at every heading.
+        this.blanksDivide = !items.some((item) => item.kind === 'tier');
+        this.index = 1;
+        this.label = null;
+        this.occupied = false;
+        this.pendingBreak = false;
+    }
+
+    /**
+     * A heading. It opens a new tier only if the current one already holds
+     * somebody - a heading above the first player is naming tier 1, not
+     * creating an empty one before it.
+     */
+    heading(tier) {
+        if (this.occupied) {
+            this.index += 1;
+            this.occupied = false;
+        }
+        this.label = tier.label;
+        this.pendingBreak = false;
+    }
+
+    /** A blank line. Consecutive ones collapse: `pendingBreak` is a flag. */
+    blank() {
+        if (this.blanksDivide) this.pendingBreak = true;
+    }
+
+    /**
+     * The tier fields to stamp on the next player, advancing first if a blank
+     * line has divided them from the last one.
+     *
+     * The `occupied` test is what stops leading and trailing blanks opening
+     * empty tiers: a break only counts when there is something to break from.
+     */
+    forNextPlayer() {
+        if (this.pendingBreak && this.occupied) {
+            this.index += 1;
+            this.label = null;
+            this.occupied = false;
+        }
+        this.pendingBreak = false;
+        this.occupied = true;
+        return { tier: this.index, tier_label: this.label ?? `Tier ${this.index}` };
+    }
+
+    /**
+     * The entries, with the tier fields dropped if the list turned out to have
+     * only one tier.
+     *
+     * A list with no tier structure must come out exactly as it did before any
+     * of this existed - same fields, so the same thing is saved to Firebase
+     * and the panel has nothing to draw a divider from. One tier is not a tier;
+     * it is just a list.
+     */
+    settle(entries) {
+        if (this.index > 1) return entries;
+        return entries.map((entry) => {
+            const bare = { ...entry };
+            delete bare.tier;
+            delete bare.tier_label;
+            return bare;
+        });
+    }
+}
+
+/**
+ * The entries grouped for rendering, as `[{ tier, label, entries }]`, or null
+ * where the list is not tiered.
+ *
+ * Null rather than one group covering everything, so the panel renders exactly
+ * what it used to for an untiered list rather than a single pointless heading.
+ * Groups are built by walking in order rather than by bucketing, because the
+ * list is already in rank order and that is the order tiers come in.
+ */
+export function groupByTier(entries) {
+    if (!entries.some((entry) => entry.tier)) return null;
+
+    const groups = [];
+    entries.forEach((entry) => {
+        const last = groups[groups.length - 1];
+        if (last && last.tier === entry.tier) {
+            last.entries.push(entry);
+            return;
+        }
+        groups.push({ tier: entry.tier, label: entry.tier_label ?? `Tier ${entry.tier}`, entries: [entry] });
+    });
+    return groups;
+}

--- a/src/lib/rankTiers.test.js
+++ b/src/lib/rankTiers.test.js
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { groupByTier } from './rankTiers.js';
+
+const entry = (ranking, tier, tier_label) => ({
+    ranking,
+    match_results: [[`p${ranking}`, '0.000']],
+    search_string: `player ${ranking}`,
+    ...(tier ? { tier, tier_label } : {}),
+});
+
+describe('groupByTier', () => {
+    it('groups consecutive entries that share a tier', () => {
+        const groups = groupByTier([
+            entry(1, 1, 'Tier 1'),
+            entry(2, 1, 'Tier 1'),
+            entry(3, 2, 'Tier 2'),
+            entry(4, 2, 'Tier 2'),
+        ]);
+        expect(groups.map((group) => [group.tier, group.entries.length])).toEqual([
+            [1, 2],
+            [2, 2],
+        ]);
+    });
+
+    it('carries the label a heading gave the tier', () => {
+        const groups = groupByTier([entry(1, 1, 'Tier 1 · Elite'), entry(2, 2, 'Tier 2 · Solid')]);
+        expect(groups.map((group) => group.label)).toEqual(['Tier 1 · Elite', 'Tier 2 · Solid']);
+    });
+
+    it('falls back to a plain label when a tier has none', () => {
+        expect(groupByTier([entry(1, 1, undefined), entry(2, 2, undefined)])[0].label).toBe('Tier 1');
+    });
+
+    // Null rather than one group covering everything: an untiered list has to
+    // render exactly as it did before tiers existed, with no heading at all.
+    it('returns null for a list with no tiers', () => {
+        expect(groupByTier([entry(1), entry(2), entry(3)])).toBeNull();
+    });
+
+    it('returns null for an empty list', () => {
+        expect(groupByTier([])).toBeNull();
+    });
+
+    // Filtering happens before grouping - a position chip can empty a tier
+    // out of the middle of the list - and the groups that remain must still
+    // be the right ones rather than being merged across the hole.
+    it('keeps tiers apart when the ones between them are filtered away', () => {
+        const groups = groupByTier([entry(1, 1, 'Tier 1'), entry(9, 3, 'Tier 3')]);
+        expect(groups.map((group) => group.tier)).toEqual([1, 3]);
+    });
+});


### PR DESCRIPTION
Tiered lists are ordinary, and both of the ways they mark a tier were being thrown away. A blank line between groups was discarded with the other blanks, and a heading was worse than discarded — `Tier 1` parsed to the name `Tier` and landed in the miss list, and `Tier 2 - Elite` parsed to `Tier Elite` and could match somebody.

So this fixes tiered pastes as much as it adds anything.

## Reading the heading

`readTierMarker` requires the word and a number. Ranking lists are full of `RB1`-shaped labels, and a bare `T3` isn't worth the risk of losing a real player to a misread heading. Surrounding punctuation is stripped, so `--- Tier 4 ---`, `TIER 3:` and `Tier 2 - Elite` all read, and a descriptor becomes part of the label.

## The two awkward rules

Both live in `lib/rankTiers.js`:

- **A blank line divides tiers only in a list with no headings.** Where there are headings the blank lines are typography, and counting both would make a blank *inside* a tier open a new one.
- **A division only counts when there's something to divide from**, which is what stops leading and trailing blanks opening empty tiers.

**A list that turns out to have one tier comes out with no tier fields at all.** One tier is not a tier, it's a list — and an untiered list has to save the same shape to Firebase and render exactly as it did before any of this existed. That's the property most of the risk here sits behind.

Grouping happens after filtering, not before: a position chip can empty a tier out of the middle of a list, and a heading over nothing is worse than no heading.

A table is always one tier — `toRows` drops empty rows and no column is offered for tiers. Worth revisiting if a tier column turns out to be common.

## Verification

Driven in a browser at 375px against a real tiered paste run through the actual `createRankings`, not hand-built state.

The sticky headings needed measuring rather than eyeballing: my first attempt rendered a list that fit the viewport entirely, so nothing scrolled and "it looks sticky" would have been meaningless. With a list long enough to scroll, scrolling 220px pinned the first heading at `top: 0` while the other two moved normally.

The first heading layout was also wrong and the screenshot caught it — the count sat one space after the label, so "TIER 1 · ELITE 3" read as though the tier were named "Elite 3". It's pushed to the far edge now.

## Tests

33 new. Four sabotages, each caught by its own tests and nothing else: letting blanks divide when headings exist, keeping tier fields on a single-tier list, dropping the leading-blank guard, and grouping before filtering.

One of those caught a bad test first — my "blanks don't divide once there are headings" case put the blanks *next to* headings, where a heading absorbs them either way, so it couldn't tell the two rules apart. It now uses a blank between two players inside a tier, and fails correctly.
