### PR TITLE
Start a rank list from the market, without pasting anything

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -486,8 +486,13 @@ class App extends React.Component {
         );
     };
 
+    // Replacing the list drops the misses with it. They belong to the paste
+    // that produced them, so leaving them behind attaches "3 pasted lines
+    // matched nothing" to a list that was never pasted - visible today by
+    // opening a saved list after a paste that missed, and now also the
+    // difference between an imported list and the one before it.
     updateRankingPlayersIdsList = (rankingPlayersIdsList) => {
-        this.setState({ rankingPlayersIdsList });
+        this.setState({ rankingPlayersIdsList, notFoundPlayers: [] });
     };
 
     // The caller no longer names the loading state it wants: there was only

--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -77,6 +77,18 @@ function mockFetch(url) {
     if (url.includes('legacy/players')) {
         return jsonResponse(playerInfo);
     }
+    if (url.includes('/api/v1/values')) {
+        // Two real fixture players, so an imported list can be told apart from
+        // a pasted one on screen.
+        return jsonResponse({
+            settings: { source: 'fantasycalc', format: 'dynasty', numQbs: 2, numTeams: 12, ppr: 1 },
+            asOf: '2026-08-11T08:30:02Z',
+            values: [
+                { playerId: '13307', overallRank: 1, positionRank: 1, value: 9000 },
+                { playerId: '13274', overallRank: 2, positionRank: 1, value: 8000 },
+            ],
+        });
+    }
     if (url.includes('dlf_adp')) {
         // RanksPanel fetches this on mount regardless of the App-level flow
         // under test; give it a successful response so it stays out of the way.
@@ -1161,5 +1173,60 @@ describe('App, fixing an unmatched line', () => {
         // not the "Rank: n" label, which only appears in the editing branch.
         const row = screen.getByRole('group', { name: /^Marlin Klein, / });
         expect(within(row).getByText('2')).toBeTruthy();
+    });
+});
+
+// Importing the market's values, through the real App rather than the panel.
+// The list arrives already keyed by Sleeper id, so what needs an integration
+// test is not the matching (there is none) but the state: a list replaced from
+// any source has to take the previous list's misses with it.
+describe('App, importing market values', () => {
+    beforeEach(() => {
+        localStorage.setItem('sleeper.account', JSON.stringify({ userId: SLEEPER_USER_ID, username: 'ryangh' }));
+        global.fetch = vi.fn(mockFetch);
+    });
+
+    afterEach(() => {
+        window.location.hash = '';
+        localStorage.clear();
+    });
+
+    const openRanks = async (user) => {
+        render(<App />);
+        await screen.findAllByText(/ryangh/, {}, { timeout: 5000 });
+        await user.click(screen.getAllByRole('button', { name: 'Ranks' })[0]);
+    };
+
+    it('fills the rank list from the market', async () => {
+        const user = userEvent.setup();
+        await openRanks(user);
+
+        await user.click(screen.getByRole('button', { name: 'Paste list' }));
+        await user.click(screen.getByRole('button', { name: 'Import as a rank list' }));
+
+        expect(await screen.findByRole('group', { name: /^Marlin Klein, / })).toBeTruthy();
+    });
+
+    // The bug this fixes predates the import: opening a saved list after a
+    // paste that missed left "1 pasted line matched nothing" attached to a
+    // list that was never pasted. Replacing the list from any source drops
+    // the misses with it.
+    it("drops the previous list's misses when a new list replaces it", async () => {
+        const user = userEvent.setup();
+        await openRanks(user);
+
+        // A paste that misses, so there is something to leave behind.
+        await user.click(screen.getByRole('button', { name: 'Paste list' }));
+        const box = screen.getByPlaceholderText('Copy + Paste rankings here...');
+        await user.click(box);
+        await user.paste('1. Zzzz Qqqqmore');
+        await user.click(screen.getByRole('button', { name: 'Submit' }));
+        expect(await screen.findByText(/matched nothing/)).toBeTruthy();
+
+        await user.click(screen.getByRole('button', { name: 'Paste list' }));
+        await user.click(screen.getByRole('button', { name: 'Import as a rank list' }));
+
+        await screen.findByRole('group', { name: /^Marlin Klein, / });
+        expect(screen.queryByText(/matched nothing/)).toBeNull();
     });
 });

--- a/src/Panels/RanksPanel.jsx
+++ b/src/Panels/RanksPanel.jsx
@@ -14,6 +14,9 @@ import APP_DB_URLS from '../urls.js';
 import Spinner from '../Components/Spinner';
 import { isTaken, rosteredBy } from '../lib/rosterInfo.js';
 import { fetchRequest } from '../lib/http.js';
+import { fetchMarketValues } from '../lib/sleeperApi.js';
+import { asOfMillis, settingsLabel, toRankList } from '../lib/marketValues.js';
+import { agoLabel } from '../lib/relativeTime.js';
 import { positionClass } from './pickLabels.js';
 import { usePublishRankList } from '../RankList.jsx';
 const { APP_USERS, TYPE_PARAMS, DLF_ADP } = APP_DB_URLS;
@@ -124,6 +127,14 @@ const RanksPanel = ({
     // edits on the next keystroke.
     const [columnMap, setColumnMap] = useState(null);
     const [fileError, setFileError] = useState(null);
+    // Held from the last import rather than fetched on mount: the settings and
+    // the timestamp are only ever shown next to the import control, and
+    // fetching 31KB of values to label a button nobody has pressed is work for
+    // nothing.
+    const [importing, setImporting] = useState(false);
+    const [importError, setImportError] = useState(null);
+    const [marketSettings, setMarketSettings] = useState(null);
+    const [marketAsOf, setMarketAsOf] = useState(null);
     const pasteButtonRef = useRef(null);
     const saveButtonRef = useRef(null);
     const filtersChipRef = useRef(null);
@@ -152,6 +163,39 @@ const RanksPanel = ({
         reader.onerror = () => setFileError(`Couldn't read ${file.name}.`);
         reader.onload = () => takeText(String(reader.result ?? ''));
         reader.readAsText(file);
+    };
+
+    // The one route into the rank list that parses nothing and matches
+    // nothing: the values arrive keyed by Sleeper id, so `toRankList` is a
+    // lookup rather than a search. Everything the paste box needs
+    // (lib/rankParse.js, lib/rankMatch.js) exists to bridge human text to
+    // those ids, and this side of the sheet never crosses that bridge.
+    const importMarketValues = async () => {
+        setImporting(true);
+        setImportError(null);
+
+        const response = await fetchMarketValues();
+        const entries = toRankList(response?.values, playerInfo);
+        setImporting(false);
+
+        // Three-way, not two: a failed request and a market that has nothing
+        // to say are different, and telling someone their league is fine when
+        // the server is down is the failure this app keeps re-learning.
+        if (!response) {
+            setImportError("Couldn't reach the value feed. Try again, or paste a list below.");
+            return;
+        }
+        if (entries.length === 0) {
+            setImportError('The value feed came back empty. Paste a list below instead.');
+            return;
+        }
+
+        setMarketSettings(settingsLabel(response.settings));
+        setMarketAsOf(asOfMillis(response.asOf));
+        updateRankingPlayersIdsList(entries);
+        setCurrentListVal(defaultSelector);
+        setIsNewRankList(true);
+        setShowPasteSheet(false);
     };
 
     const startSearch = () => {
@@ -508,6 +552,57 @@ const RanksPanel = ({
                                     takeFile(event.dataTransfer.files?.[0]);
                                 }}
                             >
+                                {/* Above the paste box, because it is the only
+                                    thing here that works with nothing in hand.
+                                    A first run otherwise lands on an empty
+                                    Ranks screen with everything downstream -
+                                    best available, the board's order, the
+                                    lineup builder - waiting on a list the user
+                                    has to go and find. */}
+                                <div className="border-line rounded-row flex flex-col gap-2 border p-3">
+                                    <span className="flex items-baseline justify-between gap-2">
+                                        <span className="text-ink text-[14px] font-semibold">
+                                            Start from the market
+                                        </span>
+                                        {marketAsOf && (
+                                            <span className="text-ink-quiet shrink-0 font-mono text-[10px]">
+                                                {agoLabel(marketAsOf)}
+                                            </span>
+                                        )}
+                                    </span>
+                                    {/* Never just "current rankings". These are
+                                        one provider's values at fixed settings,
+                                        and in a 1QB or 10-team league they are
+                                        about a different game rather than
+                                        slightly off. */}
+                                    <span className="text-ink-quiet font-mono text-[10px] tracking-[.06em]">
+                                        {marketSettings
+                                            ? `FantasyCalc · ${marketSettings}`
+                                            : 'FantasyCalc trade values'}
+                                    </span>
+                                    <button
+                                        type="button"
+                                        disabled={importing}
+                                        onClick={importMarketValues}
+                                        className="border-line text-ink min-h-11 rounded-full border px-3.5 text-[13px] font-semibold disabled:opacity-50"
+                                    >
+                                        {importing ? 'Importing…' : 'Import as a rank list'}
+                                    </button>
+                                    {importError && (
+                                        <p role="alert" className="text-warn m-0 text-[13px]">
+                                            {importError}
+                                        </p>
+                                    )}
+                                </div>
+
+                                <span className="flex items-center gap-2.5">
+                                    <span className="bg-line-mid h-px flex-1" />
+                                    <span className="text-ink-dim font-mono text-[10px] tracking-[.14em] uppercase">
+                                        or
+                                    </span>
+                                    <span className="bg-line-mid h-px flex-1" />
+                                </span>
+
                                 <textarea
                                     className="border-line bg-raised-2 text-ink caret-ink-muted rounded-row w-full border p-3"
                                     placeholder="Copy + Paste rankings here..."

--- a/src/Panels/RanksPanel.test.jsx
+++ b/src/Panels/RanksPanel.test.jsx
@@ -720,3 +720,149 @@ describe('RanksPanel tiers', () => {
         expect(screen.getByText(FREE_AGENT.name)).toBeTruthy();
     });
 });
+
+// Importing the market's values. The point of this route is that it does no
+// guessing - the values arrive keyed by Sleeper id - so what these cover is
+// the wiring and, mostly, that the screen does not overclaim about what the
+// numbers are.
+describe('RanksPanel market import', () => {
+    const marketResponse = {
+        settings: { source: 'fantasycalc', format: 'dynasty', numQbs: 2, numTeams: 12, ppr: 1 },
+        asOf: '2026-08-11T08:30:02Z',
+        values: [
+            { playerId: FREE_AGENT.id, overallRank: 1, positionRank: 1, value: 9000 },
+            { playerId: MY_PLAYER.id, overallRank: 2, positionRank: 1, value: 8000 },
+        ],
+    };
+
+    // The ADP request fires on mount and goes through the same global fetch,
+    // so the stub answers by URL rather than unconditionally. It has to be
+    // installed *after* renderPanel, which assigns its own global.fetch and
+    // would otherwise clobber it.
+    const stubFetch = (valuesResponse, { ok = true } = {}) => {
+        global.fetch = vi.fn((url) => {
+            if (String(url).includes('/api/v1/values')) {
+                return ok
+                    ? Promise.resolve({ ok: true, statusText: 'OK', json: () => Promise.resolve(valuesResponse) })
+                    : Promise.resolve({ ok: false, status: 500, statusText: 'Server Error' });
+            }
+            return Promise.resolve({ ok: true, statusText: 'OK', json: () => Promise.resolve({}) });
+        });
+    };
+
+    const openAndImport = async (user) => {
+        await user.click(screen.getByRole('button', { name: 'Paste list' }));
+        await user.click(screen.getByRole('button', { name: 'Import as a rank list' }));
+    };
+
+    it('offers the import above the paste box', async () => {
+        const user = userEvent.setup();
+        renderPanel();
+        stubFetch(marketResponse);
+
+        await user.click(screen.getByRole('button', { name: 'Paste list' }));
+
+        expect(screen.getByRole('button', { name: 'Import as a rank list' })).toBeTruthy();
+    });
+
+    it('builds a rank list in the order the market ranks them', async () => {
+        const user = userEvent.setup();
+        const { updateRankingPlayersIdsList } = renderPanel();
+        stubFetch(marketResponse);
+
+        await openAndImport(user);
+
+        await vi.waitFor(() => expect(updateRankingPlayersIdsList).toHaveBeenCalled());
+        const entries = updateRankingPlayersIdsList.mock.calls.at(-1)[0];
+        expect(entries.map((entry) => entry.match_results[0][0])).toEqual([FREE_AGENT.id, MY_PLAYER.id]);
+        expect(entries.map((entry) => entry.ranking)).toEqual([1, 2]);
+    });
+
+    it('closes the sheet once the list is in', async () => {
+        const user = userEvent.setup();
+        renderPanel();
+        stubFetch(marketResponse);
+
+        await openAndImport(user);
+
+        await vi.waitFor(() => expect(screen.queryByPlaceholderText('Copy + Paste rankings here...')).toBeNull());
+    });
+
+    // The standing rule for this whole feature: the numbers are fine, the
+    // sentence next to them overclaims. These are one provider's values at
+    // fixed settings, and a 1QB league is a different game.
+    it('says what the values are of, rather than calling them the rankings', async () => {
+        const user = userEvent.setup();
+        renderPanel();
+        stubFetch(marketResponse);
+
+        await user.click(screen.getByRole('button', { name: 'Paste list' }));
+
+        expect(screen.getByText(/FantasyCalc/)).toBeTruthy();
+    });
+
+    // It rendered "NaNd ago": the API sends an ISO string and agoLabel
+    // subtracts from Date.now(). Every unit test passed; a browser caught it.
+    it('renders a readable age, not NaN, for the value list', async () => {
+        const user = userEvent.setup();
+        renderPanel();
+        stubFetch(marketResponse);
+
+        await openAndImport(user);
+        await vi.waitFor(() => expect(screen.queryByPlaceholderText('Copy + Paste rankings here...')).toBeNull());
+        await user.click(screen.getByRole('button', { name: 'Paste list' }));
+
+        expect(screen.getByText('Start from the market').closest('div').textContent).not.toMatch(/NaN/);
+    });
+
+    it('shows the settings it read back from the response', async () => {
+        const user = userEvent.setup();
+        renderPanel();
+        stubFetch(marketResponse);
+
+        await openAndImport(user);
+        await vi.waitFor(() => expect(screen.queryByPlaceholderText('Copy + Paste rankings here...')).toBeNull());
+        await user.click(screen.getByRole('button', { name: 'Paste list' }));
+
+        expect(screen.getByText(/Dynasty · superflex · 12-team · PPR/)).toBeTruthy();
+    });
+
+    it('says so when the feed cannot be reached, rather than emptying the list', async () => {
+        const user = userEvent.setup();
+        const { updateRankingPlayersIdsList } = renderPanel();
+        stubFetch(null, { ok: false });
+
+        await openAndImport(user);
+
+        expect(await screen.findByRole('alert')).toHaveTextContent(/Couldn't reach the value feed/);
+        expect(updateRankingPlayersIdsList).not.toHaveBeenCalled();
+    });
+
+    // A reachable feed with nothing in it is a different situation from an
+    // unreachable one, and collapsing them tells someone the server is down
+    // when it is answering.
+    it('tells an empty feed apart from an unreachable one', async () => {
+        const user = userEvent.setup();
+        const { updateRankingPlayersIdsList } = renderPanel();
+        stubFetch({ settings: marketResponse.settings, asOf: null, values: [] });
+
+        await openAndImport(user);
+
+        expect(await screen.findByRole('alert')).toHaveTextContent(/came back empty/);
+        expect(updateRankingPlayersIdsList).not.toHaveBeenCalled();
+    });
+
+    it('drops a value the player pool has never heard of', async () => {
+        const user = userEvent.setup();
+        const { updateRankingPlayersIdsList } = renderPanel();
+        stubFetch({
+            ...marketResponse,
+            values: [...marketResponse.values, { playerId: '99999999', overallRank: 3, positionRank: 9, value: 1 }],
+        });
+
+        await openAndImport(user);
+
+        await vi.waitFor(() => expect(updateRankingPlayersIdsList).toHaveBeenCalled());
+        expect(updateRankingPlayersIdsList.mock.calls.at(-1)[0]).toHaveLength(2);
+    });
+});

--- a/src/lib/marketValues.js
+++ b/src/lib/marketValues.js
@@ -1,0 +1,66 @@
+// Turning the market's value list into a rank list.
+//
+// This is the one way into the rank list that does no guessing. Every other
+// route starts with text a human pasted and has to work out which of nine
+// thousand players each line meant - see lib/rankParse.js and lib/rankMatch.js
+// for how much machinery that takes. The values arrive keyed by Sleeper id,
+// so there is nothing to parse and nothing that can be matched to the wrong
+// person.
+
+/**
+ * The response's `asOf` as epoch milliseconds, or null.
+ *
+ * The API sends an ISO string and `agoLabel` subtracts from `Date.now()`, so
+ * handing the string straight over renders `NaNd ago` - which is what it did,
+ * and what no test caught until it was looked at in a browser. Converting here
+ * rather than at the call site puts it somewhere it can be tested.
+ */
+export function asOfMillis(asOf) {
+    if (!asOf) return null;
+    const millis = Date.parse(asOf);
+    return Number.isNaN(millis) ? null : millis;
+}
+
+/** How the settings read in a sentence, so nothing has to claim more. */
+export function settingsLabel(settings) {
+    if (!settings) return null;
+    const { format, numQbs, numTeams, ppr } = settings;
+    return [
+        format === 'dynasty' ? 'Dynasty' : format,
+        numQbs >= 2 ? 'superflex' : `${numQbs}QB`,
+        `${numTeams}-team`,
+        ppr === 1 ? 'PPR' : ppr === 0.5 ? 'half-PPR' : `${ppr} PPR`,
+    ]
+        .filter(Boolean)
+        .join(' · ');
+}
+
+/**
+ * The value list as rank-list entries, in the order the market ranks them.
+ *
+ * Scored `0.000` for the same reason a hand-picked player is: the score is
+ * the *matcher's* confidence, and nothing here was matched. Anything above 0
+ * renders as a low-confidence match and would outline every row in the list
+ * in warning colour.
+ *
+ * Ranks are the position in this list, not `overallRank` from the response.
+ * The two agree while every player is known, and diverge the moment one is
+ * not - a rank list numbered 1, 2, 4 because the player at 3 is missing from
+ * the pool is showing the user a gap they cannot act on and did not create.
+ *
+ * A value the player database has never heard of is dropped. In practice the
+ * feed and the pool agree (checked against the deployed pair: 0 of 439
+ * unjoinable), but the pool is refreshed by a different nightly job than the
+ * values are, so a player can exist in one and not yet the other.
+ */
+export function toRankList(values, playerInfo) {
+    if (!values?.length) return [];
+
+    return values
+        .filter((entry) => playerInfo?.[entry.playerId])
+        .map((entry, index) => ({
+            match_results: [[entry.playerId, '0.000']],
+            ranking: index + 1,
+            search_string: playerInfo[entry.playerId].full_name ?? entry.playerId,
+        }));
+}

--- a/src/lib/marketValues.test.js
+++ b/src/lib/marketValues.test.js
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+import { asOfMillis, settingsLabel, toRankList } from './marketValues.js';
+
+const playerInfo = {
+    1: { player_id: '1', full_name: 'Josh Allen', position: 'QB', team: 'BUF' },
+    2: { player_id: '2', full_name: 'Bijan Robinson', position: 'RB', team: 'ATL' },
+    3: { player_id: '3', full_name: "Ja'Marr Chase", position: 'WR', team: 'CIN' },
+};
+
+const value = (playerId, overallRank) => ({ playerId, overallRank, positionRank: 1, value: 1000 - overallRank });
+
+describe('toRankList', () => {
+    it('keeps the order the market ranks them in', () => {
+        const list = toRankList([value('2', 1), value('3', 2), value('1', 3)], playerInfo);
+        expect(list.map((entry) => entry.match_results[0][0])).toEqual(['2', '3', '1']);
+    });
+
+    it('numbers from one', () => {
+        const list = toRankList([value('1', 1), value('2', 2)], playerInfo);
+        expect(list.map((entry) => entry.ranking)).toEqual([1, 2]);
+    });
+
+    // Nothing here was matched, so nothing can be a low-confidence match -
+    // above 0 outlines the row in warning colour.
+    it('scores every entry as certain', () => {
+        expect(toRankList([value('1', 1)], playerInfo)[0].match_results[0][1]).toBe('0.000');
+    });
+
+    it('labels each entry with the player it means', () => {
+        expect(toRankList([value('1', 1)], playerInfo)[0].search_string).toBe('Josh Allen');
+    });
+
+    // The pool and the values are refreshed by different nightly jobs, so one
+    // can carry a player the other does not yet.
+    it('drops a player the pool has never heard of', () => {
+        const list = toRankList([value('1', 1), value('999', 2), value('2', 3)], playerInfo);
+        expect(list.map((entry) => entry.match_results[0][0])).toEqual(['1', '2']);
+    });
+
+    // The rank is the position in the list, not the market's own number. A
+    // list numbered 1, 2, 4 shows a gap the user cannot act on and did not
+    // create.
+    it('closes the gap a dropped player would leave in the numbering', () => {
+        const list = toRankList([value('1', 1), value('999', 2), value('2', 3)], playerInfo);
+        expect(list.map((entry) => entry.ranking)).toEqual([1, 2]);
+    });
+
+    it.each([
+        ['an empty list', []],
+        ['no list at all', undefined],
+        ['a null list', null],
+    ])('returns nothing for %s', (_label, values) => {
+        expect(toRankList(values, playerInfo)).toEqual([]);
+    });
+
+    it('returns nothing when the player pool has not loaded', () => {
+        expect(toRankList([value('1', 1)], undefined)).toEqual([]);
+    });
+});
+
+describe('settingsLabel', () => {
+    it('reads the settings back as a sentence', () => {
+        expect(settingsLabel({ format: 'dynasty', numQbs: 2, numTeams: 12, ppr: 1 })).toBe(
+            'Dynasty · superflex · 12-team · PPR',
+        );
+    });
+
+    it('names a single-QB format rather than calling it superflex', () => {
+        expect(settingsLabel({ format: 'dynasty', numQbs: 1, numTeams: 10, ppr: 0.5 })).toBe(
+            'Dynasty · 1QB · 10-team · half-PPR',
+        );
+    });
+
+    it('has nothing to say without settings', () => {
+        expect(settingsLabel(null)).toBeNull();
+    });
+});
+
+describe('asOfMillis', () => {
+    // `agoLabel` subtracts from Date.now(), so an ISO string handed over raw
+    // renders "NaNd ago" - which it did, and which only showed up in a browser.
+    it('converts the API timestamp to epoch milliseconds', () => {
+        expect(asOfMillis('2026-08-11T08:30:02Z')).toBe(Date.parse('2026-08-11T08:30:02Z'));
+    });
+
+    it.each([
+        ['nothing', null],
+        ['an empty string', ''],
+        ['a value that is not a date', 'whenever'],
+    ])('has nothing to report for %s', (_label, asOf) => {
+        expect(asOfMillis(asOf)).toBeNull();
+    });
+});

--- a/src/lib/sleeperApi.js
+++ b/src/lib/sleeperApi.js
@@ -2,7 +2,7 @@ import { checkErrors } from './http.js';
 import { decorateRosters } from './rosterInfo.js';
 import { resolveLeagueSeason } from './sleeper.js';
 import APP_DB_URLS, { SLEEPER_API_URLS } from '../urls.js';
-const { ACTIVE_PLAYERS, AVAILABILITY, LEAGUE_INTEL, MANAGER_ACTIVITY } = APP_DB_URLS;
+const { ACTIVE_PLAYERS, AVAILABILITY, LEAGUE_INTEL, MANAGER_ACTIVITY, MARKET_VALUES } = APP_DB_URLS;
 const { LEAGUE, USER_LEAGUES, USER_BY_NAME, NFL_STATE, DRAFT, ROSTERS, SLEEPER_USERS, TRADED_PICKS, DRAFTS } =
     SLEEPER_API_URLS;
 
@@ -234,5 +234,25 @@ export async function fetchAvailability({ draftId, userId, playerIds, atPick }) 
         .then((response) => response.json())
         .catch((error) => {
             console.error('Error fetching leaguemate intel:', error);
+        });
+}
+
+/**
+ * The market's current dynasty values, best player first.
+ *
+ * The response carries `settings` alongside the values, and it is not
+ * optional decoration: these are superflex, 12-team, full-PPR numbers, and in
+ * a 1-QB or 10-team league they are about a different game rather than
+ * slightly off. Render one only with the other to hand - same rule as
+ * `coverage` on manager activity.
+ *
+ * Resolves to `undefined` on failure, per this module's contract.
+ */
+export async function fetchMarketValues() {
+    return await fetch(MARKET_VALUES)
+        .then(checkErrors)
+        .then((response) => response.json())
+        .catch((error) => {
+            console.error('Error fetching market values:', error);
         });
 }

--- a/src/urls.js
+++ b/src/urls.js
@@ -5,6 +5,7 @@ const appDB = 'https://sleeper-player-db-default-rtdb.firebaseio.com/';
 const fta = import.meta.env.DEV ? '/' : 'https://fantasyteamassistant.com/';
 const ftaLegacy = 'api/legacy/players';
 const ftaAvailability = (draftId) => `api/v1/drafts/${draftId}/availability`;
+const ftaMarketValues = 'api/v1/values';
 const ftaLeagueIntel = (leagueId) => `api/v1/leagues/${leagueId}/intel`;
 const ftaManagerActivity = (userId) => `api/v1/users/${userId}/activity`;
 const latestUpdateAttempt = 'latest_update_attempt/';
@@ -33,6 +34,10 @@ const APP_DB_URLS = {
     // same dev-relative treatment as ACTIVE_PLAYERS above - see the comment
     // on `fta` about why localhost must go through the Vite proxy.
     AVAILABILITY: (draftId) => fta + ftaAvailability(draftId),
+    // The market's current dynasty values, best player first, keyed by
+    // Sleeper id. A rank list the user does not have to supply - see
+    // lib/marketValues.js for what is and is not claimed about it.
+    MARKET_VALUES: fta + ftaMarketValues,
     // The leaguemates of one league, and what they do in their other ones
     // (docs/leaguemate-intel.md §3e). Keyed by league despite being the
     // "cross-league" view - the cross-league part is what the managers do


### PR DESCRIPTION
Ranks opens empty, and best available, the board's order and the lineup builder all wait on a list the user has to go and find. The backend has been collecting FantasyCalc values nightly since the intel work and now serves them at `/api/v1/values` ([be#45](https://github.com/rghart/sleeper-player-be/pull/45), deployed), so the sheet can offer a list rather than only a place to paste one.

**This is the one route into the rank list that guesses at nothing.** The values arrive keyed by Sleeper id, so `toRankList` is a lookup. `rankParse.js` and `rankMatch.js` exist to bridge human text to those ids; this path never crosses that bridge. All 439 live values join to the deployed player pool — 0 unjoinable.

## What the screen says about them

More important here than usual. These are one provider's **dynasty superflex 12-team full-PPR** values. In a 1QB or 10-team league they're about a different game rather than slightly off. So:

- the settings are read out of the response and shown, not assumed
- the control says "Start from the market", not "Get the rankings"
- the card carries how old the values are

## Two decisions

**Ranks are the position in the list, not the market's `overallRank`.** The two agree until a value has no player behind it; then a list numbered 1, 2, 4 shows a gap the user can't act on and didn't create.

**Replacing the rank list now clears the miss list.** Misses belong to the paste that produced them. This was already wrong before the import existed — open a saved list after a paste that missed and you'd see "1 pasted line matched nothing" attached to a list that was never pasted.

## What the browser caught

`asOf` is an ISO string and `agoLabel` subtracts from `Date.now()`, so the card rendered **"NaNd ago"** with every unit test green. It only showed up on screen. The conversion is now its own tested function, plus a panel test asserting the card contains no `NaN`.

Verified end-to-end against the live endpoint, not a stub: the import fires a real `GET /api/v1/values` → 200, fills the list, and the label reads `8h ago · FantasyCalc · Dynasty · superflex · 12-team · PPR`.

## Tests

28 new, 842 total. Four sabotages caught: using `overallRank` as the rank, collapsing "feed unreachable" into "feed empty", not clearing misses on replace, and handing `agoLabel` something it can't subtract.

## Not in here

Tiers from value gaps, and a value-vs-your-rank delta. Both are real follow-ons now the data is in the client, and both are their own judgement calls rather than plumbing.
