### PR TITLE
Import the market values for the league you are actually in

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,6 +32,7 @@ import {
     writeRemoteAccount,
 } from './lib/sleeperIdentity.js';
 import { insertAtRank, resolvedEntry } from './lib/rankList.js';
+import { leagueMarketSettings } from './lib/marketValues.js';
 import { addPlayerToRoster, removePlayerFromLineup, toRosterSlots } from './lib/roster.js';
 import { buildLineupSet, memoizeRosterInfo } from './lib/rosterInfo.js';
 import { resolveMyDisplayName } from './lib/sleeper.js';
@@ -725,6 +726,7 @@ class App extends React.Component {
                 addToRoster={this.addToRoster}
                 updatePlayerId={this.updatePlayerId}
                 resolveMissingPlayer={this.resolveMissingPlayer}
+                marketSettings={leagueMarketSettings(leagueData.currentLeague)}
                 notFoundPlayers={notFoundPlayers}
                 rankingPlayersIdsList={rankingPlayersIdsList}
                 myDisplayName={myDisplayName}

--- a/src/Panels/RanksPanel.jsx
+++ b/src/Panels/RanksPanel.jsx
@@ -95,6 +95,7 @@ const RanksPanel = ({
     addToRoster,
     updatePlayerId,
     resolveMissingPlayer,
+    marketSettings: leagueShape,
     notFoundPlayers,
     myDisplayName,
     savedRankLists,
@@ -174,7 +175,7 @@ const RanksPanel = ({
         setImporting(true);
         setImportError(null);
 
-        const response = await fetchMarketValues();
+        const response = await fetchMarketValues(leagueShape);
         const entries = toRankList(response?.values, playerInfo);
         setImporting(false);
 

--- a/src/Panels/RanksPanel.test.jsx
+++ b/src/Panels/RanksPanel.test.jsx
@@ -755,6 +755,44 @@ describe('RanksPanel market import', () => {
         await user.click(screen.getByRole('button', { name: 'Import as a rank list' }));
     };
 
+    // The reason the endpoint takes params at all. Asking without saying which
+    // league you are in gets an answer about somebody else's.
+    it('asks the market about this league, not the default one', async () => {
+        const user = userEvent.setup();
+        renderPanel({ marketSettings: { dynasty: false, numQbs: 1, numTeams: 10, ppr: 0.5 } });
+        stubFetch(marketResponse);
+
+        await openAndImport(user);
+
+        await vi.waitFor(() => {
+            const url = global.fetch.mock.calls.map(([u]) => String(u)).find((u) => u.includes('/values'));
+            expect(url).toBeTruthy();
+            const params = new URLSearchParams(url.split('?')[1]);
+            expect(Object.fromEntries(params)).toEqual({
+                dynasty: 'false',
+                num_qbs: '1',
+                num_teams: '10',
+                ppr: '0.5',
+            });
+        });
+    });
+
+    // A league whose shape could not be read must still be able to import -
+    // the API answers with its stored slice, and the response says which.
+    it('asks without params when the league shape is unknown', async () => {
+        const user = userEvent.setup();
+        renderPanel({ marketSettings: null });
+        stubFetch(marketResponse);
+
+        await openAndImport(user);
+
+        await vi.waitFor(() => {
+            const url = global.fetch.mock.calls.map(([u]) => String(u)).find((u) => u.includes('/values'));
+            expect(url).toBeTruthy();
+            expect(url).not.toContain('?');
+        });
+    });
+
     it('offers the import above the paste box', async () => {
         const user = userEvent.setup();
         renderPanel();

--- a/src/lib/marketValues.js
+++ b/src/lib/marketValues.js
@@ -8,6 +8,46 @@
 // person.
 
 /**
+ * The league shape to ask the market about, read off Sleeper's league object.
+ *
+ * Values are priced against a format and the difference is not a rounding: in
+ * superflex the market's best player is a quarterback, in single-QB he is a
+ * running back. Asking without saying which league you are in gets you an
+ * answer about somebody else's.
+ *
+ * Only the fields the league actually answers are included, and the API falls
+ * back field by field - so a league object missing its scoring settings costs
+ * the PPR and nothing else, rather than the whole request.
+ */
+export function leagueMarketSettings(league) {
+    if (!league) return null;
+
+    const settings = {};
+
+    // `settings.type` is Sleeper's own: 0 redraft, 1 keeper, 2 dynasty. A
+    // keeper league is not a dynasty one and is closer to redraft for pricing,
+    // so only 2 counts.
+    if (league.settings?.type != null) settings.dynasty = league.settings.type === 2;
+
+    if (league.total_rosters) settings.numTeams = league.total_rosters;
+
+    // A SUPER_FLEX slot is what makes a league two-QB, not a second QB slot -
+    // and it is by far the common way to build one. Two literal QB slots count
+    // too, which is the rarer version of the same league.
+    const positions = league.roster_positions;
+    if (Array.isArray(positions)) {
+        const quarterbacks = positions.filter((slot) => slot === 'QB').length;
+        settings.numQbs = positions.includes('SUPER_FLEX') ? 2 : Math.max(quarterbacks, 1);
+    }
+
+    // Reception scoring is the one scoring field the market is priced on.
+    // `0` is a real answer (standard scoring) and must not be read as absent.
+    if (league.scoring_settings?.rec != null) settings.ppr = league.scoring_settings.rec;
+
+    return Object.keys(settings).length > 0 ? settings : null;
+}
+
+/**
  * The response's `asOf` as epoch milliseconds, or null.
  *
  * The API sends an ISO string and `agoLabel` subtracts from `Date.now()`, so

--- a/src/lib/marketValues.test.js
+++ b/src/lib/marketValues.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { asOfMillis, settingsLabel, toRankList } from './marketValues.js';
+import { asOfMillis, leagueMarketSettings, settingsLabel, toRankList } from './marketValues.js';
 
 const playerInfo = {
     1: { player_id: '1', full_name: 'Josh Allen', position: 'QB', team: 'BUF' },
@@ -89,5 +89,79 @@ describe('asOfMillis', () => {
         ['a value that is not a date', 'whenever'],
     ])('has nothing to report for %s', (_label, asOf) => {
         expect(asOfMillis(asOf)).toBeNull();
+    });
+});
+
+// Reading the league shape off Sleeper's own league object. Getting this wrong
+// is not a rounding error - asking the market about superflex when the league
+// is single-QB returns a list whose best player plays a different position.
+describe('leagueMarketSettings', () => {
+    const league = (overrides = {}) => ({
+        total_rosters: 12,
+        settings: { type: 2 },
+        roster_positions: ['QB', 'RB', 'RB', 'WR', 'WR', 'TE', 'FLEX', 'SUPER_FLEX', 'BN'],
+        scoring_settings: { rec: 1 },
+        ...overrides,
+    });
+
+    it('reads a superflex dynasty league', () => {
+        expect(leagueMarketSettings(league())).toEqual({
+            dynasty: true,
+            numTeams: 12,
+            numQbs: 2,
+            ppr: 1,
+        });
+    });
+
+    // A SUPER_FLEX slot is what makes a league two-QB, and it is by far the
+    // common way to build one.
+    it('counts a SUPER_FLEX slot as a second quarterback', () => {
+        expect(leagueMarketSettings(league()).numQbs).toBe(2);
+    });
+
+    it('reads a single-QB league as one', () => {
+        const positions = ['QB', 'RB', 'RB', 'WR', 'WR', 'TE', 'FLEX', 'BN'];
+        expect(leagueMarketSettings(league({ roster_positions: positions })).numQbs).toBe(1);
+    });
+
+    // The rarer way to build the same league.
+    it('counts two literal QB slots as two quarterbacks', () => {
+        const positions = ['QB', 'QB', 'RB', 'WR', 'TE', 'BN'];
+        expect(leagueMarketSettings(league({ roster_positions: positions })).numQbs).toBe(2);
+    });
+
+    // Sleeper's own encoding: 0 redraft, 1 keeper, 2 dynasty. A keeper league
+    // prices closer to redraft than to dynasty.
+    it.each([
+        [0, false],
+        [1, false],
+        [2, true],
+    ])('reads settings.type %i as dynasty=%s', (type, dynasty) => {
+        expect(leagueMarketSettings(league({ settings: { type } })).dynasty).toBe(dynasty);
+    });
+
+    // Standard scoring is a real answer, not a missing one.
+    it('keeps a zero PPR rather than treating it as absent', () => {
+        expect(leagueMarketSettings(league({ scoring_settings: { rec: 0 } })).ppr).toBe(0);
+    });
+
+    it('reads half PPR', () => {
+        expect(leagueMarketSettings(league({ scoring_settings: { rec: 0.5 } })).ppr).toBe(0.5);
+    });
+
+    // The API falls back field by field, so a league missing one field should
+    // cost that field and nothing else.
+    it('omits only the field the league cannot answer', () => {
+        const settings = leagueMarketSettings(league({ scoring_settings: undefined }));
+        expect(settings).not.toHaveProperty('ppr');
+        expect(settings).toMatchObject({ dynasty: true, numTeams: 12, numQbs: 2 });
+    });
+
+    it.each([
+        ['no league', undefined],
+        ['a null league', null],
+        ['a league with nothing readable', {}],
+    ])('has nothing to say for %s', (_label, value) => {
+        expect(leagueMarketSettings(value)).toBeNull();
     });
 });

--- a/src/lib/sleeperApi.js
+++ b/src/lib/sleeperApi.js
@@ -238,7 +238,11 @@ export async function fetchAvailability({ draftId, userId, playerIds, atPick }) 
 }
 
 /**
- * The market's current dynasty values, best player first.
+ * The market's current values for a league shape, best player first.
+ *
+ * `settings` is that shape - see `leagueMarketSettings` in lib/marketValues.js.
+ * Omitted entirely, the API answers with the slice it stores, which is a
+ * superflex 12-team full-PPR dynasty league and quite possibly not yours.
  *
  * The response carries `settings` alongside the values, and it is not
  * optional decoration: these are superflex, 12-team, full-PPR numbers, and in
@@ -248,8 +252,19 @@ export async function fetchAvailability({ draftId, userId, playerIds, atPick }) 
  *
  * Resolves to `undefined` on failure, per this module's contract.
  */
-export async function fetchMarketValues() {
-    return await fetch(MARKET_VALUES)
+export async function fetchMarketValues(settings) {
+    // Only what the caller could work out, because the API falls back field
+    // by field - a league whose scoring settings did not load should still get
+    // its own size and format rather than nothing.
+    const params = new URLSearchParams();
+    if (settings?.dynasty != null) params.set('dynasty', String(settings.dynasty));
+    if (settings?.numQbs != null) params.set('num_qbs', String(settings.numQbs));
+    if (settings?.numTeams != null) params.set('num_teams', String(settings.numTeams));
+    if (settings?.ppr != null) params.set('ppr', String(settings.ppr));
+
+    const query = params.toString();
+
+    return await fetch(query ? `${MARKET_VALUES}?${query}` : MARKET_VALUES)
         .then(checkErrors)
         .then((response) => response.json())
         .catch((error) => {


### PR DESCRIPTION
The import shipped asking for one slice, because that was the only one the API served — dynasty, superflex, 12-team, full PPR. It happened to be the right list for the league it was tested against and the wrong one for everybody else.

Backend side is [be#47](https://github.com/rghart/sleeper-player-be/pull/47), merged and deployed. This is the frontend half.

`leagueMarketSettings` reads the shape off Sleeper's own league object — `total_rosters`, `settings.type`, a `SUPER_FLEX` slot, `scoring_settings.rec` — and the request carries it.

Only the fields the league actually answers are sent, matching the API's field-by-field fallback: a league whose scoring settings didn't load still gets its own size and format rather than nothing. The card reads back what was *answered*, so a fallback is visible instead of assumed.

## Three readings that are easy to get wrong, and silent when you do

- **A `SUPER_FLEX` slot is what makes a league two-QB**, not a second literal `QB` slot. It's by far the common way to build one; counting only `QB` slots reads a superflex league as single-QB.
- **`settings.type` is 0 redraft / 1 keeper / 2 dynasty.** A keeper league prices closer to redraft, so only `2` counts.
- **A PPR of `0` is standard scoring** — an answer, not a missing value. A truthiness check drops it and silently asks for full PPR instead.

Each has its own test, and each is one of the four sabotages.

## Verification

Against the deployed endpoint, with a harness league set to 1QB / 10-team / half-PPR — deliberately not the stored slice, so the request has to carry params and the answer has to be a live fetch:

```
GET /api/v1/values?dynasty=true&num_qbs=1&num_teams=10&ppr=0.5 → 200
card: "FantasyCalc · Dynasty · 1QB · 10-team · half-PPR"
```

And on the API directly, the fix is visible in the data rather than only in the query string:

| | market's #1 |
| --- | --- |
| superflex (stored slice) | Josh Allen |
| `?num_qbs=1` | Bijan Robinson |

## Tests

15 new, 857 total. Four sabotages caught: ignoring `SUPER_FLEX`, treating keeper as dynasty, dropping a zero PPR, and the panel not passing the shape at all.
