### PR TITLE
Stop calling every two-quarterback league superflex

### DIFF
--- a/src/Panels/RanksPanel.jsx
+++ b/src/Panels/RanksPanel.jsx
@@ -191,7 +191,10 @@ const RanksPanel = ({
             return;
         }
 
-        setMarketSettings(settingsLabel(response.settings));
+        // The league shape is passed alongside the response because the
+        // response cannot tell superflex from a true two-QB league - both are
+        // a quarterback count of 2 to the provider.
+        setMarketSettings(settingsLabel(response.settings, leagueShape));
         setMarketAsOf(asOfMillis(response.asOf));
         updateRankingPlayersIdsList(entries);
         setCurrentListVal(defaultSelector);

--- a/src/Panels/RanksPanel.test.jsx
+++ b/src/Panels/RanksPanel.test.jsx
@@ -759,7 +759,11 @@ describe('RanksPanel market import', () => {
     // league you are in gets an answer about somebody else's.
     it('asks the market about this league, not the default one', async () => {
         const user = userEvent.setup();
-        renderPanel({ marketSettings: { dynasty: false, numQbs: 1, numTeams: 10, ppr: 0.5 } });
+        // `superflex` is included deliberately: it is display-only, and this
+        // assertion is exact, so a leak of it into the query fails here.
+        renderPanel({
+            marketSettings: { dynasty: false, numQbs: 1, numTeams: 10, ppr: 0.5, superflex: false },
+        });
         stubFetch(marketResponse);
 
         await openAndImport(user);
@@ -853,16 +857,46 @@ describe('RanksPanel market import', () => {
         expect(screen.getByText('Start from the market').closest('div').textContent).not.toMatch(/NaN/);
     });
 
+    const importThenReopen = async (user) => {
+        await openAndImport(user);
+        await vi.waitFor(() => expect(screen.queryByPlaceholderText('Copy + Paste rankings here...')).toBeNull());
+        await user.click(screen.getByRole('button', { name: 'Paste list' }));
+    };
+
     it('shows the settings it read back from the response', async () => {
         const user = userEvent.setup();
         renderPanel();
         stubFetch(marketResponse);
 
-        await openAndImport(user);
-        await vi.waitFor(() => expect(screen.queryByPlaceholderText('Copy + Paste rankings here...')).toBeNull());
-        await user.click(screen.getByRole('button', { name: 'Paste list' }));
+        await importThenReopen(user);
+
+        // No league to hand, so the quarterback count is all that can honestly
+        // be said - naming a format would be describing a league nobody has
+        // described.
+        expect(screen.getByText(/Dynasty · 2QB · 12-team · PPR/)).toBeTruthy();
+    });
+
+    // Superflex and two-QB are different leagues that price alike, so the
+    // response says 2 for both. Only the league object knows which.
+    it('names superflex when the league has a superflex slot', async () => {
+        const user = userEvent.setup();
+        renderPanel({ marketSettings: { numQbs: 2, numTeams: 12, superflex: true } });
+        stubFetch(marketResponse);
+
+        await importThenReopen(user);
 
         expect(screen.getByText(/Dynasty · superflex · 12-team · PPR/)).toBeTruthy();
+    });
+
+    it('does not call a two-QB league superflex', async () => {
+        const user = userEvent.setup();
+        renderPanel({ marketSettings: { numQbs: 2, numTeams: 12, superflex: false } });
+        stubFetch(marketResponse);
+
+        await importThenReopen(user);
+
+        expect(screen.queryByText(/superflex/)).toBeNull();
+        expect(screen.getByText(/Dynasty · 2QB · 12-team · PPR/)).toBeTruthy();
     });
 
     it('says so when the feed cannot be reached, rather than emptying the list', async () => {

--- a/src/lib/marketValues.js
+++ b/src/lib/marketValues.js
@@ -31,13 +31,29 @@ export function leagueMarketSettings(league) {
 
     if (league.total_rosters) settings.numTeams = league.total_rosters;
 
-    // A SUPER_FLEX slot is what makes a league two-QB, not a second QB slot -
-    // and it is by far the common way to build one. Two literal QB slots count
-    // too, which is the rarer version of the same league.
+    // Two-QB and superflex are different leagues, not two names for one. A
+    // two-QB league has two dedicated QB slots and you *must* start two; a
+    // superflex slot takes any position, so you *may* start a second. Both
+    // raise quarterback value, which is why they price alike and why the old
+    // reading here got away with treating them as the same thing.
+    //
+    // How many quarterbacks a lineup can hold is the sum, not either one: a
+    // league with two QB slots and a superflex can start three, and the
+    // previous version reported two because it stopped at the superflex.
     const positions = league.roster_positions;
     if (Array.isArray(positions)) {
         const quarterbacks = positions.filter((slot) => slot === 'QB').length;
-        settings.numQbs = positions.includes('SUPER_FLEX') ? 2 : Math.max(quarterbacks, 1);
+        const superflex = positions.includes('SUPER_FLEX');
+        settings.numQbs = Math.max(quarterbacks + (superflex ? 1 : 0), 1);
+        // Display only, and deliberately not sent: FantasyCalc prices on a
+        // quarterback count and has no notion of *which* format produced it,
+        // so this exists so the card can name the league correctly rather
+        // than to change what is asked for. A true two-QB league forces the
+        // second starter and so wants a quarterback slightly more than a
+        // superflex league does - that is a distinction the provider's
+        // parameter cannot carry, and inventing a number for it would be
+        // making one up.
+        settings.superflex = superflex;
     }
 
     // Reception scoring is the one scoring field the market is priced on.
@@ -62,17 +78,36 @@ export function asOfMillis(asOf) {
 }
 
 /** How the settings read in a sentence, so nothing has to claim more. */
-export function settingsLabel(settings) {
+export function settingsLabel(settings, league) {
     if (!settings) return null;
     const { format, numQbs, numTeams, ppr } = settings;
     return [
         format === 'dynasty' ? 'Dynasty' : format,
-        numQbs >= 2 ? 'superflex' : `${numQbs}QB`,
+        quarterbackTerm(numQbs, league),
         `${numTeams}-team`,
         ppr === 1 ? 'PPR' : ppr === 0.5 ? 'half-PPR' : `${ppr} PPR`,
     ]
         .filter(Boolean)
         .join(' · ');
+}
+
+/**
+ * What to call the quarterback format.
+ *
+ * The response cannot answer this. It carries a quarterback *count*, and
+ * both a superflex league and a genuine two-QB league arrive as 2 - so
+ * labelling every 2 "superflex" told anyone in a two-QB league their list was
+ * priced for a format they are not in. The league object knows the
+ * difference; the response never will.
+ *
+ * Falls back to the count when the league is unknown, which reads as `2QB`.
+ * That is a claim about what the values are priced on rather than about a
+ * league nobody has described, and is the honest thing to say with only the
+ * response to hand.
+ */
+function quarterbackTerm(numQbs, league) {
+    if (league?.superflex) return 'superflex';
+    return `${numQbs}QB`;
 }
 
 /**

--- a/src/lib/marketValues.test.js
+++ b/src/lib/marketValues.test.js
@@ -61,14 +61,35 @@ describe('toRankList', () => {
 describe('settingsLabel', () => {
     it('reads the settings back as a sentence', () => {
         expect(settingsLabel({ format: 'dynasty', numQbs: 2, numTeams: 12, ppr: 1 })).toBe(
-            'Dynasty · superflex · 12-team · PPR',
+            'Dynasty · 2QB · 12-team · PPR',
         );
+    });
+
+    // Superflex and two-QB are different leagues that price alike, so the
+    // response carries a count of 2 for both. Calling every 2 "superflex" told
+    // anyone in a two-QB league their list was priced for a format they are
+    // not in.
+    it('names superflex only when the league actually has a superflex slot', () => {
+        const response = { format: 'dynasty', numQbs: 2, numTeams: 12, ppr: 1 };
+
+        expect(settingsLabel(response, { superflex: true })).toBe('Dynasty · superflex · 12-team · PPR');
+        expect(settingsLabel(response, { superflex: false })).toBe('Dynasty · 2QB · 12-team · PPR');
+    });
+
+    // With only the response to hand, the count is a claim about what the
+    // values are priced on rather than about a league nobody has described.
+    it('falls back to the count when the league is unknown', () => {
+        expect(settingsLabel({ format: 'dynasty', numQbs: 2, numTeams: 12, ppr: 1 }, null)).toContain('2QB');
     });
 
     it('names a single-QB format rather than calling it superflex', () => {
         expect(settingsLabel({ format: 'dynasty', numQbs: 1, numTeams: 10, ppr: 0.5 })).toBe(
             'Dynasty · 1QB · 10-team · half-PPR',
         );
+    });
+
+    it('names a redraft league redraft', () => {
+        expect(settingsLabel({ format: 'redraft', numQbs: 1, numTeams: 12, ppr: 1 })).toContain('redraft');
     });
 
     it('has nothing to say without settings', () => {
@@ -109,6 +130,7 @@ describe('leagueMarketSettings', () => {
             dynasty: true,
             numTeams: 12,
             numQbs: 2,
+            superflex: true,
             ppr: 1,
         });
     });
@@ -124,10 +146,30 @@ describe('leagueMarketSettings', () => {
         expect(leagueMarketSettings(league({ roster_positions: positions })).numQbs).toBe(1);
     });
 
-    // The rarer way to build the same league.
+    // A different league, not the same one built differently: two QB slots
+    // force a second starter, a superflex slot only permits one. They price
+    // alike, which is why the provider takes one number for both.
     it('counts two literal QB slots as two quarterbacks', () => {
         const positions = ['QB', 'QB', 'RB', 'WR', 'TE', 'BN'];
-        expect(leagueMarketSettings(league({ roster_positions: positions })).numQbs).toBe(2);
+        const settings = leagueMarketSettings(league({ roster_positions: positions }));
+
+        expect(settings.numQbs).toBe(2);
+        expect(settings.superflex).toBe(false);
+    });
+
+    // The count is how many quarterbacks a lineup can hold, so the two slot
+    // kinds add. The previous reading stopped at the superflex and said two.
+    it('adds a superflex on top of the QB slots', () => {
+        const positions = ['QB', 'QB', 'SUPER_FLEX', 'RB', 'WR', 'BN'];
+        expect(leagueMarketSettings(league({ roster_positions: positions })).numQbs).toBe(3);
+    });
+
+    it('reports a single-QB league as neither superflex nor two-QB', () => {
+        const positions = ['QB', 'RB', 'WR', 'TE', 'FLEX', 'BN'];
+        const settings = leagueMarketSettings(league({ roster_positions: positions }));
+
+        expect(settings.numQbs).toBe(1);
+        expect(settings.superflex).toBe(false);
     });
 
     // Sleeper's own encoding: 0 redraft, 1 keeper, 2 dynasty. A keeper league


### PR DESCRIPTION
Two-QB and superflex are different leagues, and #163 treated them as one name for the same thing.

A two-QB league has two dedicated QB slots and **forces** you to start two. A superflex slot takes any position, so a second quarterback is **permitted**. They price alike, which is why FantasyCalc takes a single `numQbs` for both — and why conflating them went unnoticed.

## What was actually wrong

**The number sent was right either way.** Both formats correctly resolve to `numQbs=2`, so no request was ever wrong and no list was ever mispriced.

**The sentence next to it was wrong.** Any count of 2 was labelled `superflex`, so someone in a genuine two-QB league was told their list was priced for a format they're not in. That's this feature's oldest failure — the figure is fine, the copy overclaims — and it had crept back in.

## The fix

The label names superflex only when the league has a `SUPER_FLEX` slot. With no league to read it falls back to the count (`2QB`), which is a claim about what the values are priced on rather than about a league nobody has described. The response can't make this call: it carries a count, and both formats arrive as 2.

`superflex` is derived for the label alone and **never sent**. A true two-QB league wants a quarterback slightly more than a superflex one does — that's a distinction `numQbs` cannot carry, and inventing a number for it would be making one up. There's an exact-match test on the query string so a leak fails loudly.

## A second bug the same reading hid

The count stopped at the superflex slot:

```js
positions.includes('SUPER_FLEX') ? 2 : Math.max(quarterbacks, 1)
```

So a league with two QB slots *and* a superflex reported two startable quarterbacks instead of three. The slot kinds add.

## Tests

864 total. Three sabotages caught: reinstating the old `numQbs >= 2 → superflex` rule, collapsing the slot-kind sum, and leaking `superflex` into the query.

The third initially passed — my query-string fixture had no `superflex` key, so the exact-match assertion couldn't see a leak. Fixture fixed; it fails correctly now.
