### PR TITLE
Put faces, teams and market value on the rank list

### DIFF
--- a/src/Components/ListRow.jsx
+++ b/src/Components/ListRow.jsx
@@ -39,6 +39,11 @@ const ListRow = ({
     // column, so they pass their own override here rather than ListRow
     // hardcoding one typography for every caller.
     ordinalClassName = 'text-[12px] text-ink-dim',
+    // Sits between the ordinal and the name block — an avatar, in practice.
+    // Given its own slot rather than folded into `name` because the name is a
+    // truncating flex child and anything inside it inherits that: an avatar
+    // there would compress before the text did, which is backwards.
+    leading,
     name,
     nameTone = 'default',
     flag,
@@ -66,6 +71,7 @@ const ListRow = ({
                     {ordinal}
                 </span>
             )}
+            {leading}
             <span className="flex min-w-0 flex-1 flex-col">
                 <span className="flex min-w-0 items-center gap-2">
                     {leadingDot && <span className={`h-1.5 w-1.5 shrink-0 rounded-full ${DOT_TONE[leadingDot]}`} />}

--- a/src/Components/PlayerAvatar.jsx
+++ b/src/Components/PlayerAvatar.jsx
@@ -1,0 +1,96 @@
+import { useState } from 'react';
+
+// The player's face, with their team's mark on it — both from Sleeper's CDN,
+// which is the same source the app already pulls player data from.
+//
+// This existed before the redesign (PR #133 dropped it along with the old
+// PlayerInfoItem markup) and is deliberately coming back: a list of 200 names
+// in one typeface is genuinely hard to scan, and a face is the fastest thing
+// a human recognises. It is decoration in the sense that no decision depends
+// on it, which is exactly why it must never cost a row its layout.
+//
+// Sizes are fixed rather than fluid: the row geometry in `ListRow` is pinned
+// to the pixel (see its comment about 46px/56px), so an avatar that could
+// change size would be the one thing able to break it.
+
+const PLAYER_THUMB = (playerId) => `https://sleepercdn.com/content/nfl/players/thumb/${playerId}.jpg`;
+const TEAM_LOGO = (team) => `https://sleepercdn.com/images/team_logos/nfl/${team.toLowerCase()}.png`;
+
+/**
+ * The two-letter fallback, same idea as `avatarInitials` for managers but on a
+ * full name that is always "First Last" here rather than a display handle.
+ */
+const initials = (name) => {
+    if (!name) return '';
+    const words = String(name).trim().split(/\s+/).filter(Boolean);
+    if (words.length === 0) return '';
+    if (words.length === 1) return words[0].slice(0, 2).toUpperCase();
+    return (words[0][0] + words[1][0]).toUpperCase();
+};
+
+const PlayerAvatar = ({ playerId, name, team, size = 32 }) => {
+    // Tracked per-image rather than as one flag: a player with no headshot
+    // very often still has a team, and vice versa for a free agent. Collapsing
+    // them would drop a mark we do have.
+    const [playerFailed, setPlayerFailed] = useState(false);
+    const [teamFailed, setTeamFailed] = useState(false);
+
+    // Sleeper answers 200 with a placeholder silhouette for most missing
+    // headshots rather than 404ing, so `onError` is a backstop for the cases
+    // it does 404 (and for the CDN being unreachable), not the main path.
+    const showPlayer = playerId && !playerFailed;
+    const showTeam = team && !teamFailed;
+    const badge = Math.round(size * 0.45);
+
+    return (
+        // `aria-hidden`: every row already carries the player's name, team and
+        // position in its accessible label, so announcing this would be the
+        // third time. Purely visual, and marked as such.
+        <span
+            aria-hidden="true"
+            className="bg-raised-2 relative shrink-0 overflow-visible rounded-full"
+            style={{ width: size, height: size }}
+        >
+            {showPlayer ? (
+                <img
+                    src={PLAYER_THUMB(playerId)}
+                    alt=""
+                    // `loading="lazy"` matters more here than anywhere else in
+                    // the app: a pasted rank list is 200+ rows, and eagerly
+                    // fetching 200 headshots on mount would be a worse trade
+                    // than not having them at all.
+                    loading="lazy"
+                    decoding="async"
+                    onError={() => setPlayerFailed(true)}
+                    className="h-full w-full rounded-full object-cover object-top"
+                    style={{ width: size, height: size }}
+                />
+            ) : (
+                <span
+                    className="text-ink-dim flex h-full w-full items-center justify-center rounded-full font-mono font-semibold"
+                    style={{ fontSize: Math.round(size * 0.34) }}
+                >
+                    {initials(name)}
+                </span>
+            )}
+
+            {showTeam && (
+                // Overlapping the bottom-right corner rather than sitting in
+                // the meta line: the team is a property *of the player*, and
+                // pairing the two costs no horizontal room on a 375px row —
+                // which is the width the meta line was already truncating at.
+                <img
+                    src={TEAM_LOGO(team)}
+                    alt=""
+                    loading="lazy"
+                    decoding="async"
+                    onError={() => setTeamFailed(true)}
+                    className="bg-ground absolute -right-0.5 -bottom-0.5 rounded-full object-contain p-[1px]"
+                    style={{ width: badge, height: badge }}
+                />
+            )}
+        </span>
+    );
+};
+
+export default PlayerAvatar;

--- a/src/Components/PlayerAvatar.test.jsx
+++ b/src/Components/PlayerAvatar.test.jsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import PlayerAvatar from './PlayerAvatar';
+
+// jsdom applies no stylesheet and never loads images, so these cover which
+// elements exist and what they point at. Whether the crop looks right is a
+// browser question and was checked there.
+const imagesIn = (container) => [...container.querySelectorAll('img')];
+
+describe('PlayerAvatar', () => {
+    it('points at the player thumb and the team logo', () => {
+        const { container } = render(<PlayerAvatar playerId="4984" name="Josh Allen" team="BUF" />);
+        const [player, team] = imagesIn(container);
+
+        expect(player).toHaveAttribute('src', 'https://sleepercdn.com/content/nfl/players/thumb/4984.jpg');
+        expect(team).toHaveAttribute('src', 'https://sleepercdn.com/images/team_logos/nfl/buf.png');
+    });
+
+    it('lower-cases the team, since the CDN path is lower-case', () => {
+        const { container } = render(<PlayerAvatar playerId="1" name="A B" team="LAR" />);
+        expect(imagesIn(container)[1]).toHaveAttribute('src', expect.stringContaining('/lar.png'));
+    });
+
+    it('renders no team logo for a free agent, rather than a broken one', () => {
+        const { container } = render(<PlayerAvatar playerId="4984" name="Josh Allen" team={null} />);
+        expect(imagesIn(container)).toHaveLength(1);
+    });
+
+    it('falls back to initials when there is no player id', () => {
+        const { container } = render(<PlayerAvatar playerId={null} name="Josh Allen" team="BUF" />);
+
+        expect(imagesIn(container)).toHaveLength(1);
+        expect(screen.getByText('JA')).toBeInTheDocument();
+    });
+
+    it('takes two letters from a single-word name', () => {
+        render(<PlayerAvatar playerId={null} name="Ocho" />);
+        expect(screen.getByText('OC')).toBeInTheDocument();
+    });
+
+    it('renders nothing rather than "undefined" when there is no name at all', () => {
+        const { container } = render(<PlayerAvatar playerId={null} name={undefined} />);
+        expect(container.textContent).toBe('');
+    });
+
+    it('is hidden from assistive tech, since the row already names the player', () => {
+        // Announcing it would be the third time the name is read on one row.
+        const { container } = render(<PlayerAvatar playerId="4984" name="Josh Allen" team="BUF" />);
+        expect(container.firstChild).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('lazy-loads, because a pasted list is 200+ rows', () => {
+        const { container } = render(<PlayerAvatar playerId="4984" name="Josh Allen" team="BUF" />);
+        imagesIn(container).forEach((img) => expect(img).toHaveAttribute('loading', 'lazy'));
+    });
+});

--- a/src/Components/PlayerInfoItem.jsx
+++ b/src/Components/PlayerInfoItem.jsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 import ListRow from './ListRow';
+import PlayerAvatar from './PlayerAvatar';
 import PositionTag from './PositionTag';
 import PlayerSearch from './PlayerSearch';
+import ValueChip from './ValueChip';
 import { playerAccessibleName, playerAvailabilityText } from './playerInfoLabels.js';
 import { isInLineup, isTaken, rosteredBy } from '../lib/rosterInfo.js';
 
@@ -16,6 +18,10 @@ const PlayerInfoItem = ({
     isNewRankList,
     adpData,
     myDisplayName,
+    // `{ value, changePct }` for this player, or undefined when the values
+    // fetch failed or the market has never seen him. Undefined renders
+    // nothing at all rather than a placeholder - see ValueChip.
+    marketValue,
 }) => {
     const [editingPlayer, setEditingPlayer] = useState(false);
     const taken = isTaken(rosterInfo, player.player_id);
@@ -165,6 +171,7 @@ const PlayerInfoItem = ({
             ordinal={searchData.ranking}
             ordinalWidth="22px"
             ordinalClassName="text-right text-[12px] font-medium text-ink-muted"
+            leading={<PlayerAvatar playerId={player.player_id} name={player.full_name} team={player.team} />}
             // A single always-visible name replaces the old full-text/abbr-text
             // pair, a width-hiding mechanism whose hidden fallback shipped a
             // real defect once (PR #116). It stays a nested button so clicking
@@ -183,8 +190,23 @@ const PlayerInfoItem = ({
             leadingDot={lowConfidenceMatch ? 'warn' : undefined}
             meta={
                 <>
-                    <span>{player.team ? player.team : 'FA'}</span>
-                    <span> · </span>
+                    {/* The market value leads the line, and the team
+                        abbreviation it replaces is not lost - it moved onto
+                        the avatar as a logo, which is what freed the room.
+                        Only a team-less player still needs the letters, since
+                        there is no logo to carry it. */}
+                    {marketValue && (
+                        <>
+                            <ValueChip value={marketValue.value} changePct={marketValue.changePct} />
+                            <span> · </span>
+                        </>
+                    )}
+                    {!player.team && (
+                        <>
+                            <span>FA</span>
+                            <span> · </span>
+                        </>
+                    )}
                     <span>{playerAvailabilityText({ taken, rosteredByName })}</span>
                 </>
             }

--- a/src/Components/ValueChip.jsx
+++ b/src/Components/ValueChip.jsx
@@ -1,0 +1,80 @@
+// A player's dynasty market value and which way it is going.
+//
+// The value alone is nearly useless on a rank list — it restates the ordering
+// you are already looking at. The *movement* is the part that is new
+// information, and it is the whole reason `player_value_history` exists: a
+// buy-low and a sell-high are both claims about a price changing.
+//
+// So the delta is the loud element and the value is context beneath it,
+// which is the opposite of how a market widget usually reads.
+
+// A value is 0–9999 on KTC's scale and four digits is too wide for a row that
+// already carries an ADP delta, a position tag and an action button. Thousands
+// with one decimal keeps it to four characters and loses nothing a human acts
+// on — nobody trades on the difference between 6012 and 6020.
+export const formatValue = (value) => {
+    if (value == null) return null;
+    if (value < 1000) return String(Math.round(value));
+    return `${(value / 1000).toFixed(1)}k`;
+};
+
+/**
+ * The movement, as a signed percentage.
+ *
+ * Percent rather than points because points are not comparable across the
+ * board: 200 points is a rounding error on a 9,000 asset and a third of a
+ * late 4th. The percentage is the same question everywhere.
+ *
+ * `null` when there is nothing to compare against — which is NOT the same as
+ * flat, and the API is careful to send `null` rather than `0` for it. A row
+ * that has never been seen before must not claim it held steady.
+ */
+export const formatChange = (changePct) => {
+    if (changePct == null) return null;
+    const rounded = Math.round(changePct);
+    if (rounded === 0) return '±0';
+    return rounded > 0 ? `+${rounded}%` : `${rounded}%`;
+};
+
+// Movement under this is noise, not a trend — KTC values wobble daily on
+// crowd votes. Below it the number is still shown, but in the neutral tone:
+// the figure is honest, the *colour* would be the overclaim.
+const MEANINGFUL_PCT = 3;
+
+const toneFor = (changePct) => {
+    if (changePct == null || Math.abs(changePct) < MEANINGFUL_PCT) return 'text-ink-dim';
+    return changePct > 0 ? 'text-live' : 'text-warn';
+};
+
+/**
+ * Value and movement, inline — sized to sit in a row's meta line rather than
+ * in its trailing cluster.
+ *
+ * **It lives in the meta line because the trailing cluster has no room, and
+ * that was measured, not guessed.** As a 46px trailing column it cost ten of
+ * fourteen rows their full name at 375px: "Christian McCaffrey" was clipped by
+ * 80px, against zero names clipped before this feature. The trailing area
+ * already carries an ADP delta, a position tag and an Add button, and the
+ * design's own rule from the intel work is that the row's novel signal must
+ * fit — here that is the player's name.
+ *
+ * The team abbreviation this replaces is not lost: it moved onto the avatar as
+ * a logo, which is why the space is free.
+ */
+const ValueChip = ({ value, changePct }) => {
+    const shown = formatValue(value);
+    if (shown == null) return null;
+
+    const change = formatChange(changePct);
+
+    return (
+        <span className="shrink-0">
+            <span className="text-ink-quiet font-semibold tabular-nums">{shown}</span>
+            {/* Absent, not "—", when there is no reading: a dash in a column
+                of percentages reads as a value. The line simply gets shorter. */}
+            {change && <span className={`ml-1 tabular-nums ${toneFor(changePct)}`}>{change}</span>}
+        </span>
+    );
+};
+
+export default ValueChip;

--- a/src/Components/ValueChip.test.jsx
+++ b/src/Components/ValueChip.test.jsx
@@ -1,0 +1,70 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import ValueChip, { formatChange, formatValue } from './ValueChip';
+
+describe('formatValue', () => {
+    it('abbreviates thousands, which is what keeps the row from truncating', () => {
+        expect(formatValue(9997)).toBe('10.0k');
+        expect(formatValue(6012)).toBe('6.0k');
+    });
+
+    it('leaves a sub-thousand value whole, since there is nothing to abbreviate', () => {
+        expect(formatValue(940)).toBe('940');
+        expect(formatValue(0)).toBe('0');
+    });
+
+    it('is null when there is no value, so the caller renders nothing', () => {
+        expect(formatValue(null)).toBeNull();
+        expect(formatValue(undefined)).toBeNull();
+    });
+});
+
+describe('formatChange', () => {
+    it('signs the percentage', () => {
+        expect(formatChange(4.2)).toBe('+4%');
+        expect(formatChange(-2.7)).toBe('-3%');
+    });
+
+    it('distinguishes flat from unknown', () => {
+        // The API sends null rather than 0 precisely so these stay apart: a
+        // player nobody has a reading on must not claim he held steady.
+        expect(formatChange(0)).toBe('±0');
+        expect(formatChange(0.2)).toBe('±0');
+        expect(formatChange(null)).toBeNull();
+    });
+});
+
+describe('ValueChip', () => {
+    it('shows the value and its movement', () => {
+        render(<ValueChip value={6012} changePct={4.2} />);
+        expect(screen.getByText('6.0k')).toBeInTheDocument();
+        expect(screen.getByText('+4%')).toBeInTheDocument();
+    });
+
+    it('renders nothing at all without a value', () => {
+        // A row for a player the market has never priced is exactly the row
+        // this app rendered before the feature existed.
+        const { container } = render(<ValueChip value={null} changePct={5} />);
+        expect(container).toBeEmptyDOMElement();
+    });
+
+    it('shows the value alone when there is no movement reading', () => {
+        const { container } = render(<ValueChip value={6012} changePct={null} />);
+        expect(screen.getByText('6.0k')).toBeInTheDocument();
+        // No dash placeholder: in a line of percentages a dash reads as one.
+        expect(container.textContent).toBe('6.0k');
+    });
+
+    it('colours only a move big enough to be a trend', () => {
+        // KTC values wobble daily on crowd votes; colouring a 1% move would
+        // be the figure being honest and the styling overclaiming.
+        const { container: small } = render(<ValueChip value={6012} changePct={1.4} />);
+        expect(small.querySelector('.text-ink-dim')).toBeInTheDocument();
+
+        const { container: rise } = render(<ValueChip value={6012} changePct={9} />);
+        expect(rise.querySelector('.text-live')).toBeInTheDocument();
+
+        const { container: fall } = render(<ValueChip value={6012} changePct={-9} />);
+        expect(fall.querySelector('.text-warn')).toBeInTheDocument();
+    });
+});

--- a/src/Panels/RanksPanel.jsx
+++ b/src/Panels/RanksPanel.jsx
@@ -14,7 +14,8 @@ import APP_DB_URLS from '../urls.js';
 import Spinner from '../Components/Spinner';
 import { isTaken, rosteredBy } from '../lib/rosterInfo.js';
 import { fetchRequest } from '../lib/http.js';
-import { fetchMarketValues } from '../lib/sleeperApi.js';
+import { fetchDynastyValues, fetchMarketValues } from '../lib/sleeperApi.js';
+import { usesSuperflexValues, valuesByPlayerId } from '../lib/dynastyValues.js';
 import { asOfMillis, settingsLabel, toRankList } from '../lib/marketValues.js';
 import { agoLabel } from '../lib/relativeTime.js';
 import { positionClass } from './pickLabels.js';
@@ -106,6 +107,10 @@ const RanksPanel = ({
     const [searchText, setSearchText] = useState('');
     const [currentListVal, setCurrentListVal] = useState(defaultSelector);
     const [adp, setADP] = useState({});
+    // `{}` rather than undefined: rows look values up unconditionally, and an
+    // absent entry is exactly how a player the market has never priced — or a
+    // failed fetch — renders. Values are additive decoration.
+    const [dynastyValues, setDynastyValues] = useState({});
     const [adpType, setADPType] = useState();
     const [filters, setFilters] = useState({
         showTaken: false,
@@ -360,6 +365,28 @@ const RanksPanel = ({
         getADP();
     }, []);
 
+    // Dynasty values, fetched once per league shape. Additive decoration, so
+    // a failure leaves `{}` and every row renders exactly as it did before
+    // this feature existed - the same contract the survival chips follow.
+    //
+    // Keyed on the superflex boolean rather than the whole league object: the
+    // API has two variants and re-fetching because an unrelated league field
+    // changed identity would be a request for the same bytes.
+    const superflex = usesSuperflexValues(leagueShape);
+
+    useEffect(() => {
+        let cancelled = false;
+
+        fetchDynastyValues({ superflex }).then((response) => {
+            if (cancelled) return;
+            setDynastyValues(valuesByPlayerId(response));
+        });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [superflex]);
+
     // The saved-lists fetch itself now lives in App (loadSavedRankLists) - it
     // resets isNewRankList/currentListVal back to the default whenever
     // signedIn goes false, which App's version of this effect can't reach
@@ -418,6 +445,7 @@ const RanksPanel = ({
             updatePlayerId={updatePlayerId}
             searchData={results}
             adpData={adp?.[results.match_results[0][0]]?.[adpType] ?? null}
+            marketValue={dynastyValues[results.match_results[0][0]]}
             myDisplayName={myDisplayName}
         />
     );

--- a/src/lib/dynastyValues.js
+++ b/src/lib/dynastyValues.js
@@ -1,0 +1,96 @@
+// Reading the /dynasty-values response.
+//
+// Pure, like `availability.js` and `leagueIntel.js` next door, and for the
+// same reason: what may be said about a number is decided here, where it can
+// be tested, rather than inside a template.
+//
+// Distinct from `marketValues.js`, and the two must not be merged. That one
+// turns FantasyCalc's list *into* a rank list — an ordering the user adopts.
+// This one *decorates* rows that already exist and never reorders anything:
+// the rank list is the user's own and stays theirs, exactly as the survival
+// chips do (docs/leaguemate-intel.md §3g).
+
+/**
+ * Whether this league is priced off KeepTradeCut's superflex values.
+ *
+ * KTC publishes exactly two variants, 1QB and superflex, so the continuous
+ * `numQbs` this app derives has to collapse to a boolean. Any league that can
+ * start a second quarterback prices like superflex — that is the whole reason
+ * the two exist as separate lists — so the split is at 2, not at "has a
+ * SUPER_FLEX slot".
+ *
+ * That distinction is load-bearing: a true two-QB league has no superflex slot
+ * at all and would fall to the 1QB list under a slot check, which is a list
+ * about a different game. `leagueMarketSettings` already does the work of
+ * summing slot kinds; this only reads the total.
+ *
+ * Defaults to superflex when the league shape is unknown, matching the API's
+ * own default and the slice the rest of the app is calibrated against.
+ */
+export function usesSuperflexValues(leagueShape) {
+    if (!leagueShape || leagueShape.numQbs == null) return true;
+    return leagueShape.numQbs >= 2;
+}
+
+/**
+ * The response's values keyed by Sleeper id, for O(1) lookup per row.
+ *
+ * A rank list is 200+ rows and the response is ~460 entries; scanning the
+ * array per row would be 92,000 comparisons on every render.
+ *
+ * Ids are strings on the wire and strings in `playerInfo`, so nothing is
+ * coerced here — a map keyed by number that is read by string silently misses
+ * every row, which is the failure `PlayerValueJSON` stringifies ids to avoid.
+ *
+ * Returns an empty object rather than null on a failed or empty fetch, so
+ * callers can look up unconditionally. Values are additive: a row with no
+ * entry renders exactly as it did before this feature existed.
+ */
+export function valuesByPlayerId(response) {
+    const values = response?.values;
+    if (!Array.isArray(values)) return {};
+
+    return values.reduce((byId, entry) => {
+        if (entry?.playerId != null) byId[String(entry.playerId)] = entry;
+        return byId;
+    }, {});
+}
+
+/**
+ * How stale the values are, as the response's own `asOf` in epoch millis.
+ *
+ * Same conversion `marketValues.asOfMillis` does and for the same reason: the
+ * API sends an ISO string, `agoLabel` subtracts from `Date.now()`, and handing
+ * the string over directly renders `NaNd ago`. That shipped once and no unit
+ * test caught it — only a browser did.
+ */
+export function asOfMillis(response) {
+    const asOf = response?.asOf;
+    if (!asOf) return null;
+
+    const millis = Date.parse(asOf);
+    return Number.isNaN(millis) ? null : millis;
+}
+
+/**
+ * A pick's value, for a Sleeper traded pick that knows only its season and
+ * round.
+ *
+ * **Tier is the caller's guess and this makes it explicitly.** KTC prices
+ * early/mid/late separately because they are worth substantially different
+ * amounts, but which one a pick becomes depends on where its roster finishes,
+ * which is not knowable in advance. `mid` is the honest default; a caller that
+ * knows the standings can pass a better one.
+ *
+ * Returns null rather than falling back to another tier or another season: a
+ * 2029 pick nobody prices should read as unpriced, not as a 2028 one.
+ */
+export function pickValue(response, { season, round, tier = 'mid' } = {}) {
+    const picks = response?.picks;
+    if (!Array.isArray(picks) || season == null || round == null) return null;
+
+    return (
+        picks.find((pick) => pick.season === Number(season) && pick.round === Number(round) && pick.tier === tier) ??
+        null
+    );
+}

--- a/src/lib/dynastyValues.test.js
+++ b/src/lib/dynastyValues.test.js
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { asOfMillis, pickValue, usesSuperflexValues, valuesByPlayerId } from './dynastyValues.js';
+
+describe('usesSuperflexValues', () => {
+    it('is superflex for any league that can start a second quarterback', () => {
+        expect(usesSuperflexValues({ numQbs: 2 })).toBe(true);
+        expect(usesSuperflexValues({ numQbs: 3 })).toBe(true);
+    });
+
+    it('is 1QB only for a genuine single-quarterback league', () => {
+        expect(usesSuperflexValues({ numQbs: 1 })).toBe(false);
+    });
+
+    it('reads a true two-QB league as superflex despite having no superflex slot', () => {
+        // The distinction that matters: `leagueMarketSettings` sums slot kinds,
+        // so a 2-QB league arrives as numQbs 2 with superflex false. Keying off
+        // a SUPER_FLEX slot instead would price it off the 1QB list, which is a
+        // list about a different game.
+        expect(usesSuperflexValues({ numQbs: 2, superflex: false })).toBe(true);
+    });
+
+    it('defaults to superflex when the league shape is unknown', () => {
+        expect(usesSuperflexValues(null)).toBe(true);
+        expect(usesSuperflexValues({})).toBe(true);
+    });
+});
+
+describe('valuesByPlayerId', () => {
+    const response = {
+        values: [
+            { playerId: '4984', value: 6000, changePct: 5.2 },
+            { playerId: '9509', value: 9999, changePct: null },
+        ],
+    };
+
+    it('keys by the string id playerInfo uses', () => {
+        const byId = valuesByPlayerId(response);
+        expect(byId['4984'].value).toBe(6000);
+        expect(byId['9509'].changePct).toBeNull();
+    });
+
+    it('coerces a numeric id to a string rather than keying by number', () => {
+        // A map keyed by number and read by string misses every row silently.
+        const byId = valuesByPlayerId({ values: [{ playerId: 4984, value: 1 }] });
+        expect(byId['4984']).toBeDefined();
+    });
+
+    it('is an empty object, not null, on a failed or empty fetch', () => {
+        // Callers look up unconditionally; values are additive decoration.
+        expect(valuesByPlayerId(undefined)).toEqual({});
+        expect(valuesByPlayerId({})).toEqual({});
+        expect(valuesByPlayerId({ values: null })).toEqual({});
+    });
+});
+
+describe('asOfMillis', () => {
+    it('converts the ISO string the API sends into epoch millis', () => {
+        // Handing agoLabel the raw string renders "NaNd ago" — that shipped
+        // once and only a browser caught it.
+        expect(asOfMillis({ asOf: '2026-08-13T00:33:00Z' })).toBe(Date.parse('2026-08-13T00:33:00Z'));
+    });
+
+    it('is null when absent or unparseable', () => {
+        expect(asOfMillis({})).toBeNull();
+        expect(asOfMillis({ asOf: 'soon' })).toBeNull();
+        expect(asOfMillis(undefined)).toBeNull();
+    });
+});
+
+describe('pickValue', () => {
+    const response = {
+        picks: [
+            { season: 2027, round: 1, tier: 'mid', value: 5507 },
+            { season: 2027, round: 1, tier: 'early', value: 7071 },
+            { season: 2026, round: 2, tier: 'mid', value: 3000 },
+        ],
+    };
+
+    it('defaults to the mid tier, since a Sleeper pick carries none', () => {
+        expect(pickValue(response, { season: 2027, round: 1 }).value).toBe(5507);
+    });
+
+    it('takes an explicit tier when the caller knows better', () => {
+        expect(pickValue(response, { season: 2027, round: 1, tier: 'early' }).value).toBe(7071);
+    });
+
+    it('accepts season and round as strings, which is how Sleeper sends them', () => {
+        expect(pickValue(response, { season: '2027', round: '1' }).value).toBe(5507);
+    });
+
+    it('is null for a pick nobody prices, rather than falling back to a nearby one', () => {
+        // A 2029 pick must read as unpriced, not as a 2028 one.
+        expect(pickValue(response, { season: 2029, round: 1 })).toBeNull();
+        expect(pickValue(response, { season: 2027, round: 9 })).toBeNull();
+    });
+
+    it('is null when the response carries no picks at all', () => {
+        expect(pickValue({}, { season: 2027, round: 1 })).toBeNull();
+        expect(pickValue(response, {})).toBeNull();
+    });
+});

--- a/src/lib/sleeperApi.js
+++ b/src/lib/sleeperApi.js
@@ -2,7 +2,7 @@ import { checkErrors } from './http.js';
 import { decorateRosters } from './rosterInfo.js';
 import { resolveLeagueSeason } from './sleeper.js';
 import APP_DB_URLS, { SLEEPER_API_URLS } from '../urls.js';
-const { ACTIVE_PLAYERS, AVAILABILITY, LEAGUE_INTEL, MANAGER_ACTIVITY, MARKET_VALUES } = APP_DB_URLS;
+const { ACTIVE_PLAYERS, AVAILABILITY, DYNASTY_VALUES, LEAGUE_INTEL, MANAGER_ACTIVITY, MARKET_VALUES } = APP_DB_URLS;
 const { LEAGUE, USER_LEAGUES, USER_BY_NAME, NFL_STATE, DRAFT, ROSTERS, SLEEPER_USERS, TRADED_PICKS, DRAFTS } =
     SLEEPER_API_URLS;
 
@@ -198,6 +198,37 @@ export async function fetchManagerActivity({ userId, season, limit, types }) {
         .then((response) => response.json())
         .catch((error) => {
             console.error('Error fetching manager activity:', error);
+        });
+}
+
+/**
+ * Dynasty market values keyed by Sleeper id, each with how far it has moved
+ * over `window` days, plus rookie pick values.
+ *
+ * `superflex` is not cosmetic. KeepTradeCut prices 1QB and superflex
+ * separately and they are different games — in superflex the most valuable
+ * asset is a quarterback — so a league's own shape decides which one is
+ * true for it. Derived from the league rather than pinned, same rule
+ * `leagueMarketSettings` already follows for FantasyCalc.
+ *
+ * Resolves to `undefined` on failure, per this module's contract. Values are
+ * additive decoration: a rank list without them is exactly the list this app
+ * rendered before, so callers drop the column rather than failing the screen.
+ */
+export async function fetchDynastyValues({ superflex = true, window } = {}) {
+    const params = new URLSearchParams();
+    // Sent only when false: the API defaults to superflex, and an absent
+    // param and `true` mean the same thing to it.
+    if (!superflex) params.set('superflex', 'false');
+    if (window != null) params.set('window', String(window));
+
+    const query = params.toString();
+
+    return await fetch(query ? `${DYNASTY_VALUES}?${query}` : DYNASTY_VALUES)
+        .then(checkErrors)
+        .then((response) => response.json())
+        .catch((error) => {
+            console.error('Error fetching dynasty values:', error);
         });
 }
 

--- a/src/urls.js
+++ b/src/urls.js
@@ -6,6 +6,7 @@ const fta = import.meta.env.DEV ? '/' : 'https://fantasyteamassistant.com/';
 const ftaLegacy = 'api/legacy/players';
 const ftaAvailability = (draftId) => `api/v1/drafts/${draftId}/availability`;
 const ftaMarketValues = 'api/v1/values';
+const ftaDynastyValues = 'api/v1/dynasty-values';
 const ftaLeagueIntel = (leagueId) => `api/v1/leagues/${leagueId}/intel`;
 const ftaManagerActivity = (userId) => `api/v1/users/${userId}/activity`;
 const latestUpdateAttempt = 'latest_update_attempt/';
@@ -38,6 +39,12 @@ const APP_DB_URLS = {
     // Sleeper id. A rank list the user does not have to supply - see
     // lib/marketValues.js for what is and is not claimed about it.
     MARKET_VALUES: fta + ftaMarketValues,
+    // KeepTradeCut values and how far each has moved. Distinct from
+    // MARKET_VALUES above, and the two are not interchangeable: that one is
+    // FantasyCalc and *seeds* a rank list for a league shape, this one is KTC
+    // and *decorates* rows that already exist. It is also the only source
+    // that can price a draft pick.
+    DYNASTY_VALUES: fta + ftaDynastyValues,
     // The leaguemates of one league, and what they do in their other ones
     // (docs/leaguemate-intel.md §3e). Keyed by league despite being the
     // "cross-league" view - the cross-league part is what the managers do


### PR DESCRIPTION
Player headshots are back on the rank row, with the team as a logo on the avatar instead of letters in the meta line, and each row now carries its dynasty market value and how far it has moved over 30 days.

Values come from a new backend endpoint (`/api/v1/dynasty-values`) serving KeepTradeCut values with movement, which the app had no way to read until now.

**The value sits in the meta line rather than the trailing cluster, and that was measured.** As a 46px trailing column it cost ten of fourteen rows their full name at 375px, against zero truncated before this change — Christian McCaffrey was clipped by 80px. The trailing area already carries an ADP delta, a position tag and an Add button. Moving the team onto the avatar is what freed the room.

Verified in a browser at 375px and 1280px: images load, no horizontal overflow, and the only names still clipped are the two longest in the pool.

- Values are additive — a failed fetch leaves the map empty and every row renders exactly as before
- Movement is coloured only above 3%, since KTC values wobble daily on crowd votes
- Flat (`±0`) and unknown (nothing) stay distinguishable, which is why the API sends `null` rather than `0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)