### PR TITLE
Add a Movers section

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import ErrorBanner from './Components/ErrorBanner';
 import LeaguePanel from './Panels/LeaguePanel';
 import RanksPanel from './Panels/RanksPanel';
 import LeaguemateIntelPanel from './Panels/LeaguemateIntelPanel';
+import MoversPanel from './Panels/MoversPanel';
 import Spinner from './Components/Spinner';
 import { SyncStatusProvider } from './SyncStatus.jsx';
 import { RankListProvider, useRankList } from './RankList.jsx';
@@ -807,6 +808,16 @@ class App extends React.Component {
                                     }
                                     if (activeId === 'leaguemates') {
                                         return <LeaguemateIntelPanel leagueID={leagueID} season={season} />;
+                                    }
+                                    if (activeId === 'movers') {
+                                        return (
+                                            <MoversPanel
+                                                marketSettings={leagueMarketSettings(leagueData.currentLeague)}
+                                                playerInfo={playerInfo}
+                                                rosterInfo={rosterInfo}
+                                                myDisplayName={myDisplayName}
+                                            />
+                                        );
                                     }
                                     return (
                                         <LeaguePanel

--- a/src/Panels/MoversPanel.jsx
+++ b/src/Panels/MoversPanel.jsx
@@ -1,0 +1,200 @@
+import { useEffect, useState } from 'react';
+import ListRow from '../Components/ListRow';
+import PlayerAvatar from '../Components/PlayerAvatar';
+import PositionTag from '../Components/PositionTag';
+import SegmentedControl from '../Components/SegmentedControl';
+import Spinner from '../Components/Spinner';
+import ValueChip from '../Components/ValueChip';
+import { agoLabel } from '../lib/relativeTime.js';
+import { asOfMillis, usesSuperflexValues, valuesByPlayerId } from '../lib/dynastyValues.js';
+import { movers, readingCoverage } from '../lib/movers.js';
+import { isTaken, rosteredBy } from '../lib/rosterInfo.js';
+import { fetchDynastyValues } from '../lib/sleeperApi.js';
+
+// Who the dynasty market is moving on, and which way.
+//
+// This is what `player_value_history` was built for. Every other screen in
+// this app answers a question about a list you supplied — your ranks, your
+// lineup, your leaguemates. This one answers a question you did not ask: the
+// market repriced somebody while you were not looking.
+//
+// League-scoped, like Leaguemates and for the same reason: the values
+// themselves are market-wide, but *which* set of values is true for you
+// depends on whether your league can start a second quarterback. Hiding the
+// league switcher would leave the numbers depending on a league you could
+// neither see nor change.
+
+const WINDOWS = [
+    { value: 7, label: '7d' },
+    { value: 30, label: '30d' },
+    { value: 90, label: '90d' },
+];
+
+const DIRECTIONS = [
+    { value: 'up', label: 'Rising' },
+    { value: 'down', label: 'Falling' },
+];
+
+const BASES = [
+    { value: 'percent', label: '%' },
+    { value: 'points', label: 'Pts' },
+];
+
+// Enough to scroll through with intent, short enough that the tail is still
+// meaningful movement rather than noise.
+const LIMIT = 40;
+
+const Header = ({ response, window: days, coverage }) => {
+    const asOf = agoLabel(asOfMillis(response));
+
+    return (
+        <div className="flex flex-col gap-0.5 px-4 pt-4 pb-2">
+            <h2 className="text-ink m-0 text-[20px] font-bold tracking-[-.02em]">Movers</h2>
+            {/* The sample the whole screen rests on. A list of movers over 460
+                priced players and one over 12 are different claims, and only
+                this line can say which. */}
+            <p className="text-ink-dim m-0 font-mono text-[11px]">
+                {coverage.withReading} of {coverage.total} priced · {days}d
+                {asOf && <span className="text-ink-quiet"> · {asOf}</span>}
+            </p>
+        </div>
+    );
+};
+
+const MoverRow = ({ entry, playerInfo, rosterInfo, myDisplayName, basis }) => {
+    const player = playerInfo?.[entry.playerId];
+    if (!player) return null;
+
+    const taken = isTaken(rosterInfo, entry.playerId);
+    const rosteredByName = rosteredBy(rosterInfo, entry.playerId);
+    const isMine = taken && rosteredByName === myDisplayName;
+
+    // Ownership is the whole reason this screen is actionable rather than
+    // trivia: a faller you own is a sell decision, a riser nobody owns is an
+    // add, and a riser on someone else's roster is a buy target. Stated in
+    // words rather than a colour, same rule the rank row follows.
+    const ownership = isMine ? 'Yours' : taken ? rosteredByName : 'Free agent';
+
+    return (
+        <ListRow
+            as="div"
+            label={`${player.full_name}, ${ownership}, ${entry.changePct > 0 ? 'up' : 'down'} ${Math.abs(
+                Math.round(entry.changePct),
+            )} percent`}
+            leading={<PlayerAvatar playerId={entry.playerId} name={player.full_name} team={player.team} />}
+            name={player.full_name}
+            nameTone={taken && !isMine ? 'muted' : 'default'}
+            flag={isMine ? { text: 'YOU', tone: 'mine' } : undefined}
+            meta={
+                <>
+                    <ValueChip value={entry.value} changePct={entry.changePct} />
+                    <span> · </span>
+                    <span>{ownership}</span>
+                </>
+            }
+            trailing={
+                <>
+                    {/* The points figure is the one thing the meta line does
+                        not already carry, and on the points sort it is the
+                        column being ranked - so it earns the space only
+                        there. */}
+                    {basis === 'points' && (
+                        <span className="text-ink-quiet w-[42px] shrink-0 text-right font-mono text-[11px] tabular-nums">
+                            {entry.change > 0 ? '+' : ''}
+                            {Math.round(entry.change)}
+                        </span>
+                    )}
+                    <PositionTag position={player.position} />
+                </>
+            }
+        />
+    );
+};
+
+const MoversPanel = ({ marketSettings, playerInfo, rosterInfo, myDisplayName }) => {
+    const [response, setResponse] = useState(undefined);
+    const [loading, setLoading] = useState(true);
+    const [days, setDays] = useState(30);
+    const [direction, setDirection] = useState('up');
+    const [basis, setBasis] = useState('percent');
+
+    const superflex = usesSuperflexValues(marketSettings);
+
+    useEffect(() => {
+        let cancelled = false;
+        setLoading(true);
+
+        fetchDynastyValues({ superflex, window: days }).then((body) => {
+            if (cancelled) return;
+            setResponse(body);
+            setLoading(false);
+        });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [superflex, days]);
+
+    if (loading) {
+        return (
+            <div className="flex min-h-40 items-center justify-center">
+                <Spinner />
+            </div>
+        );
+    }
+
+    // Unlike the rank list's value chips, this is not additive - the values
+    // *are* the screen, so a failed fetch has to say so rather than render an
+    // empty list that looks like a quiet market.
+    if (!response) {
+        return (
+            <p className="text-ink-muted m-0 flex min-h-11 items-center px-4 text-sm">
+                Couldn&rsquo;t load market values. The value service may be unavailable.
+            </p>
+        );
+    }
+
+    const values = response.values || [];
+    const coverage = readingCoverage(values);
+    const ranked = movers(values, { direction, basis, limit: LIMIT });
+    const byId = valuesByPlayerId(response);
+
+    return (
+        <div>
+            <Header response={response} window={days} coverage={coverage} />
+
+            <div className="flex flex-wrap items-center gap-2 px-4 pb-2">
+                <SegmentedControl label="Direction" options={DIRECTIONS} value={direction} onChange={setDirection} />
+                <SegmentedControl label="Window" options={WINDOWS} value={days} onChange={setDays} />
+                {/* Both bases are offered rather than a value floor being
+                    hidden inside the ranking - see lib/movers.js for the
+                    measurement behind that. */}
+                <SegmentedControl label="Sort by" options={BASES} value={basis} onChange={setBasis} />
+            </div>
+
+            {ranked.length === 0 ? (
+                <p className="text-ink-muted m-0 flex min-h-11 items-center px-4 text-sm">
+                    {coverage.withReading === 0
+                        ? 'No movement recorded yet over this window.'
+                        : 'Nothing has moved in this direction over this window.'}
+                </p>
+            ) : (
+                <ul className="flex list-none flex-col gap-0.5 px-2 py-2.5">
+                    {ranked.map((entry) => (
+                        <li key={entry.playerId}>
+                            <MoverRow
+                                entry={byId[entry.playerId] || entry}
+                                playerInfo={playerInfo}
+                                rosterInfo={rosterInfo}
+                                myDisplayName={myDisplayName}
+                                basis={basis}
+                            />
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
+};
+
+export default MoversPanel;

--- a/src/lib/movers.js
+++ b/src/lib/movers.js
@@ -44,6 +44,12 @@ export function movers(values, { direction = 'up', basis = 'percent', limit } = 
     const ranked = (values || [])
         .filter((entry) => {
             const moved = entry?.[key];
+            // The null check is deliberate but not load-bearing: `null > 0`
+            // and `null < 0` are both false, so the direction comparison
+            // below already excludes a missing reading. Deleting it changes
+            // no behaviour (a sabotage run confirmed the tests stay green) —
+            // it is here to say that "no reading" is an anticipated state
+            // rather than something that happens to fall through.
             if (moved == null || moved === 0) return false;
             return direction === 'up' ? moved > 0 : moved < 0;
         })

--- a/src/lib/movers.js
+++ b/src/lib/movers.js
@@ -1,0 +1,69 @@
+// Ranking the market's movers.
+//
+// Pure, like `dynastyValues.js` next door. The whole point of
+// `player_value_history` was to make this question answerable — a buy-low and
+// a sell-high are both claims about a price changing — and this is the module
+// that decides which changes are worth putting in front of someone.
+
+/**
+ * The two honest ways to ask "who moved", and they are genuinely different
+ * questions rather than a preference.
+ *
+ * Measured against live data on 2026-08-13, over a 30-day window:
+ *
+ *   * By **percent**, the top movers are deep bench — the two biggest were
+ *     +641% and +433%, at overall ranks 395 and 401. Median value of the top
+ *     20 was 1,433 against an overall median of 2,154. That is not noise to
+ *     be filtered out: a backup tripling in value is exactly the waiver-wire
+ *     news you want. But it does crowd out everything else.
+ *   * By **points**, the same list surfaces players who were already valuable
+ *     — rank 89 gaining 607 is a real shift in what your roster is worth, and
+ *     it is invisible on a percent list at 16%.
+ *
+ * So both are offered rather than one being picked and a value floor hidden
+ * inside. A floor would be this module deciding which of the two questions
+ * the user meant.
+ */
+export const SORT_BASES = ['percent', 'points'];
+
+/**
+ * Movers for one direction, most-moved first.
+ *
+ * `direction` is `'up'` or `'down'`. Entries with no reading are dropped
+ * rather than sorted as zero: `change` is `null` when there was nothing to
+ * compare against, which is not the same as flat, and treating it as 0 would
+ * bury real flat players under players we simply cannot see.
+ *
+ * A genuinely flat player is excluded from both lists too — he has not moved,
+ * so he is not a mover, and including him would pad the tail of whichever
+ * list is shorter.
+ */
+export function movers(values, { direction = 'up', basis = 'percent', limit } = {}) {
+    const key = basis === 'points' ? 'change' : 'changePct';
+
+    const ranked = (values || [])
+        .filter((entry) => {
+            const moved = entry?.[key];
+            if (moved == null || moved === 0) return false;
+            return direction === 'up' ? moved > 0 : moved < 0;
+        })
+        // Descending by magnitude, so both directions read "biggest first"
+        // rather than the fallers list starting at -1%.
+        .sort((a, b) => Math.abs(b[key]) - Math.abs(a[key]));
+
+    return limit == null ? ranked : ranked.slice(0, limit);
+}
+
+/**
+ * How much of the board actually has a reading, for the sample line.
+ *
+ * Stated rather than implied, same rule the leaguemates view follows: a list
+ * of movers over 460 priced players and one over 12 are different claims, and
+ * only the header can say which this is.
+ */
+export function readingCoverage(values) {
+    const total = (values || []).length;
+    const withReading = (values || []).filter((entry) => entry?.change != null).length;
+
+    return { total, withReading };
+}

--- a/src/lib/movers.test.js
+++ b/src/lib/movers.test.js
@@ -24,8 +24,12 @@ describe('movers', () => {
     });
 
     it('drops a player with no reading rather than treating him as flat', () => {
-        // `change` is null when there was nothing to compare against. Sorting
-        // that as 0 would bury genuinely flat players under invisible ones.
+        // `change` is null when there was nothing to compare against.
+        //
+        // This asserts a real guarantee but is over-determined: the direction
+        // comparison excludes null on its own, so deleting the explicit guard
+        // in `movers` leaves this green. Kept as a statement of the contract
+        // callers rely on, not as cover for that line.
         const all = [...movers(values, { direction: 'up' }), ...movers(values, { direction: 'down' })];
         expect(all.map((e) => e.playerId)).not.toContain('unknown');
     });

--- a/src/lib/movers.test.js
+++ b/src/lib/movers.test.js
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { movers, readingCoverage } from './movers.js';
+
+const entry = (playerId, change, changePct) => ({ playerId, change, changePct, value: 1000 });
+
+describe('movers', () => {
+    const values = [
+        entry('rise-big', 900, 90),
+        entry('rise-small', 100, 10),
+        entry('fall-big', -800, -80),
+        entry('fall-small', -50, -5),
+        entry('flat', 0, 0),
+        entry('unknown', null, null),
+    ];
+
+    it('ranks risers biggest first', () => {
+        expect(movers(values, { direction: 'up' }).map((e) => e.playerId)).toEqual(['rise-big', 'rise-small']);
+    });
+
+    it('ranks fallers by magnitude, so the list starts with the biggest drop', () => {
+        // Sorting ascending would start the fallers list at -5%, which reads
+        // as "nothing is happening".
+        expect(movers(values, { direction: 'down' }).map((e) => e.playerId)).toEqual(['fall-big', 'fall-small']);
+    });
+
+    it('drops a player with no reading rather than treating him as flat', () => {
+        // `change` is null when there was nothing to compare against. Sorting
+        // that as 0 would bury genuinely flat players under invisible ones.
+        const all = [...movers(values, { direction: 'up' }), ...movers(values, { direction: 'down' })];
+        expect(all.map((e) => e.playerId)).not.toContain('unknown');
+    });
+
+    it('excludes a flat player from both directions, since he has not moved', () => {
+        const all = [...movers(values, { direction: 'up' }), ...movers(values, { direction: 'down' })];
+        expect(all.map((e) => e.playerId)).not.toContain('flat');
+    });
+
+    it('ranks by points when asked, which is a different order from percent', () => {
+        // The case that makes both bases worth offering: a small player
+        // doubling outranks a big one on percent and loses on points.
+        const mixed = [
+            { playerId: 'scrub', value: 200, change: 200, changePct: 100 },
+            { playerId: 'stud', value: 9000, change: 600, changePct: 7 },
+        ];
+
+        expect(movers(mixed, { basis: 'percent' }).map((e) => e.playerId)).toEqual(['scrub', 'stud']);
+        expect(movers(mixed, { basis: 'points' }).map((e) => e.playerId)).toEqual(['stud', 'scrub']);
+    });
+
+    it('caps the list when a limit is given', () => {
+        expect(movers(values, { direction: 'up', limit: 1 })).toHaveLength(1);
+    });
+
+    it('survives an absent or empty list', () => {
+        expect(movers(undefined)).toEqual([]);
+        expect(movers([])).toEqual([]);
+    });
+});
+
+describe('readingCoverage', () => {
+    it('counts how much of the board can actually be read', () => {
+        // A movers list over 460 priced players and one over 12 are different
+        // claims, and only the header can say which this is.
+        expect(readingCoverage([entry('a', 1, 1), entry('b', null, null)])).toEqual({
+            total: 2,
+            withReading: 1,
+        });
+    });
+
+    it('is zeroes rather than a crash on an absent list', () => {
+        expect(readingCoverage(undefined)).toEqual({ total: 0, withReading: 0 });
+    });
+});

--- a/src/sections.js
+++ b/src/sections.js
@@ -16,6 +16,14 @@ export const SECTIONS = [
     // would leave per-league content depending on a league you can neither
     // see nor change. 'global' is still unused.
     { id: 'leaguemates', label: 'Leaguemates', scope: 'league' },
+    // Movers is 'league' scope for the same reason, and it is the less
+    // obvious case: the values are market-wide, so this looks like the
+    // 'global' section the docstring above imagines. But *which* set of
+    // values is true for you depends on whether your league can start a
+    // second quarterback - KeepTradeCut prices 1QB and superflex as separate
+    // lists - so hiding the league switcher would leave the numbers
+    // depending on a league you could neither see nor change.
+    { id: 'movers', label: 'Movers', scope: 'league' },
 ];
 
 export const DEFAULT_SECTION_ID = 'draft';


### PR DESCRIPTION
Every other screen answers a question about a list you supplied — your ranks, your lineup, your leaguemates. This one answers a question you didn't ask: the market repriced somebody while you weren't looking. It's what the value history was collected for.

Risers and fallers over a 7/30/90-day window, each row carrying who owns the player — which is what makes it actionable rather than trivia. A faller you own is a sell, a riser nobody owns is an add, and a riser on someone else's roster is a buy target.

**Both percent and points are offered rather than one being picked with a value floor hidden inside the ranking.** Measured against live data over 30 days, they're genuinely different questions: by percent the top movers are deep bench (+641% and +433% at overall ranks 395 and 401, median value 1,433 against 2,154 overall), while by points the same window surfaces players who were already valuable — Diggs, Deebo, Carson Beck. A floor would be the code deciding which question was meant.

League-scoped despite the values being market-wide, because which set of values is true for you depends on whether your league can start a second quarterback.

Verified in a browser at 375px and 1280px: 0 truncated, no horizontal overflow, all three ownership states render, and the window control refetches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)