### PR TITLE
Add a Trades section

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import LeaguePanel from './Panels/LeaguePanel';
 import RanksPanel from './Panels/RanksPanel';
 import LeaguemateIntelPanel from './Panels/LeaguemateIntelPanel';
 import MoversPanel from './Panels/MoversPanel';
+import TradesPanel from './Panels/TradesPanel';
 import Spinner from './Components/Spinner';
 import { SyncStatusProvider } from './SyncStatus.jsx';
 import { RankListProvider, useRankList } from './RankList.jsx';
@@ -808,6 +809,16 @@ class App extends React.Component {
                                     }
                                     if (activeId === 'leaguemates') {
                                         return <LeaguemateIntelPanel leagueID={leagueID} season={season} />;
+                                    }
+                                    if (activeId === 'trades') {
+                                        return (
+                                            <TradesPanel
+                                                leagueID={leagueID}
+                                                sleeperUserId={sleeperAccount?.userId}
+                                                marketSettings={leagueMarketSettings(leagueData.currentLeague)}
+                                                playerInfo={playerInfo}
+                                            />
+                                        );
                                     }
                                     if (activeId === 'movers') {
                                         return (

--- a/src/Panels/TradesPanel.jsx
+++ b/src/Panels/TradesPanel.jsx
@@ -1,0 +1,197 @@
+import { useEffect, useState } from 'react';
+import PlayerAvatar from '../Components/PlayerAvatar';
+import PositionTag from '../Components/PositionTag';
+import Spinner from '../Components/Spinner';
+import { usesSuperflexValues } from '../lib/dynastyValues.js';
+import { fetchLeagueTrades } from '../lib/sleeperApi.js';
+
+// Trades this manager and their leaguemates might both want.
+//
+// The strongest claim this app makes, and the one that most needs hedging.
+// Every other screen reports a measurement; this one proposes an action. So
+// the framing is deliberately "these two rosters fit, here is the arithmetic"
+// rather than "send this offer" — whether a trade is good for you depends on
+// whether you are contending, which nothing here knows.
+//
+// That is why the roster shape is rendered at the top rather than hidden: a
+// suggestion says "you are deep at RB and thin at WR", and the counts behind
+// that are what let someone disagree with it.
+
+const POSITION_ORDER = ['QB', 'RB', 'WR', 'TE'];
+
+// Below this the two sides are close enough that the difference is not the
+// story. Above it, the gap is worth naming rather than leaving to be read off
+// two numbers.
+const NOTABLE_GAP = 40;
+
+const Shape = ({ shape }) => {
+    if (!shape?.depth) return null;
+
+    return (
+        <div className="flex flex-wrap gap-1.5 px-4 pb-3">
+            {POSITION_ORDER.filter((position) => shape.depth[position] != null).map((position) => {
+                const mine = shape.depth[position];
+                const league = shape.leagueAverage?.[position];
+                // Deep and thin are relative to the league, not to the
+                // starting lineup — in dynasty everyone is past their
+                // starters everywhere. See the backend's TradeFinder.
+                const tone =
+                    league == null
+                        ? 'text-ink-dim'
+                        : mine > league + 0.5
+                          ? 'text-live'
+                          : mine < league - 0.5
+                            ? 'text-warn'
+                            : 'text-ink-dim';
+
+                return (
+                    <span key={position} className="bg-raised-2 flex items-center gap-1.5 rounded-full px-2 py-1">
+                        <PositionTag position={position} />
+                        <span className={`font-mono text-[11px] tabular-nums ${tone}`}>
+                            {mine}
+                            {league != null && <span className="text-ink-quiet"> vs {league.toFixed(1)}</span>}
+                        </span>
+                    </span>
+                );
+            })}
+        </div>
+    );
+};
+
+const Side = ({ label, ids, playerInfo, tone }) => (
+    <div className="flex min-w-0 flex-1 flex-col gap-1">
+        <span className="text-ink-dim font-mono text-[9px] tracking-[.08em] uppercase">{label}</span>
+        {ids.map((id) => {
+            const player = playerInfo?.[id];
+            return (
+                <span key={id} className="flex min-w-0 items-center gap-2">
+                    <PlayerAvatar playerId={id} name={player?.full_name} team={player?.team} size={24} />
+                    <span className={`min-w-0 truncate text-[13px] font-semibold ${tone}`}>
+                        {/* An id rather than a blank when the pool has never
+                            heard of him: a row that silently drops one side of
+                            a trade is worse than one showing a number. */}
+                        {player?.full_name || id}
+                    </span>
+                </span>
+            );
+        })}
+    </div>
+);
+
+const Suggestion = ({ suggestion, playerInfo }) => {
+    const gap = Math.round(suggestion.getValue - suggestion.giveValue);
+    const notable = Math.abs(gap) >= NOTABLE_GAP;
+
+    return (
+        <div className="bg-raised rounded-row flex flex-col gap-2 px-3 py-2.5">
+            <div className="flex items-baseline justify-between gap-2">
+                <span className="text-ink truncate text-[13px] font-semibold">{suggestion.partnerName}</span>
+                {/* Named only when it is worth naming. Below the threshold two
+                    adjusted totals a few points apart is not a finding. */}
+                <span
+                    className={`shrink-0 font-mono text-[10px] tabular-nums ${
+                        notable ? (gap > 0 ? 'text-live' : 'text-warn') : 'text-ink-dim'
+                    }`}
+                >
+                    {notable ? `${gap > 0 ? '+' : ''}${gap} for you` : 'even'}
+                </span>
+            </div>
+
+            <div className="flex items-start gap-3">
+                <Side label="You send" ids={suggestion.give} playerInfo={playerInfo} tone="text-ink-quiet" />
+                <span className="text-ink-dim shrink-0 self-center text-[13px]">→</span>
+                <Side label="You get" ids={suggestion.get} playerInfo={playerInfo} tone="text-ink" />
+            </div>
+
+            {/* Both numbers, because on a package trade the interesting thing
+                is how far they differ: raw sums are what make eight spare
+                parts look like a fair offer, and the adjusted pair is what
+                says they are not. */}
+            <p className="text-ink-quiet m-0 font-mono text-[10px] tabular-nums">
+                adjusted {Math.round(suggestion.giveValue)} vs {Math.round(suggestion.getValue)} · raw gap{' '}
+                {Math.round(suggestion.rawGap)}
+            </p>
+        </div>
+    );
+};
+
+const TradesPanel = ({ leagueID, sleeperUserId, marketSettings, playerInfo }) => {
+    const [response, setResponse] = useState(undefined);
+    const [loading, setLoading] = useState(true);
+
+    const superflex = usesSuperflexValues(marketSettings);
+
+    useEffect(() => {
+        if (!leagueID || !sleeperUserId) {
+            setLoading(false);
+            return undefined;
+        }
+
+        let cancelled = false;
+        setLoading(true);
+
+        fetchLeagueTrades({ leagueId: leagueID, userId: sleeperUserId, superflex }).then((body) => {
+            if (cancelled) return;
+            setResponse(body);
+            setLoading(false);
+        });
+
+        return () => {
+            cancelled = true;
+        };
+    }, [leagueID, sleeperUserId, superflex]);
+
+    if (!sleeperUserId) {
+        return (
+            <p className="text-ink-muted m-0 flex min-h-11 items-center px-4 text-sm">
+                Connect your Sleeper account to see trades for your roster.
+            </p>
+        );
+    }
+
+    if (loading) {
+        return (
+            <div className="flex min-h-40 items-center justify-center">
+                <Spinner />
+            </div>
+        );
+    }
+
+    if (!response) {
+        return (
+            <p className="text-ink-muted m-0 flex min-h-11 items-center px-4 text-sm">
+                Couldn&rsquo;t load trade suggestions. The value service may be unavailable.
+            </p>
+        );
+    }
+
+    const suggestions = response.suggestions || [];
+
+    return (
+        <div>
+            <div className="flex flex-col gap-0.5 px-4 pt-4 pb-2">
+                <h2 className="text-ink m-0 text-[20px] font-bold tracking-[-.02em]">Trades</h2>
+                <p className="text-ink-dim m-0 font-mono text-[11px]">Your roster vs the league average</p>
+            </div>
+
+            <Shape shape={response.rosterShape} />
+
+            {suggestions.length === 0 ? (
+                <p className="text-ink-muted m-0 px-4 text-sm leading-snug">
+                    Nothing fits right now. That usually means your roster is shaped like everyone else&rsquo;s — a
+                    trade needs one side deep where the other is thin.
+                </p>
+            ) : (
+                <ul className="flex list-none flex-col gap-2 px-3 py-2">
+                    {suggestions.map((suggestion, index) => (
+                        <li key={`${suggestion.partnerId}-${index}`}>
+                            <Suggestion suggestion={suggestion} playerInfo={playerInfo} />
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
+};
+
+export default TradesPanel;

--- a/src/lib/sleeperApi.js
+++ b/src/lib/sleeperApi.js
@@ -2,7 +2,8 @@ import { checkErrors } from './http.js';
 import { decorateRosters } from './rosterInfo.js';
 import { resolveLeagueSeason } from './sleeper.js';
 import APP_DB_URLS, { SLEEPER_API_URLS } from '../urls.js';
-const { ACTIVE_PLAYERS, AVAILABILITY, DYNASTY_VALUES, LEAGUE_INTEL, MANAGER_ACTIVITY, MARKET_VALUES } = APP_DB_URLS;
+const { ACTIVE_PLAYERS, AVAILABILITY, DYNASTY_VALUES, LEAGUE_INTEL, LEAGUE_TRADES, MANAGER_ACTIVITY, MARKET_VALUES } =
+    APP_DB_URLS;
 const { LEAGUE, USER_LEAGUES, USER_BY_NAME, NFL_STATE, DRAFT, ROSTERS, SLEEPER_USERS, TRADED_PICKS, DRAFTS } =
     SLEEPER_API_URLS;
 
@@ -229,6 +230,29 @@ export async function fetchDynastyValues({ superflex = true, window } = {}) {
         .then((response) => response.json())
         .catch((error) => {
             console.error('Error fetching dynasty values:', error);
+        });
+}
+
+/**
+ * Trades this manager and their leaguemates might both want.
+ *
+ * The response carries `rosterShape` alongside the suggestions, and it is not
+ * decoration: a suggestion claims "you are deep here and thin there", and
+ * rendering that without the counts behind it asks to be trusted rather than
+ * showing its working. `leagueAverage` is the yardstick depth is measured
+ * against - `starters` is for display only.
+ *
+ * Resolves to `undefined` on failure, per this module's contract.
+ */
+export async function fetchLeagueTrades({ leagueId, userId, superflex = true }) {
+    const params = new URLSearchParams({ user_id: String(userId) });
+    if (!superflex) params.set('superflex', 'false');
+
+    return await fetch(`${LEAGUE_TRADES(leagueId)}?${params}`)
+        .then(checkErrors)
+        .then((response) => response.json())
+        .catch((error) => {
+            console.error('Error fetching trade suggestions:', error);
         });
 }
 

--- a/src/sections.js
+++ b/src/sections.js
@@ -24,6 +24,9 @@ export const SECTIONS = [
     // lists - so hiding the league switcher would leave the numbers
     // depending on a league you could neither see nor change.
     { id: 'movers', label: 'Movers', scope: 'league' },
+    // Trades is about these twelve rosters specifically, so 'league' is the
+    // obvious scope here rather than the argued one it is for Movers.
+    { id: 'trades', label: 'Trades', scope: 'league' },
 ];
 
 export const DEFAULT_SECTION_ID = 'draft';
@@ -32,10 +35,7 @@ export const DEFAULT_SECTION_ID = 'draft';
 // SECTIONS, which drives routing and the tab bar - adding these to SECTIONS
 // would make useHashRoute treat their ids as valid routes with nothing to
 // render for them.
-export const PLANNED_SECTIONS = [
-    { id: 'league-history', label: 'League history' },
-    { id: 'trade-finder', label: 'Trade finder' },
-];
+export const PLANNED_SECTIONS = [{ id: 'league-history', label: 'League history' }];
 
 // Which section a fresh load should open on, based on where the current
 // league's draft stands. A completed draft has nothing left to do on the

--- a/src/urls.js
+++ b/src/urls.js
@@ -8,6 +8,7 @@ const ftaAvailability = (draftId) => `api/v1/drafts/${draftId}/availability`;
 const ftaMarketValues = 'api/v1/values';
 const ftaDynastyValues = 'api/v1/dynasty-values';
 const ftaLeagueIntel = (leagueId) => `api/v1/leagues/${leagueId}/intel`;
+const ftaLeagueTrades = (leagueId) => `api/v1/leagues/${leagueId}/trades`;
 const ftaManagerActivity = (userId) => `api/v1/users/${userId}/activity`;
 const latestUpdateAttempt = 'latest_update_attempt/';
 const dlfADP = 'dlf_adp/';
@@ -50,6 +51,11 @@ const APP_DB_URLS = {
     // "cross-league" view - the cross-league part is what the managers do
     // elsewhere, not what the request spans.
     LEAGUE_INTEL: (leagueId) => fta + ftaLeagueIntel(leagueId),
+    // Trades the asking manager and each leaguemate might both want. Keyed
+    // by league because it is about these twelve rosters, and read live -
+    // a suggestion built on last night's roster is about a team that no
+    // longer exists.
+    LEAGUE_TRADES: (leagueId) => fta + ftaLeagueTrades(leagueId),
     // One leaguemate's recent trades, waivers and free-agent adds, across
     // every league they are in. Not nested under a league on purpose - the
     // data spans all of theirs, so a league in the path would imply a filter


### PR DESCRIPTION
The drawer has advertised a trade finder since before any of its inputs existed. They exist now: priced draft picks, a package evaluator validated against KeepTradeCut's own implementation, and roster ownership.

Suggestions come from a new backend endpoint (`GET /api/v1/leagues/:id/trades`) that reads the league's rosters live and matches surplus against need. A suggestion has to clear two independent bars: the sides are within 12% once adjusted, and **each side** gives where it is deep and gets where it is thin — a trade only you want is a trade that doesn't happen.

**Depth is measured against the league, not the starting lineup.** The first version compared bodies to starter counts and returned nothing at all against a real league: District 13 rosters carry 8 RB and 9 WR against 2 starting slots each, so every position is "deep" for everyone and nobody is ever thin. That only showed up running against live data.

The roster shape renders above the suggestions on purpose — a suggestion claims "you are deep at RB and thin at WR", and the counts behind it are what let you disagree.

Verified against District 13 at 375px and 1280px: 0 truncated, no overflow, no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)