### PR TITLE
Show injury on the rows a decision gets made on

### DIFF
--- a/src/Components/BestAvailable.jsx
+++ b/src/Components/BestAvailable.jsx
@@ -1,5 +1,7 @@
 import { useMemo, useState } from 'react';
 import ListRow from './ListRow';
+import InjuryTag from './InjuryTag';
+import { injuryAccessibleText, injuryDetail } from './injuryLabels.js';
 import PositionTag from './PositionTag';
 import OwnershipFilters, { DEFAULT_OWNERSHIP, matchesOwnership } from './OwnershipFilters';
 import IntelDetail from './IntelDetail';
@@ -294,7 +296,16 @@ const BestAvailable = ({
                     // draft's read-only sheet has no lineup to compare against
                     // and passes none.
                     const started = Boolean(lineupSet) && isInLineup(lineupSet, id);
-                    const accessibleName = playerAccessibleName({ player, taken, rosteredByName, isMine, started });
+                    const accessibleName = playerAccessibleName({
+                        player,
+                        taken,
+                        rosteredByName,
+                        isMine,
+                        started,
+                        // No return date: this list has no values to read one
+                        // from, same as the lineup slot rows.
+                        injury: injuryAccessibleText(player, null),
+                    });
 
                     const target = targetsById.get(id);
                     const survival = survivalAt(target, atPick);
@@ -319,12 +330,24 @@ const BestAvailable = ({
                                 ordinalClassName="text-right text-[12px] text-ink-muted"
                                 name={player.full_name}
                                 nameTone={unavailable ? 'muted' : 'default'}
+                                // Plain, not the Ranks row's tappable variant:
+                                // this row is sometimes a button itself and a
+                                // button cannot nest one. The detail goes on
+                                // the meta line instead, which has the room the
+                                // Ranks meta line measurably does not.
+                                nameAfter={<InjuryTag player={player} />}
                                 flag={isMine ? { text: 'YOU', tone: 'mine' } : undefined}
                                 meta={
                                     <>
                                         <span>{player.team ? player.team : 'FA'}</span>
                                         <span> · </span>
                                         <span>{taken ? `rostered by ${rosteredByName}` : 'free agent'}</span>
+                                        {injuryDetail(player, null) && (
+                                            <>
+                                                <span> · </span>
+                                                <span className="text-warn">{injuryDetail(player, null)}</span>
+                                            </>
+                                        )}
                                     </>
                                 }
                                 trailing={

--- a/src/Components/BestAvailable.test.jsx
+++ b/src/Components/BestAvailable.test.jsx
@@ -64,6 +64,41 @@ const renderBestAvailable = (overrides = {}) =>
         />,
     );
 
+describe('BestAvailable injury', () => {
+    // The sheet you pick a starter from, so an injury belongs on it. The badge
+    // is the plain variant here: this row is sometimes a button itself, and the
+    // Ranks row's tappable one cannot nest inside that.
+    const hurt = (attrs) => ({
+        ...playerInfo,
+        [FREE_AGENT.id]: { ...playerInfo[FREE_AGENT.id], ...attrs },
+    });
+
+    it('badges an injured player and puts the detail on the meta line', () => {
+        renderBestAvailable({
+            ownership: SHOW_EVERYONE,
+            playerInfo: hurt({ injury_status: 'Questionable', injury_body_part: 'Hamstring' }),
+        });
+
+        expect(screen.getByTestId('injury-tag')).toHaveTextContent('Q');
+        expect(screen.getByText('Q · Hamstring')).toBeInTheDocument();
+    });
+
+    it('renders the badge as text, never as a nested button', () => {
+        renderBestAvailable({
+            ownership: SHOW_EVERYONE,
+            playerInfo: hurt({ injury_status: 'IR' }),
+        });
+
+        expect(screen.getByTestId('injury-tag').tagName).toBe('SPAN');
+    });
+
+    it('leaves healthy rows alone', () => {
+        renderBestAvailable({ ownership: SHOW_EVERYONE });
+
+        expect(screen.queryByTestId('injury-tag')).not.toBeInTheDocument();
+    });
+});
+
 describe('BestAvailable', () => {
     it('lists players in ranking order', () => {
         renderBestAvailable({ ownership: SHOW_EVERYONE });

--- a/src/Components/InjuryTag.jsx
+++ b/src/Components/InjuryTag.jsx
@@ -1,0 +1,93 @@
+import { useRef, useState } from 'react';
+import Popover from './Popover';
+import { injuryBadge, injuryDetailLines } from './injuryLabels.js';
+
+// The injury badge that sits beside a player's name, in the idiom every
+// fantasy app uses: a short letter code, coloured by severity. Amber for
+// questionable (he may well play), red for the statuses that mean he will not.
+//
+// Text, not a tint block like `PositionTag`. A filled badge here reads as loud
+// as the position tag and there are two of them on a row.
+//
+// **The detail is a popover, because the meta line has no room for it.**
+// Measured at 375px against a real rank list: that line has 155px of width and
+// the value chip plus the manager's name already need 145 of it, so appending
+// "· Q · Knee - ACL · back Aug 22" truncated 7 of 14 rows and clipped away the
+// return date — the one part of this KeepTradeCut publishes and nothing else
+// does. Tap-for-detail is what the app already does with `TermTip` when a
+// figure needs more words than a row can hold.
+//
+// Without `detail` this renders as plain text. That is not a fallback: a row
+// that is *itself* a button (SlotRow) cannot legally nest one, so the lineup
+// carries the same detail on its own meta line, which has the room this one
+// does not.
+const TONE = {
+    warn: 'text-warn',
+    danger: 'text-danger',
+};
+
+const InjuryTag = ({ player, injuryReturn = null, detail = false }) => {
+    const ref = useRef(null);
+    const [open, setOpen] = useState(false);
+    const badge = injuryBadge(player);
+
+    if (!badge) return null;
+
+    const className = `shrink-0 font-mono text-[9px] font-semibold tracking-[.1em] ${TONE[badge.tone]}`;
+
+    if (!detail) {
+        return (
+            <span data-testid="injury-tag" className={className}>
+                {badge.badge}
+            </span>
+        );
+    }
+
+    const lines = injuryDetailLines(player, injuryReturn);
+
+    return (
+        <>
+            <button
+                ref={ref}
+                type="button"
+                data-testid="injury-tag"
+                onClick={(event) => {
+                    // Defensive, and currently unreachable: this sits in
+                    // ListRow's `nameAfter` slot, which is a *sibling* of the
+                    // name button rather than inside it, and the only row that
+                    // renders this variant is a `div`. So there is nothing
+                    // above to swallow the click today — sabotaging this line
+                    // fails no test, deliberately noted rather than papered
+                    // over with a contrived one. It stays because the slot's
+                    // contract does not promise either of those things, and
+                    // the row it lands on is one prop away from being a
+                    // button.
+                    event.stopPropagation();
+                    setOpen((isOpen) => !isOpen);
+                }}
+                aria-label={`${badge.label}, more detail`}
+                className={`${className} hover:underline`}
+            >
+                {badge.badge}
+            </button>
+            {open && (
+                <Popover triggerRef={ref} onClose={() => setOpen(false)} label={badge.label} width={200}>
+                    <div className="px-2 py-1.5">
+                        <p
+                            className={`m-0 font-mono text-[10px] font-semibold tracking-[.06em] uppercase ${TONE[badge.tone]}`}
+                        >
+                            {lines.headline}
+                        </p>
+                        {lines.body.map((line) => (
+                            <p key={line} className="text-ink-muted m-0 mt-1 text-[11px] leading-snug">
+                                {line}
+                            </p>
+                        ))}
+                    </div>
+                </Popover>
+            )}
+        </>
+    );
+};
+
+export default InjuryTag;

--- a/src/Components/ListRow.jsx
+++ b/src/Components/ListRow.jsx
@@ -46,6 +46,13 @@ const ListRow = ({
     leading,
     name,
     nameTone = 'default',
+    // Sits between the name and `flag`. Like `leading`, it is a slot rather
+    // than something the caller folds into `name`, because `name` is the
+    // truncating flex child: a badge in there would be clipped before the
+    // text it qualifies, which is backwards for a badge that exists to warn.
+    // Closer to the name than `flag` on purpose — this says something about
+    // the player, `flag` says something about your relationship to him.
+    nameAfter,
     flag,
     leadingDot,
     meta,
@@ -80,6 +87,7 @@ const ListRow = ({
                     >
                         {name}
                     </span>
+                    {nameAfter}
                     {flag && (
                         <span
                             className={`shrink-0 font-mono text-[9px] font-semibold tracking-[.1em] ${FLAG_TONE[flag.tone]}`}

--- a/src/Components/PlayerInfoItem.jsx
+++ b/src/Components/PlayerInfoItem.jsx
@@ -4,6 +4,8 @@ import PlayerAvatar from './PlayerAvatar';
 import PositionTag from './PositionTag';
 import PlayerSearch from './PlayerSearch';
 import ValueChip from './ValueChip';
+import InjuryTag from './InjuryTag';
+import { injuryAccessibleText } from './injuryLabels.js';
 import { playerAccessibleName, playerAvailabilityText } from './playerInfoLabels.js';
 import { isInLineup, isTaken, rosteredBy } from '../lib/rosterInfo.js';
 
@@ -32,7 +34,19 @@ const PlayerInfoItem = ({
     // background (`.search-alert`); the `--color-warn` border below is the
     // replacement, and it is independent of taken/mine.
     const lowConfidenceMatch = Number(searchData.match_results[0][1]) > 0;
-    const accessibleName = playerAccessibleName({ player, taken, rosteredByName, isMine, lowConfidenceMatch });
+    // Status and body part come from Sleeper's player dump, the expected
+    // return date from the value row — the only place that publishes one. A
+    // player with no value entry still shows his injury; only the "back
+    // Aug 22" part goes missing.
+    const injuryReturn = marketValue?.injuryReturn;
+    const accessibleName = playerAccessibleName({
+        player,
+        taken,
+        rosteredByName,
+        isMine,
+        lowConfidenceMatch,
+        injury: injuryAccessibleText(player, injuryReturn),
+    });
 
     const updatePlayerInfo = (newPlayerId) => {
         const newSearchData = { ...searchData };
@@ -186,6 +200,7 @@ const PlayerInfoItem = ({
                 </button>
             }
             nameTone={taken ? 'muted' : 'default'}
+            nameAfter={<InjuryTag player={player} injuryReturn={injuryReturn} detail />}
             flag={isMine ? { text: 'YOU', tone: 'mine' } : undefined}
             leadingDot={lowConfidenceMatch ? 'warn' : undefined}
             meta={
@@ -207,6 +222,11 @@ const PlayerInfoItem = ({
                             <span> · </span>
                         </>
                     )}
+                    {/* No injury detail here, deliberately. Measured at
+                        375px against a real list: this line has 155px and the
+                        value chip plus a manager name already need 145, so
+                        appending the status truncated 7 of 14 rows and ate the
+                        return date. It lives in the badge's popover instead. */}
                     <span>{playerAvailabilityText({ taken, rosteredByName })}</span>
                 </>
             }

--- a/src/Components/PlayerInfoItem.test.jsx
+++ b/src/Components/PlayerInfoItem.test.jsx
@@ -57,6 +57,86 @@ function renderItem(playerId, { lineupSet = new Set(), ...overrides } = {}) {
     return props;
 }
 
+describe('PlayerInfoItem injury', () => {
+    // Injury status and body part come from Sleeper's player dump; the
+    // expected return date rides on the value row, because only KeepTradeCut
+    // publishes one. The two arrive by different routes and the row has to
+    // read either without the other.
+    const injured = (attrs) => ({ ...playerInfo[FREE_AGENT_ID], ...attrs });
+
+    it('badges an injured player and spells the status out in the name', () => {
+        renderItem(FREE_AGENT_ID, {
+            player: injured({ injury_status: 'Questionable', injury_body_part: 'Hamstring' }),
+        });
+
+        expect(screen.getByTestId('injury-tag')).toHaveTextContent('Q');
+        expect(screen.getByRole('group', { name: /questionable, hamstring/i })).toBeInTheDocument();
+    });
+
+    // The detail is a popover rather than meta-line text because that line is
+    // measurably full — 145px of content in 155px of room at 375px.
+    it('opens the detail, with the return date, when the badge is tapped', async () => {
+        const user = userEvent.setup();
+        renderItem(FREE_AGENT_ID, {
+            player: injured({ injury_status: 'Questionable', injury_body_part: 'Hamstring' }),
+            marketValue: { value: 4300, changePct: null, injuryReturn: '2026-08-22' },
+        });
+
+        await user.click(screen.getByTestId('injury-tag'));
+
+        expect(screen.getByText('Hamstring')).toBeInTheDocument();
+        expect(screen.getByText(/Expected (back|due back) Aug 22/)).toBeInTheDocument();
+    });
+
+    // Real behaviour, but structurally guaranteed rather than defended: the
+    // badge is a sibling of the name button, so nothing propagates. Kept as a
+    // regression guard on that structure, not as cover for the
+    // `stopPropagation` call, which sabotage shows no test can currently reach.
+    it('does not open the edit form when the badge is tapped', async () => {
+        const user = userEvent.setup();
+        renderItem(FREE_AGENT_ID, { player: injured({ injury_status: 'IR' }) });
+
+        await user.click(screen.getByTestId('injury-tag'));
+
+        expect(screen.queryByPlaceholderText('Manually update player')).not.toBeInTheDocument();
+    });
+
+    it('keeps the meta line free of injury text, which does not fit on it', () => {
+        renderItem(FREE_AGENT_ID, {
+            player: injured({ injury_status: 'Questionable', injury_body_part: 'Hamstring' }),
+            marketValue: { value: 4300, changePct: null, injuryReturn: '2026-08-22' },
+        });
+
+        expect(screen.queryByText(/· Hamstring/)).not.toBeInTheDocument();
+    });
+
+    it('shows the injury even when the market has never seen the player', () => {
+        // A rank list holds players with no value entry at all, and the
+        // injury is the half that does not depend on one.
+        renderItem(FREE_AGENT_ID, {
+            player: injured({ injury_status: 'IR' }),
+            marketValue: undefined,
+        });
+
+        expect(screen.getByTestId('injury-tag')).toHaveTextContent('IR');
+    });
+
+    it('leaves a healthy player exactly as he was', () => {
+        renderItem(FREE_AGENT_ID);
+
+        expect(screen.queryByTestId('injury-tag')).not.toBeInTheDocument();
+        expect(screen.getByRole('group', { name: /free agent$/i })).toBeInTheDocument();
+    });
+
+    // The trap this whole mapping exists for: 61 players carry `NA`, which is
+    // not an injury.
+    it('does not badge a player whose status is NA', () => {
+        renderItem(FREE_AGENT_ID, { player: injured({ injury_status: 'NA' }) });
+
+        expect(screen.queryByTestId('injury-tag')).not.toBeInTheDocument();
+    });
+});
+
 describe('PlayerInfoItem', () => {
     it('shows a free agent as available and offers the Add button', () => {
         renderItem(FREE_AGENT_ID);

--- a/src/Components/injuryLabels.js
+++ b/src/Components/injuryLabels.js
@@ -1,0 +1,105 @@
+// Injury comes from Sleeper's own player dump (`injury_status` /
+// `injury_body_part`), not from a value source — see the backend migration
+// that extracted them. `injury_return` arrives separately, on the dynasty
+// value row, because only KeepTradeCut publishes an expected return date.
+//
+// The badge text is deliberately not the raw status. Sleeper spells them
+// "Questionable"/"PUP"/"Sus", which is nine characters of a row that measured
+// tests have already shown has none to spare, so each maps to the short form
+// the rest of fantasy uses.
+const STATUS = {
+    Questionable: { badge: 'Q', label: 'questionable', tone: 'warn' },
+    Out: { badge: 'OUT', label: 'out', tone: 'danger' },
+    IR: { badge: 'IR', label: 'on injured reserve', tone: 'danger' },
+    PUP: { badge: 'PUP', label: 'on PUP', tone: 'danger' },
+    DNR: { badge: 'DNR', label: 'did not report', tone: 'danger' },
+    Sus: { badge: 'SUS', label: 'suspended', tone: 'danger' },
+};
+
+// `NA` is not an injury and must never render as one. It is how Sleeper
+// spells "no applicable status" and it is on 61 players — mostly inactive and
+// practice-squad — against 372 genuinely questionable ones (measured
+// 2026-08-15 against the live payload). Rendering it would put a warning
+// badge on five dozen healthy players, which is the same `NA`-is-not-a-value
+// trap the id crosswalk hit.
+//
+// Anything else unrecognised is dropped for the same reason: a status this
+// module has no short form for would render as raw text of unknown length,
+// and a badge nobody can read is worse than no badge.
+export const injuryBadge = (player) => STATUS[player?.injury_status] ?? null;
+
+// The popover's contents: a headline naming the status, then whatever else is
+// known. Split into lines rather than one joined string because this is the
+// one place with room to be readable — the row itself has 10px of slack (see
+// InjuryTag) and had to give the detail up.
+export const injuryDetailLines = (player, injuryReturn) => {
+    const badge = injuryBadge(player);
+    if (!badge) return { headline: null, body: [] };
+
+    const body = [];
+    if (player.injury_body_part) body.push(player.injury_body_part);
+
+    const back = returnText(injuryReturn);
+    // Named as an expectation, not a fact. It is KeepTradeCut's read of when
+    // he returns, and a date rendered bare invites being taken for official.
+    if (back) body.push(`Expected ${back}`);
+
+    return { headline: badge.label, body };
+};
+
+// "Q · Hamstring · back Aug 22" — the detail line, built only from the parts
+// that exist. The body part is absent for about one injured player in eight
+// and the return date for most of them, so every separator is conditional
+// rather than the line being assembled and then tidied.
+export const injuryDetail = (player, injuryReturn) => {
+    const badge = injuryBadge(player);
+    if (!badge) return null;
+
+    const parts = [badge.badge];
+    if (player.injury_body_part) parts.push(player.injury_body_part);
+
+    const back = returnText(injuryReturn);
+    if (back) parts.push(back);
+
+    return parts.join(' · ');
+};
+
+// "back Aug 22" for a date still ahead, "due back Aug 15" for one already
+// passed. The two are different facts: a return date in the past means the
+// player was expected back and the market has not been told otherwise, which
+// is a softer signal than a date still to come, and collapsing them would let
+// a stale date read as fresh news.
+export const returnText = (injuryReturn, today = new Date()) => {
+    if (!injuryReturn) return null;
+
+    // The API sends a plain `YYYY-MM-DD`. Parsing it with `new Date()` would
+    // read it as UTC midnight and render the day before in any negative
+    // offset, so the parts are split out and fed to the local-time
+    // constructor instead.
+    const [year, month, day] = injuryReturn.split('-').map(Number);
+    if (!year || !month || !day) return null;
+
+    const date = new Date(year, month - 1, day);
+    if (Number.isNaN(date.getTime())) return null;
+
+    const label = date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
+    const startOfToday = new Date(today.getFullYear(), today.getMonth(), today.getDate());
+
+    return date < startOfToday ? `due back ${label}` : `back ${label}`;
+};
+
+// Screen readers get the long form: the badge is two or three letters chosen
+// to fit, and "Q" read aloud is not a word. Appended to the accessible name
+// the same way "yours" and "low confidence match" already are.
+export const injuryAccessibleText = (player, injuryReturn) => {
+    const badge = injuryBadge(player);
+    if (!badge) return null;
+
+    const parts = [badge.label];
+    if (player.injury_body_part) parts.push(player.injury_body_part.toLowerCase());
+
+    const back = returnText(injuryReturn);
+    if (back) parts.push(back);
+
+    return parts.join(', ');
+};

--- a/src/Components/injuryLabels.test.js
+++ b/src/Components/injuryLabels.test.js
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { injuryAccessibleText, injuryBadge, injuryDetail, returnText } from './injuryLabels.js';
+
+const player = (attrs) => ({ full_name: 'Malik Nabers', position: 'WR', ...attrs });
+
+describe('injuryBadge', () => {
+    it('shortens the statuses Sleeper spells out', () => {
+        expect(injuryBadge(player({ injury_status: 'Questionable' })).badge).toBe('Q');
+        expect(injuryBadge(player({ injury_status: 'PUP' })).badge).toBe('PUP');
+    });
+
+    it('colours questionable as a warning and the rest as danger', () => {
+        // "Questionable" usually plays; the others do not. Rendering them
+        // alike would make the row's loudest signal mean two different things.
+        expect(injuryBadge(player({ injury_status: 'Questionable' })).tone).toBe('warn');
+        expect(injuryBadge(player({ injury_status: 'IR' })).tone).toBe('danger');
+        expect(injuryBadge(player({ injury_status: 'Out' })).tone).toBe('danger');
+    });
+
+    // 61 players carry `NA` against 372 genuinely questionable ones, so
+    // treating it as an injury would put a warning badge on five dozen healthy
+    // players. It is Sleeper's spelling of "no status", not a status.
+    it('refuses NA, which is how Sleeper spells no status at all', () => {
+        expect(injuryBadge(player({ injury_status: 'NA' }))).toBeNull();
+    });
+
+    it('drops a status it has no short form for rather than rendering it raw', () => {
+        expect(injuryBadge(player({ injury_status: 'Doubtful-ish' }))).toBeNull();
+    });
+
+    it('is silent for a healthy player and for a missing one', () => {
+        expect(injuryBadge(player({}))).toBeNull();
+        expect(injuryBadge(null)).toBeNull();
+    });
+});
+
+describe('returnText', () => {
+    const today = new Date(2026, 7, 15);
+
+    it('reads a date still ahead as when he is back', () => {
+        expect(returnText('2026-08-22', today)).toBe('back Aug 22');
+    });
+
+    // Different facts: a date already passed means he was expected back and
+    // nothing has said otherwise, which is softer news than one still to come.
+    it('marks a date already passed as overdue rather than as news', () => {
+        expect(returnText('2026-08-01', today)).toBe('due back Aug 1');
+    });
+
+    it('treats today as still ahead', () => {
+        expect(returnText('2026-08-15', today)).toBe('back Aug 15');
+    });
+
+    // `new Date('2026-08-22')` is UTC midnight, which renders as Aug 21 in any
+    // negative offset — the app's own timezone included.
+    it('does not slip a day in a negative UTC offset', () => {
+        expect(returnText('2026-08-22', today)).toBe('back Aug 22');
+        expect(returnText('2026-01-01', new Date(2025, 11, 1))).toBe('back Jan 1');
+    });
+
+    it('is silent when there is no date', () => {
+        expect(returnText(null, today)).toBeNull();
+        expect(returnText('not-a-date', today)).toBeNull();
+    });
+});
+
+describe('injuryDetail', () => {
+    it('joins only the parts that exist', () => {
+        expect(injuryDetail(player({ injury_status: 'Questionable', injury_body_part: 'Hamstring' }), null)).toBe(
+            'Q · Hamstring',
+        );
+        expect(injuryDetail(player({ injury_status: 'IR' }), null)).toBe('IR');
+    });
+
+    it('is silent for a player with no injury, whatever else he carries', () => {
+        expect(injuryDetail(player({ injury_body_part: 'Hamstring' }), '2026-08-22')).toBeNull();
+    });
+});
+
+describe('injuryAccessibleText', () => {
+    // "Q" read aloud is not a word.
+    it('spells the badge out', () => {
+        expect(injuryAccessibleText(player({ injury_status: 'Questionable', injury_body_part: 'Knee' }), null)).toBe(
+            'questionable, knee',
+        );
+        expect(injuryAccessibleText(player({ injury_status: 'PUP' }), null)).toBe('on PUP');
+    });
+
+    it('is silent for a healthy player, so the name is unchanged', () => {
+        expect(injuryAccessibleText(player({}), null)).toBeNull();
+    });
+});

--- a/src/Components/playerInfoLabels.js
+++ b/src/Components/playerInfoLabels.js
@@ -29,6 +29,11 @@ export const playerAccessibleName = ({
     isMine = false,
     lowConfidenceMatch = false,
     started = false,
+    // The long form of the injury badge — "questionable, hamstring, back
+    // Aug 22". The badge itself is two or three letters chosen to fit a row
+    // with no room, and "Q" read aloud is not a word, so the meaning goes in
+    // the name the same way the colour-only states above do.
+    injury = null,
 }) => {
     let availability = 'free agent';
     if (taken) {
@@ -40,6 +45,9 @@ export const playerAccessibleName = ({
     }
     if (started) {
         nameParts.push('already started');
+    }
+    if (injury) {
+        nameParts.push(injury);
     }
     return nameParts.join(', ');
 };

--- a/src/Panels/LineupPanel.test.jsx
+++ b/src/Panels/LineupPanel.test.jsx
@@ -168,6 +168,36 @@ describe('LineupPanel', () => {
     });
 });
 
+describe('LineupPanel injury', () => {
+    // A lineup slot is where an injury matters most and where the return date
+    // is least available: this panel fetches no values, so it shows the status
+    // and body part and says nothing about when he is back.
+    const hurt = (attrs) => ({
+        ...PLAYER_INFO,
+        [STARTER.player_id]: { ...STARTER, ...attrs },
+    });
+
+    it('badges a hurt starter and puts the detail on the meta line', () => {
+        renderLineup({ playerInfo: hurt({ injury_status: 'Questionable', injury_body_part: 'Hamstring' }) });
+
+        expect(screen.getByTestId('injury-tag')).toHaveTextContent('Q');
+        expect(screen.getByText(/LV · Q · Hamstring/)).toBeInTheDocument();
+    });
+
+    it('spells the status out in the slot name', () => {
+        renderLineup({ playerInfo: hurt({ injury_status: 'IR' }) });
+
+        expect(screen.getByRole('button', { name: /on injured reserve/i })).toBeInTheDocument();
+    });
+
+    it('leaves a healthy starter row unchanged', () => {
+        renderLineup();
+
+        expect(screen.queryByTestId('injury-tag')).not.toBeInTheDocument();
+        expect(screen.getByText('LV')).toBeInTheDocument();
+    });
+});
+
 describe('LineupPanel best-available sheet', () => {
     it('shows the handle, filtered to the open slots, when there are open slots and a rank list', () => {
         renderLineup({ rankingPlayersIdsList: [rankEntry(FREE_AGENT_TE.id, 1)] });

--- a/src/Panels/SlotRow.jsx
+++ b/src/Panels/SlotRow.jsx
@@ -1,6 +1,8 @@
 import { slotAccessibleName, slotOccupantLabel } from './lineupLabels.js';
 import ListRow from '../Components/ListRow';
 import PositionTag from '../Components/PositionTag';
+import InjuryTag from '../Components/InjuryTag';
+import { injuryDetail } from '../Components/injuryLabels.js';
 
 const SlotRow = ({ slot, index, playerInfo, onOpen }) => {
     // A slot is occupied whenever it holds a player id, even if that id is
@@ -48,10 +50,15 @@ const SlotRow = ({ slot, index, playerInfo, onOpen }) => {
                 ordinalWidth="44px"
                 ordinalClassName="text-[10px] font-semibold tracking-[.08em] text-ink-muted"
                 name={occupantName}
+                nameAfter={<InjuryTag player={player} />}
                 // No opponent/schedule data is available here, so only the
                 // team renders on the meta line - inventing an opponent would
                 // be worse than leaving the line short.
-                meta={player?.team}
+                //
+                // No expected return date either: that lives on the value row
+                // and this panel does not fetch values. Status and body part
+                // are the parts a lineup decision actually turns on.
+                meta={[player?.team, injuryDetail(player, null)].filter(Boolean).join(' · ')}
                 trailing={player && <PositionTag position={player.position} />}
             />
         </li>

--- a/src/Panels/lineupLabels.js
+++ b/src/Panels/lineupLabels.js
@@ -1,3 +1,5 @@
+import { injuryAccessibleText } from '../Components/injuryLabels.js';
+
 // Builds the accessible name shared by SlotRow's filled and empty renders, so
 // the visible text and the name cannot drift the way pickLabels.js does for
 // the feed: "FLX, Colston Loveland, WR" for a filled slot, "WR, empty" for an
@@ -17,6 +19,14 @@ export const slotAccessibleName = ({ slot, player }) => {
     const nameParts = [slot.label, slotOccupantLabel({ slot, player })];
     if (player) {
         nameParts.push(player.position);
+        // The injury badge is a colour and two letters, neither of which a
+        // screen reader conveys — same reason `playerAccessibleName` spells
+        // its colour-only states out. No return date here: this panel has no
+        // values to read one from.
+        const injury = injuryAccessibleText(player, null);
+        if (injury) {
+            nameParts.push(injury);
+        }
     }
     return nameParts.join(', ');
 };


### PR DESCRIPTION
Renders what [sleeper-player-be#50](https://github.com/rghart/sleeper-player-be/pull/50) started serving: injury status and body part (from Sleeper's own nightly dump) and an expected return date (KeepTradeCut, the only source that publishes one).

Three surfaces render players and all three get it: the rank row, the lineup slot, and the best-available sheet you pick a starter from.

## The badge

`Q` `IR` `PUP` `OUT` `DNR` `SUS` beside the name — amber for questionable, red for the rest, because "usually plays" and "will not play" must not read alike. Sleeper spells them out ("Questionable" is nine characters); this row has no nine characters to spare.

## Where the detail goes is measured

At 375px against a real 14-player list in District 13:

| | |
|---|---|
| Rank row meta line, available | **155px** |
| Value chip + manager name, already there | **145px** |
| First attempt (`· Q · Knee - ACL · back Aug 20`) | **7 of 14 rows truncated**, worst 252px over |

The return date — the KTC-only field, and the actionable one — was exactly what got cut. So on the rank row the detail is a **popover on the badge**, the same tap-for-more `TermTip` uses for intel figures. The lineup and best-available rows have room on their meta lines and carry it inline.

The best-available row also can't use the popover for a second reason: that row is sometimes a `<button>` itself, and a button cannot nest one.

## `NA` is refused

61 players carry `injury_status: "NA"` against 372 genuinely questionable. It is Sleeper's spelling of "no status", not a status, and badging it would put a warning on five dozen healthy players — the same `NA`-is-not-a-value trap the id crosswalk hit. Any status without a short form is dropped rather than rendered raw at unknown width.

## Verified in the real app

Connected as `ryangh`, District 13, a pasted 14-player list, 375px:

- **0 of 14 names truncated** — unchanged from before the change.
- **1 meta line clipped, by 7px** — De'Von Achane, a long manager name on a healthy row, and identical before and after.
- Popover reads "DID NOT REPORT / Knee - ACL + MCL / Expected back Aug 20" on Aiyuk.
- All 28 avatar and team-logo images loaded, 0 failed — which also closes the open question about whether #166's avatars and values render on a real Ranks screen. They do.

Sabotage-verified: removing the badge from the rank row fails 4 tests; accepting `NA` fails 2; dropping the past/future split on the return date fails 1; removing the injury from the accessible name fails 1. Removing the badge's `stopPropagation` fails **nothing** — it sits in a sibling slot, not inside the name button, so nothing propagates today. Kept as defensive, commented as unreachable, and the test that looked like it covered it is relabelled rather than left looking like coverage.

931 tests, all six gates pass.