### PR TITLE
Show what a free agent actually costs in FAAB

### DIFF
--- a/src/Components/FaabTip.jsx
+++ b/src/Components/FaabTip.jsx
@@ -1,0 +1,87 @@
+import { useRef, useState } from 'react';
+import Popover from './Popover';
+import { faabFailedText, faabHeadline, faabRangeText, faabSample, faabSampleText } from '../lib/faab.js';
+
+// What a player actually cost in FAAB, as a marker beside his name.
+//
+// **This started as the existing "Free agent" text made tappable, and that
+// did not work.** The rank row's meta line has 155px and the value chip plus
+// the availability words already fill it, so on every row carrying a value
+// *and* a change ("1.3k +487%") the words ellipsised to "…" and the trigger
+// became unreachable. Worth recording how that was found: `scrollWidth >
+// clientWidth` on the meta span reported those rows as *not* clipped, because
+// the overflow was inside a nested inline child rather than in the span's own
+// text. Two screenshots said otherwise and the screenshots were right. Check
+// what renders, not a proxy for it.
+//
+// So it sits in `nameAfter` beside the injury badge, where width is measured
+// and available, and it is immune to whatever the meta line is carrying.
+//
+// It appears only for players who can actually be added. A price on someone
+// locked up on another roster is trivia; on a free agent it is the number you
+// are otherwise about to guess.
+const FaabTip = ({ price, windowText }) => {
+    const ref = useRef(null);
+    const [open, setOpen] = useState(false);
+    const sample = faabSample(price);
+
+    // No entry, or none of these leagues ever bid on him. Renders nothing, so
+    // a row without a price is the row that existed before this feature.
+    if (sample.kind === 'none') return null;
+
+    const headline = faabHeadline(sample);
+    const range = faabRangeText(sample);
+    const failed = faabFailedText(sample);
+
+    return (
+        <>
+            <button
+                ref={ref}
+                type="button"
+                data-testid="faab-tip"
+                onClick={(event) => {
+                    event.stopPropagation();
+                    setOpen((isOpen) => !isOpen);
+                }}
+                aria-label={`FAAB: ${headline}, ${faabSampleText(sample)}`}
+                // Same geometry as the injury badge next to it, in the muted
+                // ink that says "reference, not warning" — an injury changes
+                // whether you want him, a price only changes what you bid.
+                //
+                // A glyph rather than the word "FAAB", and that is measured:
+                // at 375px the name sits at *exactly* its limit on a
+                // single-badge row (right edge equal to the container's, zero
+                // slack), and spelling it out pushed the one row carrying both
+                // badges 10px over — "Zavion Thomas" lost its last letter. The
+                // popover and the aria-label carry the meaning; the row only
+                // has room for a mark.
+                className="text-ink-dim shrink-0 font-mono text-[11px] font-semibold"
+            >
+                $
+            </button>
+            {open && (
+                <Popover triggerRef={ref} onClose={() => setOpen(false)} label="FAAB" width={232}>
+                    <div className="px-2 py-1.5">
+                        <p className="text-ink m-0 font-mono text-[10px] font-semibold tracking-[.06em] uppercase">
+                            {headline}
+                        </p>
+                        {range && <p className="text-ink-muted m-0 mt-1 font-mono text-[11px]">{range}</p>}
+                        {/* The denominator, never optional. */}
+                        <p className="text-ink-dim m-0 mt-1 text-[11px] leading-snug">{faabSampleText(sample)}</p>
+                        {failed && <p className="text-ink-dim m-0 mt-1 text-[11px] leading-snug">{failed}</p>}
+                        {/* Which market these prices are from. Every bid in
+                            the corpus was made outside the season, and a price
+                            rendered without saying so is overclaiming. */}
+                        {windowText && (
+                            <p className="text-ink-dim m-0 mt-1.5 border-t border-[var(--color-line)] pt-1.5 text-[10px] leading-snug">
+                                Offseason claims, {windowText}
+                            </p>
+                        )}
+                    </div>
+                </Popover>
+            )}
+        </>
+    );
+};
+
+export default FaabTip;

--- a/src/Components/PlayerInfoItem.jsx
+++ b/src/Components/PlayerInfoItem.jsx
@@ -5,6 +5,7 @@ import PositionTag from './PositionTag';
 import PlayerSearch from './PlayerSearch';
 import ValueChip from './ValueChip';
 import InjuryTag from './InjuryTag';
+import FaabTip from './FaabTip';
 import { injuryAccessibleText } from './injuryLabels.js';
 import { playerAccessibleName, playerAvailabilityText } from './playerInfoLabels.js';
 import { isInLineup, isTaken, rosteredBy } from '../lib/rosterInfo.js';
@@ -24,6 +25,11 @@ const PlayerInfoItem = ({
     // fetch failed or the market has never seen him. Undefined renders
     // nothing at all rather than a placeholder - see ValueChip.
     marketValue,
+    // `{ median, low, high, claims, leagues, failed }` for this player, or
+    // undefined when nobody in the corpus has claimed him. Undefined renders
+    // the plain availability text, exactly as before this existed.
+    faabPrice,
+    faabWindow,
 }) => {
     const [editingPlayer, setEditingPlayer] = useState(false);
     const taken = isTaken(rosterInfo, player.player_id);
@@ -135,7 +141,18 @@ const PlayerInfoItem = ({
                     <div className="text-ink-muted flex flex-wrap items-center gap-x-2 text-xs">
                         <span>Rank: {searchData.ranking}</span>
                         <span>{player.team ? player.team : 'FA'}</span>
-                        <span>{playerAvailabilityText({ taken, rosteredByName })}</span>
+                        {/* The availability words double as the FAAB trigger
+                        when he is gettable — see FaabTip for why this reuses
+                        text already on the row rather than adding a chip. */}
+                        <span>
+                            {taken ? (
+                                playerAvailabilityText({ taken, rosteredByName })
+                            ) : (
+                                <FaabTip price={faabPrice} windowText={faabWindow}>
+                                    {playerAvailabilityText({ taken, rosteredByName })}
+                                </FaabTip>
+                            )}
+                        </span>
                     </div>
                     {adpData && (
                         <div className="text-ink-muted flex items-center gap-2 text-xs">
@@ -200,7 +217,15 @@ const PlayerInfoItem = ({
                 </button>
             }
             nameTone={taken ? 'muted' : 'default'}
-            nameAfter={<InjuryTag player={player} injuryReturn={injuryReturn} detail />}
+            nameAfter={
+                <>
+                    <InjuryTag player={player} injuryReturn={injuryReturn} detail />
+                    {/* Only for a player you could actually add — see FaabTip.
+                        The meta line cannot host this; it was tried and the
+                        trigger truncated away on any row with a value change. */}
+                    {!taken && <FaabTip price={faabPrice} windowText={faabWindow} />}
+                </>
+            }
             flag={isMine ? { text: 'YOU', tone: 'mine' } : undefined}
             leadingDot={lowConfidenceMatch ? 'warn' : undefined}
             meta={

--- a/src/Components/PlayerInfoItem.test.jsx
+++ b/src/Components/PlayerInfoItem.test.jsx
@@ -57,6 +57,68 @@ function renderItem(playerId, { lineupSet = new Set(), ...overrides } = {}) {
     return props;
 }
 
+describe('PlayerInfoItem FAAB', () => {
+    const price = (attrs) => ({ median: 12, low: 0, high: 40, claims: 8, leagues: 7, failed: 3, ...attrs });
+
+    // The availability words are the trigger — the meta line has no room for
+    // a chip, measured at 155px with 145 already spent.
+    it('makes a gettable player price tappable, and opens the distribution', async () => {
+        const user = userEvent.setup();
+        renderItem(FREE_AGENT_ID, { faabPrice: price(), faabWindow: 'Dec 2025 – Aug 2026' });
+
+        await user.click(screen.getByTestId('faab-tip'));
+
+        expect(screen.getByText('Typically 12% of budget')).toBeInTheDocument();
+        expect(screen.getByText('0% to 40%')).toBeInTheDocument();
+        expect(screen.getByText('8 claims in 7 leagues')).toBeInTheDocument();
+        expect(screen.getByText('3 more claims did not go through')).toBeInTheDocument();
+        expect(screen.getByText(/Offseason claims, Dec 2025 – Aug 2026/)).toBeInTheDocument();
+    });
+
+    // A price on a player locked up on someone else's roster is trivia.
+    it('offers nothing on a player who is already taken', () => {
+        renderItem(OTHERS_PLAYER_ID, { faabPrice: price() });
+
+        expect(screen.queryByTestId('faab-tip')).not.toBeInTheDocument();
+    });
+
+    it('leaves the row alone when nobody in the corpus has claimed him', () => {
+        renderItem(FREE_AGENT_ID, { faabPrice: undefined });
+
+        expect(screen.queryByTestId('faab-tip')).not.toBeInTheDocument();
+        expect(screen.getByText('Free agent')).toBeInTheDocument();
+    });
+
+    // The trigger lived on the meta line first and was unreachable there: on
+    // any row carrying a value *and* a change it ellipsised away. It belongs
+    // beside the name, where the width is measured and available.
+    it('keeps the trigger off the meta line, which cannot hold it', () => {
+        renderItem(FREE_AGENT_ID, { faabPrice: price() });
+
+        const availability = screen.getByText('Free agent');
+        expect(availability.closest('[data-testid="faab-tip"]')).toBeNull();
+    });
+
+    it('sits alongside an injury badge rather than replacing it', () => {
+        renderItem(FREE_AGENT_ID, {
+            player: { ...playerInfo[FREE_AGENT_ID], injury_status: 'Questionable' },
+            faabPrice: price(),
+        });
+
+        expect(screen.getByTestId('injury-tag')).toBeInTheDocument();
+        expect(screen.getByTestId('faab-tip')).toBeInTheDocument();
+    });
+
+    it('weakens the claim when the sample is thin', async () => {
+        const user = userEvent.setup();
+        renderItem(FREE_AGENT_ID, { faabPrice: price({ claims: 1, leagues: 1 }) });
+
+        await user.click(screen.getByTestId('faab-tip'));
+
+        expect(screen.getByText('Went for 12% of budget, once')).toBeInTheDocument();
+    });
+});
+
 describe('PlayerInfoItem injury', () => {
     // Injury status and body part come from Sleeper's player dump; the
     // expected return date rides on the value row, because only KeepTradeCut

--- a/src/Panels/RanksPanel.jsx
+++ b/src/Panels/RanksPanel.jsx
@@ -14,8 +14,9 @@ import APP_DB_URLS from '../urls.js';
 import Spinner from '../Components/Spinner';
 import { isTaken, rosteredBy } from '../lib/rosterInfo.js';
 import { fetchRequest } from '../lib/http.js';
-import { fetchDynastyValues, fetchMarketValues } from '../lib/sleeperApi.js';
+import { fetchDynastyValues, fetchFaabPrices, fetchMarketValues } from '../lib/sleeperApi.js';
 import { usesSuperflexValues, valuesByPlayerId } from '../lib/dynastyValues.js';
+import { faabWindowText, pricesByPlayerId } from '../lib/faab.js';
 import { asOfMillis, settingsLabel, toRankList } from '../lib/marketValues.js';
 import { agoLabel } from '../lib/relativeTime.js';
 import { positionClass } from './pickLabels.js';
@@ -111,6 +112,8 @@ const RanksPanel = ({
     // absent entry is exactly how a player the market has never priced — or a
     // failed fetch — renders. Values are additive decoration.
     const [dynastyValues, setDynastyValues] = useState({});
+    const [faabPrices, setFaabPrices] = useState({});
+    const [faabWindow, setFaabWindow] = useState(null);
     const [adpType, setADPType] = useState();
     const [filters, setFilters] = useState({
         showTaken: false,
@@ -387,6 +390,24 @@ const RanksPanel = ({
         };
     }, [superflex]);
 
+    // Separate from the values effect and deliberately not keyed to the
+    // league: FAAB prices are corpus-wide and the same whichever league is
+    // selected, so re-fetching on a league switch would be work for an
+    // identical answer.
+    useEffect(() => {
+        let cancelled = false;
+
+        fetchFaabPrices().then((response) => {
+            if (cancelled) return;
+            setFaabPrices(pricesByPlayerId(response));
+            setFaabWindow(faabWindowText(response));
+        });
+
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
     // The saved-lists fetch itself now lives in App (loadSavedRankLists) - it
     // resets isNewRankList/currentListVal back to the default whenever
     // signedIn goes false, which App's version of this effect can't reach
@@ -446,6 +467,8 @@ const RanksPanel = ({
             searchData={results}
             adpData={adp?.[results.match_results[0][0]]?.[adpType] ?? null}
             marketValue={dynastyValues[results.match_results[0][0]]}
+            faabPrice={faabPrices[results.match_results[0][0]]}
+            faabWindow={faabWindow}
             myDisplayName={myDisplayName}
         />
     );

--- a/src/lib/faab.js
+++ b/src/lib/faab.js
@@ -1,0 +1,144 @@
+// Reading the /faab response.
+//
+// Pure, like `availability.js` and `dynastyValues.js` next door, and for the
+// same reason: what may be said about a number is decided here, where it can
+// be tested, rather than inside a template. This feature's recurring failure
+// has never been the maths — it is the sentence next to the number.
+//
+// These are prices that were *paid*, in leagues your leaguemates are in. No
+// public tool answers "what does he actually cost in FAAB", which is exactly
+// why the claim has to be kept inside what the sample supports.
+
+/** The response's per-player prices, or `{}` on a failed or empty fetch. */
+export function pricesByPlayerId(response) {
+    const players = response?.players;
+    if (!players || typeof players !== 'object') return {};
+    return players;
+}
+
+// Five winning claims is where a median stops being an anecdote. Measured on
+// the corpus: 516 players have a price at all, 261 have three or more, 175
+// have five or more — so this is a real band, not a threshold that empties
+// the feature.
+const FULL = 5;
+
+/**
+ * How much can honestly be said about what a player costs.
+ *
+ * Mirrors `managerSample`/`ownershipSample` in availability.js: a `kind` that
+ * decides which sentence is allowed, plus the figures that sentence needs.
+ * The renderer picks a branch; it never decides what is sayable.
+ *
+ * `median`, `low` and `high` are percentages of each paying league's own
+ * budget — the API normalises them, because fewer than half of these leagues
+ * use a budget of 100 and a raw bid is not comparable to another one.
+ */
+export function faabSample(entry) {
+    if (!entry || !entry.claims) return { kind: 'none' };
+
+    const { claims, leagues, median, low, high, failed } = entry;
+
+    // One claim is not a market. Name the price that was actually paid rather
+    // than dressing a single observation as a median — the same call
+    // `managerSample` makes for a single pick.
+    if (claims === 1) return { kind: 'single', claims, leagues, price: median, failed };
+
+    // Enough to say a number, not enough to call it typical.
+    if (claims < FULL) return { kind: 'thin', claims, leagues, median, low, high, failed };
+
+    return { kind: 'full', claims, leagues, median, low, high, failed };
+}
+
+/** `12.5` -> `"12.5%"`, `0` -> `"0%"`, and a whole number loses its `.0`. */
+export function pct(value) {
+    if (value == null) return null;
+    const rounded = Math.round(value * 10) / 10;
+    return `${Number.isInteger(rounded) ? rounded : rounded.toFixed(1)}%`;
+}
+
+/**
+ * The headline, in words, for each sample kind.
+ *
+ * Deliberately not one string with conditionals: the whole point of the kinds
+ * is that a thin sample gets a *different sentence*, not the same sentence
+ * with a smaller number in it.
+ */
+export function faabHeadline(sample) {
+    switch (sample.kind) {
+        case 'single':
+            return `Went for ${pct(sample.price)} of budget, once`;
+        case 'thin':
+            return `Went for ${pct(sample.median)} of budget`;
+        case 'full':
+            return `Typically ${pct(sample.median)} of budget`;
+        default:
+            return null;
+    }
+}
+
+/**
+ * The denominator, always shown beside the headline.
+ *
+ * Leagues, not just claims: ten claims in one league is a much weaker read
+ * than ten across ten, and only the pair says which one you have.
+ */
+export function faabSampleText(sample) {
+    if (sample.kind === 'none') return null;
+
+    const claims = `${sample.claims} ${sample.claims === 1 ? 'claim' : 'claims'}`;
+    const leagues = `${sample.leagues} ${sample.leagues === 1 ? 'league' : 'leagues'}`;
+    return `${claims} in ${leagues}`;
+}
+
+/**
+ * The spread, when there is one.
+ *
+ * Null for a single claim (no spread exists) and when low and high agree —
+ * "0% to 0%" reads as a measurement rather than as the one price it is.
+ */
+export function faabRangeText(sample) {
+    if (sample.kind === 'none' || sample.kind === 'single') return null;
+    if (sample.low == null || sample.high == null) return null;
+    if (sample.low === sample.high) return null;
+    return `${pct(sample.low)} to ${pct(sample.high)}`;
+}
+
+/**
+ * Bids that bought nothing, phrased without a cause.
+ *
+ * Sleeper does not say *why* a claim failed, so "outbid" and "invalid roster
+ * move" are indistinguishable from here. The count is still worth showing —
+ * a player with fifteen failed claims is contested — but it must not be
+ * called losing bids.
+ */
+export function faabFailedText(sample) {
+    if (!sample.failed) return null;
+    return `${sample.failed} more ${sample.failed === 1 ? 'claim' : 'claims'} did not go through`;
+}
+
+/**
+ * What window these prices come from, as a sentence.
+ *
+ * Never optional. Every bid in the corpus was made outside the 2026 season,
+ * which is a different market from the in-season one where most FAAB gets
+ * spent, and a price rendered without saying so is overclaiming.
+ */
+export function faabWindowText(response) {
+    const window = response?.window;
+    if (!window?.from || !window?.to) return null;
+
+    const format = (iso) => {
+        const [year, month, day] = iso.split('-').map(Number);
+        if (!year || !month || !day) return null;
+        return new Date(year, month - 1, day).toLocaleDateString('en-US', {
+            month: 'short',
+            year: 'numeric',
+        });
+    };
+
+    const from = format(window.from);
+    const to = format(window.to);
+    if (!from || !to) return null;
+
+    return from === to ? from : `${from} – ${to}`;
+}

--- a/src/lib/faab.test.js
+++ b/src/lib/faab.test.js
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import {
+    faabFailedText,
+    faabHeadline,
+    faabRangeText,
+    faabSample,
+    faabSampleText,
+    faabWindowText,
+    pct,
+    pricesByPlayerId,
+} from './faab.js';
+
+const entry = (attrs) => ({ median: 10, low: 0, high: 40, claims: 8, leagues: 7, failed: 0, ...attrs });
+
+describe('faabSample', () => {
+    it('says nothing at all when nobody has claimed him', () => {
+        expect(faabSample(undefined).kind).toBe('none');
+        expect(faabSample({ claims: 0 }).kind).toBe('none');
+    });
+
+    // The same call `managerSample` makes for a single pick: one observation
+    // is not an average and must not be dressed as one.
+    it('treats a single claim as a price paid, not a median', () => {
+        const sample = faabSample(entry({ claims: 1, leagues: 1 }));
+        expect(sample.kind).toBe('single');
+        expect(faabHeadline(sample)).toBe('Went for 10% of budget, once');
+    });
+
+    it('names a number below the threshold without calling it typical', () => {
+        const sample = faabSample(entry({ claims: 3 }));
+        expect(sample.kind).toBe('thin');
+        expect(faabHeadline(sample)).toBe('Went for 10% of budget');
+    });
+
+    it('only calls a price typical once the sample supports it', () => {
+        expect(faabHeadline(faabSample(entry({ claims: 5 })))).toBe('Typically 10% of budget');
+    });
+});
+
+describe('the denominator', () => {
+    // Ten claims in one league is a much weaker read than ten across ten, and
+    // only the pair says which one you have.
+    it('always names both claims and leagues', () => {
+        expect(faabSampleText(faabSample(entry({ claims: 8, leagues: 7 })))).toBe('8 claims in 7 leagues');
+    });
+
+    it('is singular when it should be', () => {
+        expect(faabSampleText(faabSample(entry({ claims: 1, leagues: 1 })))).toBe('1 claim in 1 league');
+    });
+});
+
+describe('faabRangeText', () => {
+    it('shows the spread, which is usually the story', () => {
+        expect(faabRangeText(faabSample(entry({ low: 0, high: 100 })))).toBe('0% to 100%');
+    });
+
+    // "0% to 0%" reads as a measurement rather than as the one price it is.
+    it('is silent when low and high agree', () => {
+        expect(faabRangeText(faabSample(entry({ low: 12, high: 12 })))).toBeNull();
+    });
+
+    it('is silent for a single claim, which has no spread', () => {
+        expect(faabRangeText(faabSample(entry({ claims: 1 })))).toBeNull();
+    });
+});
+
+describe('faabFailedText', () => {
+    // Sleeper does not say why a claim failed, so this must never be called
+    // losing bids.
+    it('counts them without naming a cause', () => {
+        expect(faabFailedText(faabSample(entry({ failed: 13 })))).toBe('13 more claims did not go through');
+    });
+
+    it('is silent when none failed', () => {
+        expect(faabFailedText(faabSample(entry({ failed: 0 })))).toBeNull();
+    });
+});
+
+describe('pct', () => {
+    it('drops a pointless decimal but keeps a real one', () => {
+        expect(pct(12)).toBe('12%');
+        expect(pct(12.5)).toBe('12.5%');
+        expect(pct(0)).toBe('0%');
+    });
+
+    it('passes null through rather than printing NaN', () => {
+        expect(pct(null)).toBeNull();
+    });
+});
+
+describe('faabWindowText', () => {
+    it('reads as the span the prices come from', () => {
+        expect(faabWindowText({ window: { from: '2025-12-31', to: '2026-08-15' } })).toBe('Dec 2025 – Aug 2026');
+    });
+
+    // A local-time parse, not `new Date(iso)`, which is UTC midnight and
+    // renders the previous month in any negative offset.
+    it('does not slip a month in a negative UTC offset', () => {
+        expect(faabWindowText({ window: { from: '2026-01-01', to: '2026-01-01' } })).toBe('Jan 2026');
+    });
+
+    it('is silent without a window, so nothing claims a span it lacks', () => {
+        expect(faabWindowText({})).toBeNull();
+        expect(faabWindowText(null)).toBeNull();
+    });
+});
+
+describe('pricesByPlayerId', () => {
+    it('returns an empty map on a failed fetch, so callers can look up blind', () => {
+        expect(pricesByPlayerId(undefined)).toEqual({});
+        expect(pricesByPlayerId({ players: null })).toEqual({});
+    });
+
+    it('hands back the players map as sent', () => {
+        expect(pricesByPlayerId({ players: { 4034: entry({}) } })['4034'].claims).toBe(8);
+    });
+});

--- a/src/lib/sleeperApi.js
+++ b/src/lib/sleeperApi.js
@@ -2,8 +2,16 @@ import { checkErrors } from './http.js';
 import { decorateRosters } from './rosterInfo.js';
 import { resolveLeagueSeason } from './sleeper.js';
 import APP_DB_URLS, { SLEEPER_API_URLS } from '../urls.js';
-const { ACTIVE_PLAYERS, AVAILABILITY, DYNASTY_VALUES, LEAGUE_INTEL, LEAGUE_TRADES, MANAGER_ACTIVITY, MARKET_VALUES } =
-    APP_DB_URLS;
+const {
+    ACTIVE_PLAYERS,
+    AVAILABILITY,
+    DYNASTY_VALUES,
+    FAAB,
+    LEAGUE_INTEL,
+    LEAGUE_TRADES,
+    MANAGER_ACTIVITY,
+    MARKET_VALUES,
+} = APP_DB_URLS;
 const { LEAGUE, USER_LEAGUES, USER_BY_NAME, NFL_STATE, DRAFT, ROSTERS, SLEEPER_USERS, TRADED_PICKS, DRAFTS } =
     SLEEPER_API_URLS;
 
@@ -216,6 +224,27 @@ export async function fetchManagerActivity({ userId, season, limit, types }) {
  * additive decoration: a rank list without them is exactly the list this app
  * rendered before, so callers drop the column rather than failing the screen.
  */
+/**
+ * What players actually went for in FAAB across the observed leagues.
+ *
+ * Resolves to `undefined` on failure, per this module's contract. Prices are
+ * additive decoration in exactly the way values are: a row with no entry
+ * renders as it did before this existed.
+ *
+ * `minClaims` is left alone on purpose. The response carries `claims` on
+ * every entry and `lib/faab.js` decides what a given sample may say, so
+ * filtering server-side would hand back a list the UI could not tell from a
+ * complete one.
+ */
+export async function fetchFaabPrices() {
+    return await fetch(FAAB)
+        .then(checkErrors)
+        .then((response) => response.json())
+        .catch((error) => {
+            console.error('Error fetching FAAB prices:', error);
+        });
+}
+
 export async function fetchDynastyValues({ superflex = true, window } = {}) {
     const params = new URLSearchParams();
     // Sent only when false: the API defaults to superflex, and an absent

--- a/src/urls.js
+++ b/src/urls.js
@@ -7,6 +7,7 @@ const ftaLegacy = 'api/legacy/players';
 const ftaAvailability = (draftId) => `api/v1/drafts/${draftId}/availability`;
 const ftaMarketValues = 'api/v1/values';
 const ftaDynastyValues = 'api/v1/dynasty-values';
+const ftaFaab = 'api/v1/faab';
 const ftaLeagueIntel = (leagueId) => `api/v1/leagues/${leagueId}/intel`;
 const ftaLeagueTrades = (leagueId) => `api/v1/leagues/${leagueId}/trades`;
 const ftaManagerActivity = (userId) => `api/v1/users/${userId}/activity`;
@@ -46,6 +47,7 @@ const APP_DB_URLS = {
     // and *decorates* rows that already exist. It is also the only source
     // that can price a draft pick.
     DYNASTY_VALUES: fta + ftaDynastyValues,
+    FAAB: fta + ftaFaab,
     // The leaguemates of one league, and what they do in their other ones
     // (docs/leaguemate-intel.md §3e). Keyed by league despite being the
     // "cross-league" view - the cross-league part is what the managers do


### PR DESCRIPTION
Renders [sleeper-player-be#53](https://github.com/rghart/sleeper-player-be/pull/53), which prices players from winning waiver claims across the 147 bidding leagues the crawl already covers — not a projection, what was paid.

No public tool answers "what does he actually cost in FAAB", which means the whole risk is the sentence next to the number.

## What may be said is decided in `lib/faab.js`

Not in a template — the same split `availability.js` uses, for the same reason. Three bands:

| Sample | Headline |
|---|---|
| 1 claim | "Went for 12% of budget, **once**" |
| 2–4 claims | "**Went for** 12% of budget" |
| 5+ claims | "**Typically** 12% of budget" |

Always shown alongside: the spread (`0% to 100%`), the denominator (`62 claims in 62 leagues` — claims *and* leagues, since ten claims in one league is not ten across ten), the failed count phrased without a cause (Sleeper does not say whether a claim failed on the bid or on the roster move), and the window.

The spread is usually the story. Zavion Thomas: median 3%, range 0% to 100%, across 62 leagues. Anyone reading "3%" as the price would be badly wrong, which is why the range is not optional.

## Two placements, both forced by measurement

**The meta line cannot host the trigger.** I first made the existing "Free agent" text tappable — no new width, trigger already on the row. On every row carrying a value *and* a change (`1.3k +487%`) it ellipsised to `…` and the trigger was unreachable: 3 of 8 rows.

Worth recording how that was caught, because it nearly wasn't: `scrollWidth > clientWidth` on the meta span reported those rows as **not clipped**, twice, with two different probes. The overflow was inside a nested inline child rather than in the span's own text. Two screenshots said otherwise and the screenshots were right — the reliable measurement turned out to be comparing the child's right edge against its container's.

**So the marker moved beside the name, and had to shrink.** Spelling it "FAAB" pushed the one row carrying both an injury badge and this one 10px over — "Zavion Thomas" lost its last letter. Single-badge rows sit at *exactly* zero slack (right edge equal to the container's), so a `$` glyph it is. The popover and the aria-label carry the meaning.

Final measurement at 375px against a real list: **0 of 8 names clipped, worst overflow 0px**, including the two-badge row.

Sabotage-verified: collapsing the sample bands fails 3 tests; dropping the range fails 2; dropping the window fails 1; showing a price on a taken player fails 1; dropping leagues from the denominator fails 3.

955 tests, all six gates pass.